### PR TITLE
Minor fix on the README about the embeded diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ from a single service.
 
 ## Architecture
 
-![External Data Pipeline diagram](docs/Smart proxy architecture.png "External Data Pipeline Diagram")
+![external-data-pipeline-arch](docs/Smart%20proxy%20architecture.png "External Data Pipeline Architecture")
 
 ## Results Smart Proxy in the external data pipeline
 


### PR DESCRIPTION
# Description
Minor fix into the README that prevents the arch diagram of being shown

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

N/A