### PR TITLE
Fixed issue #217

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1136,7 +1136,7 @@
       },
       "get": {
         "summary": "getRule returns rule with content for provided rule ID and rule error key",
-        "description": "",
+        "description": "[DEBUG ONLY] Retrieves and returns static content for specifief rule ID and error key",
         "parameters": [
           {
             "name": "ruleId",


### PR DESCRIPTION
# Description

Empty description found for endpoint `/rules/{ruleId}/error_keys/{errorKey}` and method `get` in OpenAPI specification

Fixes #217

## Type of change

- Documentation update

## Testing steps

N/A