### PR TITLE
Adding description for parameters in rule disable endpoint

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1260,20 +1260,24 @@
             "name": "clusterId",
             "in": "path",
             "required": true,
+            "description": "ID of the cluster which must conform to UUID format",
             "schema": {
               "type": "string",
               "minLength": 36,
               "maxLength": 36,
               "format": "uuid"
-            }
+            },
+            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266"
           },
           {
             "name": "ruleId",
             "in": "path",
             "required": true,
+            "description": "Enables a rule (ruleId) for cluster (clusterId) for current organization/user",
             "schema": {
               "type": "string"
-            }
+            },
+            "example": "some.python.module"
           }
         ],
         "responses": {


### PR DESCRIPTION
# Description

Addes descriptions and examples for parameters in the disable rule endpoint for its `put` method

Fixes #120 #129 

## Type of change

- Documentation update

## Testing steps

Regular CI