### PR TITLE
Fix expected response on groups endpoint specification and some tooling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: default clean build fmt lint vet cyclo ineffassign shellcheck errcheck goconst gosec abcgo json-check style run test cover integration_tests rest_api_tests rules_content sqlite_db license before_commit help
+.PHONY: default clean build fmt lint vet cyclo ineffassign shellcheck errcheck goconst gosec abcgo json-check style run test cover integration_tests rest_api_tests rules_content sqlite_db license before_commit openapi-check help
 
 SOURCES:=$(shell find . -name '*.go')
 BINARY:=insights-results-smart-proxy
@@ -85,3 +85,6 @@ docs/packages/%.html: %.go
 	docgo -outdir $(dir $@) $^
 
 godoc: ${DOCFILES}
+
+openapi-check:
+	./check_openapi.sh

--- a/check_openapi.sh
+++ b/check_openapi.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright 2020 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Testing OpenAPI specifications file"
+# shellcheck disable=2181
+
+if docker run --rm -v "${PWD}":/local/:Z openapitools/openapi-generator-cli validate -i ./local/openapi.json; then
+    echo "OpenAPI spec file is OK"
+else
+    echo "OpenAPI spec file validation failed"
+    exit 1
+fi

--- a/openapi.json
+++ b/openapi.json
@@ -70,6 +70,9 @@
         "summary": "Get all rule groups and their relevant information",
         "description": "This simply redirects to an endpoint of the same name of a service called insights-operator-service",
         "parameters": [],
+        "tags": [
+          "prod"
+        ],
         "operationId": "getRuleGroups",
         "responses": {
           "200": {

--- a/openapi.json
+++ b/openapi.json
@@ -72,10 +72,40 @@
         "parameters": [],
         "operationId": "getRuleGroups",
         "responses": {
-          "302": {
-            "description": "Found redirect: response containing all rule groups",
+          "200": {
+            "description": "A JSON array of groups.",
             "content": {
-              "text/plain": {}
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "groups": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "strings"
+                          },
+                          "description": {
+                            "type": "strings"
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    }
+                  }
+                }
+              }
             }
           },
           "503": {


### PR DESCRIPTION
# Description

OpenAPI spec was outdated and refers to a redirection that is not done. Fixing and adding some tooling to manually check the OpenAPI specification

Fixes #72 

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing steps
Regular CI