### PR TITLE
Taking into account some of the possible errors parsing an URL

### DIFF
--- a/server/endpoints_test.go
+++ b/server/endpoints_test.go
@@ -81,3 +81,17 @@ func TestHTTPServer_ProxyTo_VoteEndpointsExtractUserID(t *testing.T) {
 }
 
 // TODO: test that proxying is done correctly including request / response modifiers for all endpoints
+
+func TestHTTPServer_ProxyTo_VoteEndpointBadCharacter(t *testing.T) {
+	badClusterName := "00000000000000000000000000000000000%1F"
+	helpers.AssertAPIRequest(t, &helpers.DefaultServerConfig, &helpers.DefaultServicesConfig, nil, &helpers.APIRequest{
+		Method:       http.MethodPut,
+		Endpoint:     server.LikeRuleEndpoint,
+		EndpointArgs: []interface{}{badClusterName, testdata.Rule1ID},
+		UserID:       testdata.UserID,
+		OrgID:        testdata.OrgID,
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusBadRequest,
+		Body:       `{"status":"the parameters contains invalid characters and cannot be used"}`,
+	})
+}

--- a/server/errors.go
+++ b/server/errors.go
@@ -80,6 +80,13 @@ func (*AggregatorServiceUnavailableError) Error() string {
 	return "Aggregator service us unrechable"
 }
 
+// ParamsParsingError error meaning that the cluster name cannot be handled
+type ParamsParsingError struct{}
+
+func (*ParamsParsingError) Error() string {
+	return "the parameters contains invalid characters and cannot be used"
+}
+
 // handleServerError handles separate server errors and sends appropriate responses
 func handleServerError(writer http.ResponseWriter, err error) {
 	log.Error().Err(err).Msg("handleServerError()")
@@ -87,7 +94,7 @@ func handleServerError(writer http.ResponseWriter, err error) {
 	var respErr error
 
 	switch err := err.(type) {
-	case *RouterMissingParamError, *RouterParsingError, *json.SyntaxError, *NoBodyError:
+	case *RouterMissingParamError, *RouterParsingError, *json.SyntaxError, *NoBodyError, *ParamsParsingError:
 		respErr = responses.SendBadRequest(writer, err.Error())
 	case *json.UnmarshalTypeError:
 		respErr = responses.SendBadRequest(writer, "bad type in json data")

--- a/server/server.go
+++ b/server/server.go
@@ -538,7 +538,7 @@ func (server HTTPServer) newExtractUserIDFromTokenToURLRequestModifier(newEndpoi
 		newURL := httputils.MakeURLToEndpointMapString(server.Config.APIPrefix, newEndpoint, vars)
 		request.URL, err = url.Parse(newURL)
 		if err != nil {
-			return nil, err
+			return nil, &ParamsParsingError{}
 		}
 
 		request.RequestURI = request.URL.RequestURI()


### PR DESCRIPTION
# Description

When an invalid character is received in a request, the endpoints that are redirected first try to parse the new URL before doing a request to the aggregator or content-service. when parsing, the method could fail and results in an "default case scenario" error, that results into a 500 status code. In this case, we should better response with a Bad Request response.

Fixes #74

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing steps
Regular CI