### PR TITLE
Don't install utils if already installed

### DIFF
--- a/abcgo.sh
+++ b/abcgo.sh
@@ -26,7 +26,11 @@ if [[ $* == *verbose* ]]; then
     VERBOSE=true
 fi
 
-GO111MODULE=off go get -u github.com/droptheplot/abcgo
+if ! [ -x "$(command -v abcgo)" ]
+then
+    echo -e "${BLUE}Installing abcgo${NC}"
+    GO111MODULE=off go get -u github.com/droptheplot/abcgo
+fi
 
 if [ "$VERBOSE" = true ]; then
     echo -e "${BLUE}All ABC metrics${NC}:"

--- a/goconst.sh
+++ b/goconst.sh
@@ -14,7 +14,11 @@
 # limitations under the License.
 
 
-GO111MODULE=off go get github.com/jgautheron/goconst/cmd/goconst
+if ! [ -x "$(command -v goconst)" ]
+then
+    echo -e "${BLUE}Installing goconst${NC}"
+    GO111MODULE=off go get github.com/jgautheron/goconst/cmd/goconst
+fi
 
 if [[ $(goconst -min-occurrences=3 ./... | tee /dev/tty | wc -l) -ne 0 ]]
 then

--- a/gocyclo.sh
+++ b/gocyclo.sh
@@ -14,5 +14,10 @@
 # limitations under the License.
 
 
-GO111MODULE=off go get github.com/fzipp/gocyclo
+if ! [ -x "$(command -v gocyclo)" ]
+then
+    echo -e "${BLUE}Installing gocyclo${NC}"
+    GO111MODULE=off go get github.com/fzipp/gocyclo
+fi
+
 gocyclo -over 9 -avg .

--- a/goerrcheck.sh
+++ b/goerrcheck.sh
@@ -14,5 +14,10 @@
 # limitations under the License.
 
 
-GO111MODULE=off go get github.com/kisielk/errcheck
+if ! [ -x "$(command -v errcheck)" ]
+then
+    echo -e "${BLUE}Installing errcheck ${NC}"
+    GO111MODULE=off go get github.com/kisielk/errcheck
+fi
+
 errcheck ./...

--- a/golint.sh
+++ b/golint.sh
@@ -16,7 +16,11 @@
 
 cd "$(dirname "$0")" || exit
 
-GO111MODULE=off go get golang.org/x/lint/golint 2> /dev/null
+if ! [ -x "$(command -v golint)" ]
+then
+    echo -e "${BLUE}Installing golint${NC}"
+    GO111MODULE=off go get golang.org/x/lint/golint 2> /dev/null
+fi
 
 # shellcheck disable=SC2046
 if golint $(go list ./...) |

--- a/gosec.sh
+++ b/gosec.sh
@@ -28,7 +28,11 @@ cd "$(dirname "$0")" || exit
 
 echo -e "${BLUE}Security issues detection${NC}"
 
-GO111MODULE=off go get github.com/securego/gosec/cmd/gosec 2> /dev/null
+if ! [ -x "$(command -v gosec)" ]
+then
+    echo -e "${BLUE}Installing ${NC}"
+    GO111MODULE=off go get github.com/securego/gosec/cmd/gosec 2> /dev/null
+fi
 
 if ! gosec $GO_SEC_ARGS ./...
 then

--- a/ineffassign.sh
+++ b/ineffassign.sh
@@ -14,5 +14,10 @@
 # limitations under the License.
 
 
-GO111MODULE=off go get github.com/gordonklaus/ineffassign
+if ! [ -x "$(command -v ineffassign)" ]
+then
+    echo -e "${BLUE}Installing ineffassign${NC}"
+    GO111MODULE=off go get github.com/gordonklaus/ineffassign
+fi
+
 ineffassign .


### PR DESCRIPTION
# Description

Don't install utils if already installed
(the same change that was incorporated into aggregator)

Fixes #50 #51 #52 #53 #54 #55 #56

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Testing steps

Can be checked by running all updated scripts - it is much much faster now.