### PR TITLE
Add namespaced metric from insights-operator-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ INSIGHTS_RESULTS_SMART_PROXY__SERVER__AUTH="true"
 
 the actual server will listen in port 443 instead of 8080 and it will be TLS enabled
 
-## Server configuration
+### Server configuration
 
 Server configuration is in section `[server]` in config file
 
@@ -79,7 +79,7 @@ only in devel environment. In production, `true` is used every time.
 Please note that if `auth` configuration option is turned off, not all REST API endpoints will be
 usable. Whole REST API schema is satisfied only for `auth = true`.
 
-## Services configuration
+### Services configuration
 
 Services configuration is in section `[services]` in config file
 
@@ -97,9 +97,48 @@ remmediations static content and the configured groups from its endpoints.
 * `group_poll_time` is the time between groups configuration updates. It will be interpreted as the Golang
 [`time.ParseDuration`](https://golang.org/pkg/time/#ParseDuration) function.
 
+### Metrics configuration
+
+Metrics configuration is in section `[metrics]` in config file
+
+```toml
+[metrics]
+namespace = "mynamespace"
+```
+
+* `namespace` if defined, it is used as `Namespace` argument when creating all
+  the Prometheus metrics exposed by this service.
+
 ## REST API schema based on OpenAPI 3.0
 
 TODO
+
+## Prometheus API
+
+It is possible to use `/api/v1/metrics` REST API endpoint to read all metrics exposed to Prometheus
+or to any tool that is compatible with it.
+Currently, the following metrics are exposed:
+
+### API related metrics
+
+There are a set of metrics provieded by `insights-operator-utils` library, all
+of them related with the API usage. These are the API metrics exposed:
+
+1. `api_endpoints_requests` the total number of requests per endpoint
+1. `api_endpoints_response_time` API endpoints response time
+1. `api_endpoints_status_codes` a counter of the HTTP status code responses
+   returned back by the service
+
+Additionally it is possible to consume all metrics provided by Go runtime. There metrics start with
+`go_` and `process_` prefixes.
+
+### Metrics namespace
+
+As explained in the [configuration](./configuration) section of this
+documentation, a namespace can be provided in order to act as a prefix to the
+metric name. If no namespace is provided in the configuration, the metrics will
+be exposed as described in this documentation.
+
 
 ## Contribution
 

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -56,11 +56,17 @@ type SetupConfiguration struct {
 	InternalRulesOrganizationsCSVFile string `mapstructure:"internal_rules_organizations_csv_file" toml:"internal_rules_organizations_csv_file"`
 }
 
+// MetricsConfiguration defines configuration for metrics
+type MetricsConfiguration struct {
+	Namespace string `mapstructure:"namespace" toml:"namespace"`
+}
+
 // Config has exactly the same structure as *.toml file
 var Config struct {
 	ServerConf   server.Configuration   `mapstructure:"server" toml:"server"`
 	ServicesConf services.Configuration `mapstructure:"services" toml:"services"`
 	SetupConf    SetupConfiguration     `mapstructure:"setup" toml:"setup"`
+	MetricsConf  MetricsConfiguration   `mapstructure:"metrics" toml:"metrics"`
 }
 
 // LoadConfiguration loads configuration from defaultConfigFile, file set in
@@ -136,6 +142,11 @@ func GetServicesConfiguration() services.Configuration {
 // startup
 func GetSetupConfiguration() SetupConfiguration {
 	return Config.SetupConf
+}
+
+// GetMetricsConfiguration returns the metrics configuration
+func GetMetricsConfiguration() MetricsConfiguration {
+	return Config.MetricsConf
 }
 
 // checkIfFileExists returns nil if path doesn't exist or isn't a file,

--- a/config.toml
+++ b/config.toml
@@ -17,3 +17,6 @@ groups_poll_time = "60s"
 
 [setup]
 internal_rules_organizations_csv_file = ""
+
+[metrics]
+namespace = "smart_proxy"

--- a/docs/packages/conf/configuration.html
+++ b/docs/packages/conf/configuration.html
@@ -189,12 +189,23 @@ https://redhatinsights.github.io/insights-results-smart-proxy/packages/conf/conf
       </tr>
       
       <tr class="section">
+	<td class="doc"><p>MetricsConfiguration defines configuration for metrics</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">type</div> <div class="ident">MetricsConfiguration</div> <div class="keyword">struct</div> <div class="operator">{</div>
+	<div class="ident">Namespace</div> <div class="ident">string</div> <div class="literal">`mapstructure:&#34;namespace&#34; toml:&#34;namespace&#34;`</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
 	<td class="doc"><p>Config has exactly the same structure as *.toml file</p>
 </td>
 	<td class="code"><pre><code><div class="keyword">var</div> <div class="ident">Config</div> <div class="keyword">struct</div> <div class="operator">{</div>
 	<div class="ident">ServerConf</div>   <div class="ident">server</div><div class="operator">.</div><div class="ident">Configuration</div>   <div class="literal">`mapstructure:&#34;server&#34; toml:&#34;server&#34;`</div><div class="operator"></div>
 	<div class="ident">ServicesConf</div> <div class="ident">services</div><div class="operator">.</div><div class="ident">Configuration</div> <div class="literal">`mapstructure:&#34;services&#34; toml:&#34;services&#34;`</div><div class="operator"></div>
 	<div class="ident">SetupConf</div>    <div class="ident">SetupConfiguration</div>     <div class="literal">`mapstructure:&#34;setup&#34; toml:&#34;setup&#34;`</div><div class="operator"></div>
+	<div class="ident">MetricsConf</div>  <div class="ident">MetricsConfiguration</div>   <div class="literal">`mapstructure:&#34;metrics&#34; toml:&#34;metrics&#34;`</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 </code></pre></td>
@@ -315,6 +326,16 @@ startup</p>
 </td>
 	<td class="code"><pre><code><div class="keyword">func</div> <div class="ident">GetSetupConfiguration</div><div class="operator">(</div><div class="operator">)</div> <div class="ident">SetupConfiguration</div> <div class="operator">{</div>
 	<div class="keyword">return</div> <div class="ident">Config</div><div class="operator">.</div><div class="ident">SetupConf</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+</code></pre></td>
+      </tr>
+      
+      <tr class="section">
+	<td class="doc"><p>GetMetricsConfiguration returns the metrics configuration</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">func</div> <div class="ident">GetMetricsConfiguration</div><div class="operator">(</div><div class="operator">)</div> <div class="ident">MetricsConfiguration</div> <div class="operator">{</div>
+	<div class="keyword">return</div> <div class="ident">Config</div><div class="operator">.</div><div class="ident">MetricsConf</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
 </code></pre></td>

--- a/docs/packages/smart_proxy.html
+++ b/docs/packages/smart_proxy.html
@@ -149,13 +149,15 @@ limitations under the License.
 	<div class="literal">&#34;strings&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;time&#34;</div><div class="operator"></div>
 
-	<div class="literal">&#34;github.com/RedHatInsights/insights-content-service/content&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/RedHatInsights/insights-content-service/groups&#34;</div><div class="operator"></div>
+	<div class="literal">&#34;github.com/RedHatInsights/insights-operator-utils/metrics&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/rs/zerolog/log&#34;</div><div class="operator"></div>
 
 	<div class="literal">&#34;github.com/RedHatInsights/insights-results-smart-proxy/conf&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/RedHatInsights/insights-results-smart-proxy/server&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;github.com/RedHatInsights/insights-results-smart-proxy/services&#34;</div><div class="operator"></div>
+
+	<div class="ident">proxy_content</div> <div class="literal">&#34;github.com/RedHatInsights/insights-results-smart-proxy/content&#34;</div><div class="operator"></div>
 <div class="operator">)</div><div class="operator"></div>
 
 <div class="keyword">const</div> <div class="operator">(</div>
@@ -230,13 +232,19 @@ The commands are:
 	<td class="doc"><p>startService starts service and returns error code</p>
 </td>
 	<td class="code"><pre><code><div class="keyword">func</div> <div class="ident">startServer</div><div class="operator">(</div><div class="operator">)</div> <div class="ident">int</div> <div class="operator">{</div>
+	<div class="ident">_</div> <div class="operator">=</div> <div class="ident">conf</div><div class="operator">.</div><div class="ident">GetSetupConfiguration</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
 	<div class="ident">serverCfg</div> <div class="operator">:=</div> <div class="ident">conf</div><div class="operator">.</div><div class="ident">GetServerConfiguration</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">metricsCfg</div> <div class="operator">:=</div> <div class="ident">conf</div><div class="operator">.</div><div class="ident">GetMetricsConfiguration</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
 	<div class="ident">servicesCfg</div> <div class="operator">:=</div> <div class="ident">conf</div><div class="operator">.</div><div class="ident">GetServicesConfiguration</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
 	<div class="ident">groupsChannel</div> <div class="operator">:=</div> <div class="ident">make</div><div class="operator">(</div><div class="keyword">chan</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">groups</div><div class="operator">.</div><div class="ident">Group</div><div class="operator">)</div><div class="operator"></div>
-	<div class="ident">contentChannel</div> <div class="operator">:=</div> <div class="ident">make</div><div class="operator">(</div><div class="keyword">chan</div> <div class="ident">content</div><div class="operator">.</div><div class="ident">RuleContentDirectory</div><div class="operator">)</div><div class="operator"></div>
-	<div class="ident">serverInstance</div> <div class="operator">=</div> <div class="ident">server</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">serverCfg</div><div class="operator">,</div> <div class="ident">servicesCfg</div><div class="operator">,</div> <div class="ident">groupsChannel</div><div class="operator">,</div> <div class="ident">contentChannel</div><div class="operator">)</div><div class="operator"></div>
 
-	<div class="keyword">go</div> <div class="ident">updateGroupInfo</div><div class="operator">(</div><div class="ident">servicesCfg</div><div class="operator">,</div> <div class="ident">groupsChannel</div><div class="operator">,</div> <div class="ident">contentChannel</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">if</div> <div class="ident">metricsCfg</div><div class="operator">.</div><div class="ident">Namespace</div> <div class="operator">!=</div> <div class="literal">&#34;&#34;</div> <div class="operator">{</div>
+		<div class="ident">metrics</div><div class="operator">.</div><div class="ident">AddAPIMetricsWithNamespace</div><div class="operator">(</div><div class="ident">metricsCfg</div><div class="operator">.</div><div class="ident">Namespace</div><div class="operator">)</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+	<div class="ident">serverInstance</div> <div class="operator">=</div> <div class="ident">server</div><div class="operator">.</div><div class="ident">New</div><div class="operator">(</div><div class="ident">serverCfg</div><div class="operator">,</div> <div class="ident">servicesCfg</div><div class="operator">,</div> <div class="ident">groupsChannel</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="keyword">go</div> <div class="ident">updateGroupInfo</div><div class="operator">(</div><div class="ident">servicesCfg</div><div class="operator">,</div> <div class="ident">groupsChannel</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">go</div> <div class="ident">proxy_content</div><div class="operator">.</div><div class="ident">RunUpdateContentLoop</div><div class="operator">(</div><div class="ident">servicesCfg</div><div class="operator">)</div><div class="operator"></div>
 
 	<div class="ident">err</div> <div class="operator">:=</div> <div class="ident">serverInstance</div><div class="operator">.</div><div class="ident">Start</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
 	<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
@@ -255,22 +263,14 @@ The commands are:
 * If ticker comes first, the groups configuration is updated, doing a request to the content-service
 * If the channel comes first, the latest valid groups configuration is send through the channel</p>
 </td>
-	<td class="code"><pre><code><div class="keyword">func</div> <div class="ident">updateGroupInfo</div><div class="operator">(</div><div class="ident">servicesConf</div> <div class="ident">services</div><div class="operator">.</div><div class="ident">Configuration</div><div class="operator">,</div> <div class="ident">groupsChannel</div> <div class="keyword">chan</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">groups</div><div class="operator">.</div><div class="ident">Group</div><div class="operator">,</div> <div class="ident">contentChannel</div> <div class="keyword">chan</div> <div class="ident">content</div><div class="operator">.</div><div class="ident">RuleContentDirectory</div><div class="operator">)</div> <div class="operator">{</div>
+	<td class="code"><pre><code><div class="keyword">func</div> <div class="ident">updateGroupInfo</div><div class="operator">(</div><div class="ident">servicesConf</div> <div class="ident">services</div><div class="operator">.</div><div class="ident">Configuration</div><div class="operator">,</div> <div class="ident">groupsChannel</div> <div class="keyword">chan</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">groups</div><div class="operator">.</div><div class="ident">Group</div><div class="operator">)</div> <div class="operator">{</div>
 	<div class="keyword">var</div> <div class="ident">currentGroups</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">groups</div><div class="operator">.</div><div class="ident">Group</div><div class="operator"></div>
-	<div class="ident">currentContent</div> <div class="operator">:=</div> <div class="operator">&amp;</div><div class="ident">content</div><div class="operator">.</div><div class="ident">RuleContentDirectory</div><div class="operator">{</div><div class="operator">}</div><div class="operator"></div>
 
 	<div class="ident">groups</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">services</div><div class="operator">.</div><div class="ident">GetGroups</div><div class="operator">(</div><div class="ident">servicesConf</div><div class="operator">)</div><div class="operator"></div>
 	<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
 		<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Err</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;Error retrieving groups&#34;</div><div class="operator">)</div><div class="operator"></div>
 	<div class="operator">}</div> <div class="keyword">else</div> <div class="operator">{</div>
 		<div class="ident">currentGroups</div> <div class="operator">=</div> <div class="ident">groups</div><div class="operator"></div>
-	<div class="operator">}</div><div class="operator"></div>
-
-	<div class="ident">content</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">services</div><div class="operator">.</div><div class="ident">GetContent</div><div class="operator">(</div><div class="ident">servicesConf</div><div class="operator">)</div><div class="operator"></div>
-	<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
-		<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Err</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;Error retrieving static content&#34;</div><div class="operator">)</div><div class="operator"></div>
-	<div class="operator">}</div> <div class="keyword">else</div> <div class="operator">{</div>
-		<div class="ident">currentContent</div> <div class="operator">=</div> <div class="ident">content</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 
 	<div class="ident">uptimeTicker</div> <div class="operator">:=</div> <div class="ident">time</div><div class="operator">.</div><div class="ident">NewTicker</div><div class="operator">(</div><div class="ident">servicesConf</div><div class="operator">.</div><div class="ident">GroupsPollingTime</div><div class="operator">)</div><div class="operator"></div>
@@ -285,16 +285,7 @@ The commands are:
 			<div class="operator">}</div> <div class="keyword">else</div> <div class="operator">{</div>
 				<div class="ident">currentGroups</div> <div class="operator">=</div> <div class="ident">groups</div><div class="operator"></div>
 			<div class="operator">}</div><div class="operator"></div>
-
-			<div class="ident">content</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">=</div> <div class="ident">services</div><div class="operator">.</div><div class="ident">GetContent</div><div class="operator">(</div><div class="ident">servicesConf</div><div class="operator">)</div><div class="operator"></div>
-			<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
-				<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Err</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msg</div><div class="operator">(</div><div class="literal">&#34;Error retrieving static content&#34;</div><div class="operator">)</div><div class="operator"></div>
-			<div class="operator">}</div> <div class="keyword">else</div> <div class="operator">{</div>
-				<div class="ident">currentContent</div> <div class="operator">=</div> <div class="ident">content</div><div class="operator"></div>
-			<div class="operator">}</div><div class="operator"></div>
-
 		<div class="keyword">case</div> <div class="ident">groupsChannel</div> <div class="operator">&lt;-</div> <div class="ident">currentGroups</div><div class="operator">:</div>
-		<div class="keyword">case</div> <div class="ident">contentChannel</div> <div class="operator">&lt;-</div> <div class="operator">*</div><div class="ident">currentContent</div><div class="operator">:</div>
 		<div class="operator">}</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
@@ -342,12 +333,11 @@ The commands are:
 		<div class="ident">showVersion</div> <div class="ident">bool</div><div class="operator"></div>
 	<div class="operator">)</div><div class="operator"></div>
 	<div class="ident">flag</div><div class="operator">.</div><div class="ident">BoolVar</div><div class="operator">(</div><div class="operator">&amp;</div><div class="ident">showHelp</div><div class="operator">,</div> <div class="literal">&#34;help&#34;</div><div class="operator">,</div> <div class="ident">false</div><div class="operator">,</div> <div class="literal">&#34;Show the help&#34;</div><div class="operator">)</div><div class="operator"></div>
-	<div class="ident">flag</div><div class="operator">.</div><div class="ident">BoolVar</div><div class="operator">(</div><div class="operator">&amp;</div><div class="ident">showVersion</div><div class="operator">,</div> <div class="literal">&#34;version&#34;</div><div class="operator">,</div> <div class="ident">false</div><div class="operator">,</div> <div class="literal">&#34;Show the version an exit&#34;</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">flag</div><div class="operator">.</div><div class="ident">BoolVar</div><div class="operator">(</div><div class="operator">&amp;</div><div class="ident">showVersion</div><div class="operator">,</div> <div class="literal">&#34;version&#34;</div><div class="operator">,</div> <div class="ident">false</div><div class="operator">,</div> <div class="literal">&#34;Show the version and exit&#34;</div><div class="operator">)</div><div class="operator"></div>
 	<div class="ident">flag</div><div class="operator">.</div><div class="ident">Parse</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
 
 	<div class="keyword">if</div> <div class="ident">showHelp</div> <div class="operator">{</div>
-		<div class="ident">printHelp</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
-		<div class="ident">os</div><div class="operator">.</div><div class="ident">Exit</div><div class="operator">(</div><div class="ident">ExitStatusOK</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">os</div><div class="operator">.</div><div class="ident">Exit</div><div class="operator">(</div><div class="ident">printHelp</div><div class="operator">(</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 
 	<div class="keyword">if</div> <div class="ident">showVersion</div> <div class="operator">{</div>
@@ -355,8 +345,7 @@ The commands are:
 		<div class="ident">os</div><div class="operator">.</div><div class="ident">Exit</div><div class="operator">(</div><div class="ident">ExitStatusOK</div><div class="operator">)</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 
-	<div class="keyword">var</div> <div class="ident">args</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">string</div><div class="operator"></div>
-	<div class="ident">args</div> <div class="operator">=</div> <div class="ident">flag</div><div class="operator">.</div><div class="ident">Args</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">args</div> <div class="operator">:=</div> <div class="ident">flag</div><div class="operator">.</div><div class="ident">Args</div><div class="operator">(</div><div class="operator">)</div><div class="operator"></div>
 
 	<div class="ident">command</div> <div class="operator">:=</div> <div class="literal">&#34;start-service&#34;</div><div class="operator"></div>
 	<div class="keyword">if</div> <div class="ident">len</div><div class="operator">(</div><div class="ident">args</div><div class="operator">)</div> <div class="operator">&gt;=</div> <div class="literal">1</div> <div class="operator">{</div>

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20200624083233-f39245e725f9
-	github.com/RedHatInsights/insights-operator-utils v1.3.2
+	github.com/RedHatInsights/insights-operator-utils v1.4.0
 	github.com/RedHatInsights/insights-results-aggregator v1.0.0
 	github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200624135606-84f78db90ac2
 	github.com/Shopify/sarama v1.26.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -29,8 +29,9 @@ github.com/RedHatInsights/insights-operator-utils v1.0.1/go.mod h1:gRzYBMY4csuOX
 github.com/RedHatInsights/insights-operator-utils v1.0.2-0.20200610143236-c868b2f93d2a/go.mod h1:0rhk13kn0BB+yKdfZjpMoQy0lXdXY3i4NJ1xGwGMcII=
 github.com/RedHatInsights/insights-operator-utils v1.1.0/go.mod h1:PHoCR0njiPXVArw+ooowqZgBjozu1h+8mYDoRoPVh6g=
 github.com/RedHatInsights/insights-operator-utils v1.2.0/go.mod h1:PHoCR0njiPXVArw+ooowqZgBjozu1h+8mYDoRoPVh6g=
-github.com/RedHatInsights/insights-operator-utils v1.3.2 h1:e7D2e+pkxDMNMd9ZVxM+6CjGG+O79LKrHLXE5OuQOKo=
 github.com/RedHatInsights/insights-operator-utils v1.3.2/go.mod h1:F7KKAdWFR70H+3fa89ciXqimNycHdqO9HjLWRdZwOug=
+github.com/RedHatInsights/insights-operator-utils v1.4.0 h1:R1ktc6+y/UGSKQyzRV3QN8S7ulqhnc2vcXJXCCYCn4M=
+github.com/RedHatInsights/insights-operator-utils v1.4.0/go.mod h1:F7KKAdWFR70H+3fa89ciXqimNycHdqO9HjLWRdZwOug=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator v1.0.0 h1:kwBDAc4KW4bZ18ucazwOtBZvIuzcx5ii8Y1Gw/7h12c=
 github.com/RedHatInsights/insights-results-aggregator v1.0.0/go.mod h1:oscRaIGWUHw/oln2Knjf7oW4E/JTHy2Em6vAjDMXPe8=
@@ -451,7 +452,6 @@ github.com/streadway/amqp v0.0.0-20190404075320-75d898a42a94/go.mod h1:AZpEONHx3
 github.com/streadway/amqp v0.0.0-20190827072141-edfb9018d271/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
 github.com/streadway/handy v0.0.0-20190108123426-d5acb3125c2a/go.mod h1:qNTQ5P5JnDBl6z3cMAg/SywNDC5ABu5ApDIw6lUbRmI=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/smart_proxy.go
+++ b/smart_proxy.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/RedHatInsights/insights-content-service/groups"
+	"github.com/RedHatInsights/insights-operator-utils/metrics"
 	"github.com/rs/zerolog/log"
 
 	"github.com/RedHatInsights/insights-results-smart-proxy/conf"
@@ -94,8 +95,13 @@ func printEnv() int {
 func startServer() int {
 	_ = conf.GetSetupConfiguration()
 	serverCfg := conf.GetServerConfiguration()
+	metricsCfg := conf.GetMetricsConfiguration()
 	servicesCfg := conf.GetServicesConfiguration()
 	groupsChannel := make(chan []groups.Group)
+
+	if metricsCfg.Namespace != "" {
+		metrics.AddAPIMetricsWithNamespace(metricsCfg.Namespace)
+	}
 	serverInstance = server.New(serverCfg, servicesCfg, groupsChannel)
 
 	go updateGroupInfo(servicesCfg, groupsChannel)


### PR DESCRIPTION
# Description

Adding configuration parameter for API related metrics from `insights-operator-utils`. README updated

Fixes #95 

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps

Regular CI