### PR TITLE
Added Dockerfile for container image building

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM registry.redhat.io/rhel8/go-toolset:1.13 AS builder
+
+COPY . .
+
+USER 0
+
+RUN make build && \
+    chmod a+x insights-results-smart-proxy
+
+FROM registry.redhat.io/ubi8-minimal
+
+COPY --from=builder /opt/app-root/src/insights-results-smart-proxy .
+COPY --from=builder /opt/app-root/src/openapi.json /openapi/openapi.json
+
+USER 1001
+
+CMD ["/insights-results-smart-proxy"]


### PR DESCRIPTION
## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

```
buildah bud -f Dockerfile -t smart-proxy .
podman run -it --rm -e INSIGHTS_RESULTS_SMART_PROXY__SERVER__API_SPEC_FILE="/openapi/openapi.json" -e INSIGHTS_RESULTS_SMART_PROXY__SERVER__ADDRESS="0.0.0.0:8080" localhost/smart-proxy
```
