### PR TITLE
Adding a check to the OrgID

### DIFF
--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -110,7 +110,7 @@ func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {
 			server.newExtractUserIDFromTokenToURLRequestModifier(ira_server.ResetVoteOnRuleEndpoint),
 		}},
 	)).Methods(http.MethodPut, http.MethodOptions)
-	router.HandleFunc(apiPrefix+ClustersForOrganizationEndpoint, server.proxyTo(aggregatorEndpoint, nil)).Methods(http.MethodGet)
+	router.HandleFunc(apiPrefix+ClustersForOrganizationEndpoint, server.getClustersForOrg).Methods(http.MethodGet)
 	router.HandleFunc(apiPrefix+DisableRuleForClusterEndpoint, server.proxyTo(
 		aggregatorEndpoint,
 		&ProxyOptions{RequestModifiers: []RequestModifier{

--- a/server/handlers.go
+++ b/server/handlers.go
@@ -65,3 +65,16 @@ func (server HTTPServer) getContentForRule(writer http.ResponseWriter, request *
 		return
 	}
 }
+
+// getClustersForOrg retrieves the list of clusters belonging to this organization
+func (server HTTPServer) getClustersForOrg(writer http.ResponseWriter, request *http.Request) {
+	// readOrganizationID is done only for checking the authentication
+	_, err := readOrganizationID(writer, request, server.Config.Auth)
+	if err != nil {
+		// already handled in readOrganizationID ?
+		return
+	}
+
+	server.proxyTo(server.ServicesConfig.AggregatorBaseEndpoint, nil)(writer, request)
+	return
+}

--- a/server/server.go
+++ b/server/server.go
@@ -525,7 +525,7 @@ func (server HTTPServer) singleRuleEndpoint(writer http.ResponseWriter, request 
 	}
 }
 
-func (server HTTPServer) newExtractUserIDFromTokenToURLRequestModifier(newEndpoint string) func(*http.Request) (*http.Request, error) {
+func (server HTTPServer) newExtractUserIDFromTokenToURLRequestModifier(newEndpoint string) RequestModifier {
 	return func(request *http.Request) (*http.Request, error) {
 		identity, err := server.GetAuthToken(request)
 		if err != nil {


### PR DESCRIPTION
# Description

Checking of the OrgID of the authenticated user is the same as the one requested to retrieve the list of clusters

Fixes #70

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing steps
Regular CI