### PR TITLE
Fix #130. Add description an example to a parameter

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1309,13 +1309,15 @@
           {
             "name": "clusterId",
             "in": "path",
+            "description": "ID of the cluster which must conform to UUID format",
             "required": true,
             "schema": {
               "type": "string",
               "minLength": 36,
               "maxLength": 36,
               "format": "uuid"
-            }
+            },
+            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266"
           },
           {
             "name": "ruleId",


### PR DESCRIPTION
# Description

Adding description an example to parameter `clusterId`

Fixes #130 

## Type of change

- Documentation update

## Testing steps

Regular CI