### PR TITLE
Fix dislike endpoint parameters spec

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -544,20 +544,24 @@
             "name": "clusterId",
             "in": "path",
             "required": true,
+            "description": "ID of the cluster which must conform to UUID format",
             "schema": {
               "type": "string",
               "minLength": 36,
               "maxLength": 36,
               "format": "uuid"
-            }
+            },
+            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266"
           },
           {
             "name": "ruleId",
             "in": "path",
             "required": true,
+            "description": "ID of a rule",
             "schema": {
               "type": "string"
-            }
+            },
+            "example": "some.python.module"
           }
         ],
         "responses": {


### PR DESCRIPTION
# Description

Change on openapi specification, adding description and example for parameters for the `clusters{clusterId}/rules/{ruleId}/dislike` endpoint.

Fixes #115 and fixes #121 

## Type of change

- Documentation update

## Testing steps

Regular CI