### PR TITLE
Fix specification of clusters/{clusterId}/rules/{ruleId}/report parameters

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -363,20 +363,24 @@
             "name": "clusterId",
             "in": "path",
             "required": true,
+            "description": "ID of the cluster which must conform to UUID format.",
             "schema": {
               "type": "string",
               "minLength": 36,
               "maxLength": 36,
               "format": "uuid"
-            }
+            },
+            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266"
           },
           {
             "name": "ruleId",
             "in": "path",
             "required": true,
+            "description": "ID of a rule",
             "schema": {
               "type": "string"
-            }
+            },
+            "example": "some.python.module"
           }
         ],
         "responses": {


### PR DESCRIPTION
# Description

Change on openapi specification, adding description and example for parameters for the `clusters/{clusterId}/rules/{ruleId}/report` endpoint.

Fixes #112 and fixes #117 

## Type of change

- Documentation update

## Testing steps

Regular CI