### PR TITLE
Fix issue #219

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1140,6 +1140,7 @@
         "parameters": [
           {
             "name": "ruleId",
+            "description": "ID that uniquely identifies the rule to return",
             "in": "path",
             "required": true,
             "schema": {


### PR DESCRIPTION
# Description

Empty description found for endpoint `/rules/{ruleId}/error_keys/{errorKey}` method `get` and parameter `ruleId` in OpenAPI specification

Fixes #281

## Type of change

- Documentation update

## Testing steps

N/A