### PR TITLE
Fix #131. Add description an example to a parameter

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1321,9 +1321,11 @@
             "name": "ruleId",
             "in": "path",
             "required": true,
+            "description": "ID of a rule",
             "schema": {
               "type": "string"
-            }
+            },
+            "example": "some.python.module"
           }
         ],
         "responses": {


### PR DESCRIPTION
# Description

Add description an example for parameter `ruleId` in endpoint `/clusters/{clusterId}/rules/{ruleId}/enable` using `put` method

Fixes #131 

## Type of change
- Documentation update

## Testing steps

Regular CI