### PR TITLE
Fixed issue #110: all parameters for  needs to be described in OpenAPI

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -216,6 +216,7 @@
             "name": "clusterId",
             "in": "path",
             "required": true,
+            "description": "ID of the cluster which must conform to UUID format.",
             "schema": {
               "type": "string",
               "minLength": 36,


### PR DESCRIPTION
# Description

All parameters for `/clusters/{clusterId}/report` needs to be described in OpenAPI

Fixes #110

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

N/A