### PR TITLE
Fix issue #219

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1149,6 +1149,7 @@
           },
           {
             "name": "errorKey",
+            "description": "Selector that specifies rule error key (rule can contain more sections distinguished by error key).",
             "in": "path",
             "required": true,
             "schema": {


### PR DESCRIPTION
# Description

No description found for endpoint `/rules/{ruleId}/error_keys/{errorKey}` method `get` and parameter `errorKey` in OpenAPI specification

Fixes #219

## Type of change

- Documentation update

## Testing steps

N/A