### PR TITLE
Fix issue #216

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -777,6 +777,7 @@
     "/rule_ids": {
       "get": {
         "summary": "Returns the rule IDs of all the rules.",
+        "description": "Returns a list of the names of the rules. Rule name consist of its ID represented as a string.",
         "operationId": "getRuleIDs",
         "responses": {
           "200": {


### PR DESCRIPTION
# Description

No description found for endpoint `/rule_ids` and method `get` in OpenAPI specification

Fixes #216

## Type of change

- Documentation update

## Testing steps

N/A