### PR TITLE
Fixed issue #116

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -219,6 +219,7 @@
             "in": "path",
             "required": true,
             "description": "ID of the cluster which must conform to UUID format.",
+            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266",
             "schema": {
               "type": "string",
               "minLength": 36,


### PR DESCRIPTION
# Description

No description found for endpoint `/clusters/{clusterId}/report` method `get` and parameter `clusterId`

Fixes #116

## Type of change

- Documentation update

## Testing steps

N/A