### PR TITLE
Refactor: extract fetchRuleContent from server/server.go module

### DIFF
--- a/docs/packages/conf/configuration.html
+++ b/docs/packages/conf/configuration.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- Copyright 2020 Red Hat, Inc
+ Copyright 2021 Red Hat, Inc
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/docs/packages/content/content.html
+++ b/docs/packages/content/content.html
@@ -472,6 +472,62 @@ Caching is done under the hood, don't worry about it.</p>
 </code></pre></td>
       </tr>
       
+      <tr class="section">
+	<td class="doc"><p>fetchRuleContent - fetching content for particular rule
+Return values:
+  - Structure with rules and content
+  - return true if fetching content was successful, including filtering
+  - return true if the rule has been filtered by OSDElegible field. False otherwise</p>
+</td>
+	<td class="code"><pre><code><div class="keyword">func</div> <div class="ident">FetchRuleContent</div><div class="operator">(</div><div class="ident">rule</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">RuleOnReport</div><div class="operator">,</div> <div class="ident">OSDEligible</div> <div class="ident">bool</div><div class="operator">)</div> <div class="operator">(</div>
+	<div class="ident">ruleWithContentResponse</div> <div class="operator">*</div><div class="ident">local_types</div><div class="operator">.</div><div class="ident">RuleWithContentResponse</div><div class="operator">,</div>
+	<div class="ident">success</div> <div class="ident">bool</div><div class="operator">,</div>
+	<div class="ident">osdFiltered</div> <div class="ident">bool</div><div class="operator">,</div>
+<div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">ruleID</div> <div class="operator">:=</div> <div class="ident">rule</div><div class="operator">.</div><div class="ident">Module</div><div class="operator"></div>
+	<div class="ident">errorKey</div> <div class="operator">:=</div> <div class="ident">rule</div><div class="operator">.</div><div class="ident">ErrorKey</div><div class="operator"></div>
+
+	<div class="ident">ruleWithContentResponse</div> <div class="operator">=</div> <div class="ident">nil</div><div class="operator"></div>
+	<div class="ident">success</div> <div class="operator">=</div> <div class="ident">false</div><div class="operator"></div>
+	<div class="ident">osdFiltered</div> <div class="operator">=</div> <div class="ident">false</div><div class="operator"></div>
+
+	<div class="ident">ruleWithContent</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">GetRuleWithErrorKeyContent</div><div class="operator">(</div><div class="ident">ruleID</div><div class="operator">,</div> <div class="ident">errorKey</div><div class="operator">)</div><div class="operator"></div>
+	<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
+		<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Err</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msgf</div><div class="operator">(</div>
+			<div class="literal">&#34;unable to get content for rule with id %v and error key %v&#34;</div><div class="operator">,</div> <div class="ident">ruleID</div><div class="operator">,</div> <div class="ident">errorKey</div><div class="operator">,</div>
+		<div class="operator">)</div><div class="operator"></div>
+		<div class="keyword">return</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="keyword">if</div> <div class="ident">OSDEligible</div> <div class="operator">&amp;&amp;</div> <div class="operator">!</div><div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">NotRequireAdmin</div> <div class="operator">{</div>
+		<div class="ident">osdFiltered</div> <div class="operator">=</div> <div class="ident">true</div><div class="operator"></div>
+		<div class="keyword">return</div><div class="operator"></div>
+	<div class="operator">}</div><div class="operator"></div>
+
+	<div class="ident">ruleWithContentResponse</div> <div class="operator">=</div> <div class="operator">&amp;</div><div class="ident">local_types</div><div class="operator">.</div><div class="ident">RuleWithContentResponse</div><div class="operator">{</div>
+		<div class="ident">CreatedAt</div><div class="operator">:</div>       <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">PublishDate</div><div class="operator">.</div><div class="ident">UTC</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Format</div><div class="operator">(</div><div class="ident">time</div><div class="operator">.</div><div class="ident">RFC3339</div><div class="operator">)</div><div class="operator">,</div>
+		<div class="ident">Description</div><div class="operator">:</div>     <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Description</div><div class="operator">,</div>
+		<div class="ident">ErrorKey</div><div class="operator">:</div>        <div class="ident">errorKey</div><div class="operator">,</div>
+		<div class="ident">Generic</div><div class="operator">:</div>         <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Generic</div><div class="operator">,</div>
+		<div class="ident">Reason</div><div class="operator">:</div>          <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Reason</div><div class="operator">,</div>
+		<div class="ident">Resolution</div><div class="operator">:</div>      <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Resolution</div><div class="operator">,</div>
+		<div class="ident">TotalRisk</div><div class="operator">:</div>       <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">TotalRisk</div><div class="operator">,</div>
+		<div class="ident">RiskOfChange</div><div class="operator">:</div>    <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">RiskOfChange</div><div class="operator">,</div>
+		<div class="ident">RuleID</div><div class="operator">:</div>          <div class="ident">ruleID</div><div class="operator">,</div>
+		<div class="ident">TemplateData</div><div class="operator">:</div>    <div class="ident">rule</div><div class="operator">.</div><div class="ident">TemplateData</div><div class="operator">,</div>
+		<div class="ident">Tags</div><div class="operator">:</div>            <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Tags</div><div class="operator">,</div>
+		<div class="ident">UserVote</div><div class="operator">:</div>        <div class="ident">rule</div><div class="operator">.</div><div class="ident">UserVote</div><div class="operator">,</div>
+		<div class="ident">Disabled</div><div class="operator">:</div>        <div class="ident">rule</div><div class="operator">.</div><div class="ident">Disabled</div><div class="operator">,</div>
+		<div class="ident">DisableFeedback</div><div class="operator">:</div> <div class="ident">rule</div><div class="operator">.</div><div class="ident">DisableFeedback</div><div class="operator">,</div>
+		<div class="ident">DisabledAt</div><div class="operator">:</div>      <div class="ident">rule</div><div class="operator">.</div><div class="ident">DisabledAt</div><div class="operator">,</div>
+		<div class="ident">Internal</div><div class="operator">:</div>        <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Internal</div><div class="operator">,</div>
+	<div class="operator">}</div><div class="operator"></div>
+	<div class="ident">success</div> <div class="operator">=</div> <div class="ident">true</div><div class="operator"></div>
+	<div class="keyword">return</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+</code></pre></td>
+      </tr>
+      
     </tbody>
   </table>
 </div>

--- a/docs/packages/content/content_test.html
+++ b/docs/packages/content/content_test.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- Copyright 2020 Red Hat, Inc
+ Copyright 2021 Red Hat, Inc
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.
@@ -134,6 +134,7 @@ limitations under the License.</p>
 	<td class="code"><pre><code><div class="keyword">package</div> <div class="ident">content_test</div><div class="operator"></div>
 
 <div class="keyword">import</div> <div class="operator">(</div>
+	<div class="ident">local_types</div> <div class="literal">&#34;github.com/RedHatInsights/insights-results-smart-proxy/types&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;net/http&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;testing&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;time&#34;</div><div class="operator"></div>
@@ -266,6 +267,158 @@ limitations under the License.</p>
 	<div class="ident">assert</div><div class="operator">.</div><div class="ident">Equal</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">len</div><div class="operator">(</div><div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleContentDirectory3Rules</div><div class="operator">.</div><div class="ident">Rules</div><div class="operator">)</div><div class="operator">,</div> <div class="ident">len</div><div class="operator">(</div><div class="ident">rules</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
+<div class="keyword">func</div> <div class="ident">TestFetchRuleContent_OSDEligibleNotRequiredAdmin</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">helpers</div><div class="operator">.</div><div class="ident">RunTestWithTimeout</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="keyword">func</div><div class="operator">(</div><div class="ident">t</div> <div class="ident">testing</div><div class="operator">.</div><div class="ident">TB</div><div class="operator">)</div> <div class="operator">{</div>
+		<div class="keyword">defer</div> <div class="ident">helpers</div><div class="operator">.</div><div class="ident">CleanAfterGock</div><div class="operator">(</div><div class="ident">t</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">helpers</div><div class="operator">.</div><div class="ident">GockExpectAPIRequest</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">helpers</div><div class="operator">.</div><div class="ident">DefaultServicesConfig</div><div class="operator">.</div><div class="ident">ContentBaseEndpoint</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">APIRequest</div><div class="operator">{</div>
+			<div class="ident">Method</div><div class="operator">:</div>   <div class="ident">http</div><div class="operator">.</div><div class="ident">MethodGet</div><div class="operator">,</div>
+			<div class="ident">Endpoint</div><div class="operator">:</div> <div class="ident">ics_server</div><div class="operator">.</div><div class="ident">AllContentEndpoint</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">APIResponse</div><div class="operator">{</div>
+			<div class="ident">StatusCode</div><div class="operator">:</div> <div class="ident">http</div><div class="operator">.</div><div class="ident">StatusOK</div><div class="operator">,</div>
+			<div class="ident">Body</div><div class="operator">:</div>       <div class="ident">helpers</div><div class="operator">.</div><div class="ident">MustGobSerialize</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleContentDirectory3Rules</div><div class="operator">)</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">content</div><div class="operator">.</div><div class="ident">UpdateContent</div><div class="operator">(</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">DefaultServicesConfig</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">rule</div> <div class="operator">:=</div> <div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleOnReport1</div><div class="operator"></div>
+		<div class="ident">ruleContent</div><div class="operator">,</div> <div class="ident">success</div><div class="operator">,</div> <div class="ident">osdFiltered</div> <div class="operator">:=</div> <div class="ident">content</div><div class="operator">.</div><div class="ident">FetchRuleContent</div><div class="operator">(</div><div class="ident">rule</div><div class="operator">,</div> <div class="ident">true</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">True</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div><div class="ident">success</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">False</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div><div class="ident">osdFiltered</div><div class="operator">)</div> <div class="operator"></div><div class="comment">//NotRequiredAdmin is true in Rule1</div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">NotNil</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">ruleContent</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">ruleID</div> <div class="operator">:=</div> <div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleOnReport1</div><div class="operator">.</div><div class="ident">Module</div><div class="operator"></div>
+		<div class="ident">errorKey</div> <div class="operator">:=</div> <div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleOnReport1</div><div class="operator">.</div><div class="ident">ErrorKey</div><div class="operator"></div>
+		<div class="ident">ruleWithContent</div><div class="operator">,</div> <div class="ident">_</div> <div class="operator">:=</div> <div class="ident">content</div><div class="operator">.</div><div class="ident">GetRuleWithErrorKeyContent</div><div class="operator">(</div><div class="ident">ruleID</div><div class="operator">,</div> <div class="ident">errorKey</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">ruleWithContentResponse</div> <div class="operator">:=</div> <div class="operator">&amp;</div><div class="ident">local_types</div><div class="operator">.</div><div class="ident">RuleWithContentResponse</div><div class="operator">{</div>
+			<div class="ident">CreatedAt</div><div class="operator">:</div>       <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">PublishDate</div><div class="operator">.</div><div class="ident">UTC</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Format</div><div class="operator">(</div><div class="ident">time</div><div class="operator">.</div><div class="ident">RFC3339</div><div class="operator">)</div><div class="operator">,</div>
+			<div class="ident">Description</div><div class="operator">:</div>     <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Description</div><div class="operator">,</div>
+			<div class="ident">ErrorKey</div><div class="operator">:</div>        <div class="ident">errorKey</div><div class="operator">,</div>
+			<div class="ident">Generic</div><div class="operator">:</div>         <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Generic</div><div class="operator">,</div>
+			<div class="ident">Reason</div><div class="operator">:</div>          <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Reason</div><div class="operator">,</div>
+			<div class="ident">Resolution</div><div class="operator">:</div>      <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Resolution</div><div class="operator">,</div>
+			<div class="ident">TotalRisk</div><div class="operator">:</div>       <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">TotalRisk</div><div class="operator">,</div>
+			<div class="ident">RiskOfChange</div><div class="operator">:</div>    <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">RiskOfChange</div><div class="operator">,</div>
+			<div class="ident">RuleID</div><div class="operator">:</div>          <div class="ident">ruleID</div><div class="operator">,</div>
+			<div class="ident">TemplateData</div><div class="operator">:</div>    <div class="ident">rule</div><div class="operator">.</div><div class="ident">TemplateData</div><div class="operator">,</div>
+			<div class="ident">Tags</div><div class="operator">:</div>            <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Tags</div><div class="operator">,</div>
+			<div class="ident">UserVote</div><div class="operator">:</div>        <div class="ident">rule</div><div class="operator">.</div><div class="ident">UserVote</div><div class="operator">,</div>
+			<div class="ident">Disabled</div><div class="operator">:</div>        <div class="ident">rule</div><div class="operator">.</div><div class="ident">Disabled</div><div class="operator">,</div>
+			<div class="ident">DisableFeedback</div><div class="operator">:</div> <div class="ident">rule</div><div class="operator">.</div><div class="ident">DisableFeedback</div><div class="operator">,</div>
+			<div class="ident">DisabledAt</div><div class="operator">:</div>      <div class="ident">rule</div><div class="operator">.</div><div class="ident">DisabledAt</div><div class="operator">,</div>
+			<div class="ident">Internal</div><div class="operator">:</div>        <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Internal</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator"></div>
+
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">Equal</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">ruleWithContentResponse</div><div class="operator">,</div> <div class="ident">ruleContent</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="operator">}</div><div class="operator">,</div> <div class="ident">testTimeout</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">TestFetchRuleContent_NotOSDEligible</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">helpers</div><div class="operator">.</div><div class="ident">RunTestWithTimeout</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="keyword">func</div><div class="operator">(</div><div class="ident">t</div> <div class="ident">testing</div><div class="operator">.</div><div class="ident">TB</div><div class="operator">)</div> <div class="operator">{</div>
+		<div class="keyword">defer</div> <div class="ident">helpers</div><div class="operator">.</div><div class="ident">CleanAfterGock</div><div class="operator">(</div><div class="ident">t</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">helpers</div><div class="operator">.</div><div class="ident">GockExpectAPIRequest</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">helpers</div><div class="operator">.</div><div class="ident">DefaultServicesConfig</div><div class="operator">.</div><div class="ident">ContentBaseEndpoint</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">APIRequest</div><div class="operator">{</div>
+			<div class="ident">Method</div><div class="operator">:</div>   <div class="ident">http</div><div class="operator">.</div><div class="ident">MethodGet</div><div class="operator">,</div>
+			<div class="ident">Endpoint</div><div class="operator">:</div> <div class="ident">ics_server</div><div class="operator">.</div><div class="ident">AllContentEndpoint</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">APIResponse</div><div class="operator">{</div>
+			<div class="ident">StatusCode</div><div class="operator">:</div> <div class="ident">http</div><div class="operator">.</div><div class="ident">StatusOK</div><div class="operator">,</div>
+			<div class="ident">Body</div><div class="operator">:</div>       <div class="ident">helpers</div><div class="operator">.</div><div class="ident">MustGobSerialize</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleContentDirectory3Rules</div><div class="operator">)</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">content</div><div class="operator">.</div><div class="ident">UpdateContent</div><div class="operator">(</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">DefaultServicesConfig</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">rule</div> <div class="operator">:=</div> <div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleOnReport1</div><div class="operator"></div>
+		<div class="ident">ruleContent</div><div class="operator">,</div> <div class="ident">success</div><div class="operator">,</div> <div class="ident">osdFiltered</div> <div class="operator">:=</div> <div class="ident">content</div><div class="operator">.</div><div class="ident">FetchRuleContent</div><div class="operator">(</div><div class="ident">rule</div><div class="operator">,</div> <div class="ident">false</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">True</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div><div class="ident">success</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">False</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div><div class="ident">osdFiltered</div><div class="operator">)</div> <div class="operator"></div><div class="comment">//NotRequiredAdmin is true in Rule1</div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">NotNil</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">ruleContent</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">ruleID</div> <div class="operator">:=</div> <div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleOnReport1</div><div class="operator">.</div><div class="ident">Module</div><div class="operator"></div>
+		<div class="ident">errorKey</div> <div class="operator">:=</div> <div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleOnReport1</div><div class="operator">.</div><div class="ident">ErrorKey</div><div class="operator"></div>
+		<div class="ident">ruleWithContent</div><div class="operator">,</div> <div class="ident">_</div> <div class="operator">:=</div> <div class="ident">content</div><div class="operator">.</div><div class="ident">GetRuleWithErrorKeyContent</div><div class="operator">(</div><div class="ident">ruleID</div><div class="operator">,</div> <div class="ident">errorKey</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">ruleWithContentResponse</div> <div class="operator">:=</div> <div class="operator">&amp;</div><div class="ident">local_types</div><div class="operator">.</div><div class="ident">RuleWithContentResponse</div><div class="operator">{</div>
+			<div class="ident">CreatedAt</div><div class="operator">:</div>       <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">PublishDate</div><div class="operator">.</div><div class="ident">UTC</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Format</div><div class="operator">(</div><div class="ident">time</div><div class="operator">.</div><div class="ident">RFC3339</div><div class="operator">)</div><div class="operator">,</div>
+			<div class="ident">Description</div><div class="operator">:</div>     <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Description</div><div class="operator">,</div>
+			<div class="ident">ErrorKey</div><div class="operator">:</div>        <div class="ident">errorKey</div><div class="operator">,</div>
+			<div class="ident">Generic</div><div class="operator">:</div>         <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Generic</div><div class="operator">,</div>
+			<div class="ident">Reason</div><div class="operator">:</div>          <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Reason</div><div class="operator">,</div>
+			<div class="ident">Resolution</div><div class="operator">:</div>      <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Resolution</div><div class="operator">,</div>
+			<div class="ident">TotalRisk</div><div class="operator">:</div>       <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">TotalRisk</div><div class="operator">,</div>
+			<div class="ident">RiskOfChange</div><div class="operator">:</div>    <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">RiskOfChange</div><div class="operator">,</div>
+			<div class="ident">RuleID</div><div class="operator">:</div>          <div class="ident">ruleID</div><div class="operator">,</div>
+			<div class="ident">TemplateData</div><div class="operator">:</div>    <div class="ident">rule</div><div class="operator">.</div><div class="ident">TemplateData</div><div class="operator">,</div>
+			<div class="ident">Tags</div><div class="operator">:</div>            <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Tags</div><div class="operator">,</div>
+			<div class="ident">UserVote</div><div class="operator">:</div>        <div class="ident">rule</div><div class="operator">.</div><div class="ident">UserVote</div><div class="operator">,</div>
+			<div class="ident">Disabled</div><div class="operator">:</div>        <div class="ident">rule</div><div class="operator">.</div><div class="ident">Disabled</div><div class="operator">,</div>
+			<div class="ident">DisableFeedback</div><div class="operator">:</div> <div class="ident">rule</div><div class="operator">.</div><div class="ident">DisableFeedback</div><div class="operator">,</div>
+			<div class="ident">DisabledAt</div><div class="operator">:</div>      <div class="ident">rule</div><div class="operator">.</div><div class="ident">DisabledAt</div><div class="operator">,</div>
+			<div class="ident">Internal</div><div class="operator">:</div>        <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Internal</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator"></div>
+
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">Equal</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">ruleWithContentResponse</div><div class="operator">,</div> <div class="ident">ruleContent</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="operator">}</div><div class="operator">,</div> <div class="ident">testTimeout</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">TestFetchRuleContent_DisabledRuleExist</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">helpers</div><div class="operator">.</div><div class="ident">RunTestWithTimeout</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="keyword">func</div><div class="operator">(</div><div class="ident">t</div> <div class="ident">testing</div><div class="operator">.</div><div class="ident">TB</div><div class="operator">)</div> <div class="operator">{</div>
+		<div class="keyword">defer</div> <div class="ident">helpers</div><div class="operator">.</div><div class="ident">CleanAfterGock</div><div class="operator">(</div><div class="ident">t</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">helpers</div><div class="operator">.</div><div class="ident">GockExpectAPIRequest</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">helpers</div><div class="operator">.</div><div class="ident">DefaultServicesConfig</div><div class="operator">.</div><div class="ident">ContentBaseEndpoint</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">APIRequest</div><div class="operator">{</div>
+			<div class="ident">Method</div><div class="operator">:</div>   <div class="ident">http</div><div class="operator">.</div><div class="ident">MethodGet</div><div class="operator">,</div>
+			<div class="ident">Endpoint</div><div class="operator">:</div> <div class="ident">ics_server</div><div class="operator">.</div><div class="ident">AllContentEndpoint</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">APIResponse</div><div class="operator">{</div>
+			<div class="ident">StatusCode</div><div class="operator">:</div> <div class="ident">http</div><div class="operator">.</div><div class="ident">StatusOK</div><div class="operator">,</div>
+			<div class="ident">Body</div><div class="operator">:</div>       <div class="ident">helpers</div><div class="operator">.</div><div class="ident">MustGobSerialize</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleContentDirectory3Rules</div><div class="operator">)</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">content</div><div class="operator">.</div><div class="ident">UpdateContent</div><div class="operator">(</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">DefaultServicesConfig</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="keyword">var</div> <div class="ident">rule</div> <div class="operator">=</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">RuleOnReport</div><div class="operator">{</div>
+			<div class="ident">Module</div><div class="operator">:</div>          <div class="ident">testdata</div><div class="operator">.</div><div class="ident">Rule1</div><div class="operator">.</div><div class="ident">Module</div><div class="operator">,</div>
+			<div class="ident">ErrorKey</div><div class="operator">:</div>        <div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleErrorKey1</div><div class="operator">.</div><div class="ident">ErrorKey</div><div class="operator">,</div>
+			<div class="ident">UserVote</div><div class="operator">:</div>        <div class="ident">types</div><div class="operator">.</div><div class="ident">UserVoteNone</div><div class="operator">,</div>
+			<div class="ident">Disabled</div><div class="operator">:</div>        <div class="ident">true</div><div class="operator">,</div>
+			<div class="ident">DisableFeedback</div><div class="operator">:</div> <div class="literal">&#34;&#34;</div><div class="operator">,</div>
+			<div class="ident">DisabledAt</div><div class="operator">:</div>      <div class="literal">&#34;&#34;</div><div class="operator">,</div>
+			<div class="ident">TemplateData</div><div class="operator">:</div>    <div class="ident">testdata</div><div class="operator">.</div><div class="ident">Rule1ExtraData</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator"></div>
+
+		<div class="ident">ruleContent</div><div class="operator">,</div> <div class="ident">success</div><div class="operator">,</div> <div class="ident">osdFiltered</div> <div class="operator">:=</div> <div class="ident">content</div><div class="operator">.</div><div class="ident">FetchRuleContent</div><div class="operator">(</div><div class="ident">rule</div><div class="operator">,</div> <div class="ident">false</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">True</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div><div class="ident">success</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">False</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div><div class="ident">osdFiltered</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">NotNil</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">ruleContent</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="operator">}</div><div class="operator">,</div> <div class="ident">testTimeout</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
+
+<div class="keyword">func</div> <div class="ident">TestFetchRuleContent_RuleDoesNotExist</div><div class="operator">(</div><div class="ident">t</div> <div class="operator">*</div><div class="ident">testing</div><div class="operator">.</div><div class="ident">T</div><div class="operator">)</div> <div class="operator">{</div>
+	<div class="ident">helpers</div><div class="operator">.</div><div class="ident">RunTestWithTimeout</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="keyword">func</div><div class="operator">(</div><div class="ident">t</div> <div class="ident">testing</div><div class="operator">.</div><div class="ident">TB</div><div class="operator">)</div> <div class="operator">{</div>
+		<div class="keyword">defer</div> <div class="ident">helpers</div><div class="operator">.</div><div class="ident">CleanAfterGock</div><div class="operator">(</div><div class="ident">t</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">helpers</div><div class="operator">.</div><div class="ident">GockExpectAPIRequest</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">helpers</div><div class="operator">.</div><div class="ident">DefaultServicesConfig</div><div class="operator">.</div><div class="ident">ContentBaseEndpoint</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">APIRequest</div><div class="operator">{</div>
+			<div class="ident">Method</div><div class="operator">:</div>   <div class="ident">http</div><div class="operator">.</div><div class="ident">MethodGet</div><div class="operator">,</div>
+			<div class="ident">Endpoint</div><div class="operator">:</div> <div class="ident">ics_server</div><div class="operator">.</div><div class="ident">AllContentEndpoint</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator">,</div> <div class="operator">&amp;</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">APIResponse</div><div class="operator">{</div>
+			<div class="ident">StatusCode</div><div class="operator">:</div> <div class="ident">http</div><div class="operator">.</div><div class="ident">StatusOK</div><div class="operator">,</div>
+			<div class="ident">Body</div><div class="operator">:</div>       <div class="ident">helpers</div><div class="operator">.</div><div class="ident">MustGobSerialize</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleContentDirectory3Rules</div><div class="operator">)</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="ident">content</div><div class="operator">.</div><div class="ident">UpdateContent</div><div class="operator">(</div><div class="ident">helpers</div><div class="operator">.</div><div class="ident">DefaultServicesConfig</div><div class="operator">)</div><div class="operator"></div>
+
+		<div class="keyword">var</div> <div class="ident">rule</div> <div class="operator">=</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">RuleOnReport</div><div class="operator">{</div>
+			<div class="ident">Module</div><div class="operator">:</div>          <div class="ident">types</div><div class="operator">.</div><div class="ident">RuleID</div><div class="operator">(</div><div class="literal">&#34;ccx_rules_ocp.deprecated_a_long_time_ago_should_not_exist&#34;</div><div class="operator">)</div><div class="operator">,</div>
+			<div class="ident">ErrorKey</div><div class="operator">:</div>        <div class="ident">testdata</div><div class="operator">.</div><div class="ident">RuleErrorKey1</div><div class="operator">.</div><div class="ident">ErrorKey</div><div class="operator">,</div>
+			<div class="ident">UserVote</div><div class="operator">:</div>        <div class="ident">types</div><div class="operator">.</div><div class="ident">UserVoteNone</div><div class="operator">,</div>
+			<div class="ident">Disabled</div><div class="operator">:</div>        <div class="ident">false</div><div class="operator">,</div>
+			<div class="ident">DisableFeedback</div><div class="operator">:</div> <div class="literal">&#34;&#34;</div><div class="operator">,</div>
+			<div class="ident">DisabledAt</div><div class="operator">:</div>      <div class="literal">&#34;&#34;</div><div class="operator">,</div>
+			<div class="ident">TemplateData</div><div class="operator">:</div>    <div class="ident">nil</div><div class="operator">,</div>
+		<div class="operator">}</div><div class="operator"></div>
+
+		<div class="ident">ruleContent</div><div class="operator">,</div> <div class="ident">success</div><div class="operator">,</div> <div class="ident">_</div> <div class="operator">:=</div> <div class="ident">content</div><div class="operator">.</div><div class="ident">FetchRuleContent</div><div class="operator">(</div><div class="ident">rule</div><div class="operator">,</div> <div class="ident">false</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">False</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div><div class="ident">success</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">assert</div><div class="operator">.</div><div class="ident">Nil</div><div class="operator">(</div><div class="ident">t</div><div class="operator">,</div> <div class="ident">ruleContent</div><div class="operator">)</div><div class="operator"></div>
+
+	<div class="operator">}</div><div class="operator">,</div> <div class="ident">testTimeout</div><div class="operator">)</div><div class="operator"></div>
+<div class="operator">}</div><div class="operator"></div>
 </code></pre></td>
       </tr>
       

--- a/docs/packages/server/endpoints.html
+++ b/docs/packages/server/endpoints.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- Copyright 2020 Red Hat, Inc
+ Copyright 2021 Red Hat, Inc
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/docs/packages/server/handlers.html
+++ b/docs/packages/server/handlers.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- Copyright 2020 Red Hat, Inc
+ Copyright 2021 Red Hat, Inc
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/docs/packages/server/server.html
+++ b/docs/packages/server/server.html
@@ -155,8 +155,6 @@ between server and clients.</p>
 	<div class="literal">&#34;net/url&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;strconv&#34;</div><div class="operator"></div>
 	<div class="literal">&#34;strings&#34;</div><div class="operator"></div>
-	<div class="literal">&#34;time&#34;</div><div class="operator"></div>
-
 </code></pre></td>
       </tr>
       
@@ -756,63 +754,6 @@ Returns report and bool value set to true if there was no errors</p>
 	<div class="keyword">return</div> <div class="ident">aggregatorResponse</div><div class="operator">.</div><div class="ident">Report</div><div class="operator">,</div> <div class="ident">true</div><div class="operator"></div>
 <div class="operator">}</div><div class="operator"></div>
 
-</code></pre></td>
-      </tr>
-      
-      <tr class="section">
-	<td class="doc"><p>fetchRuleContent - fetching content for particular rule
-Return values:
-  - Structure with rules and content
-  - return true if fetching content was successful, including filtering
-  - return true if the rule has been filtered by OSDElegible field. False otherwise</p>
-</td>
-	<td class="code"><pre><code><div class="keyword">func</div> <div class="operator">(</div><div class="ident">server</div> <div class="ident">HTTPServer</div><div class="operator">)</div> <div class="ident">fetchRuleContent</div><div class="operator">(</div><div class="ident">rule</div> <div class="ident">types</div><div class="operator">.</div><div class="ident">RuleOnReport</div><div class="operator">,</div> <div class="ident">OSDEligible</div> <div class="ident">bool</div><div class="operator">)</div> <div class="operator">(</div>
-	<div class="ident">ruleWithContentResponse</div> <div class="operator">*</div><div class="ident">proxy_types</div><div class="operator">.</div><div class="ident">RuleWithContentResponse</div><div class="operator">,</div>
-	<div class="ident">success</div> <div class="ident">bool</div><div class="operator">,</div>
-	<div class="ident">osdFiltered</div> <div class="ident">bool</div><div class="operator">,</div>
-<div class="operator">)</div> <div class="operator">{</div>
-	<div class="ident">ruleID</div> <div class="operator">:=</div> <div class="ident">rule</div><div class="operator">.</div><div class="ident">Module</div><div class="operator"></div>
-	<div class="ident">errorKey</div> <div class="operator">:=</div> <div class="ident">rule</div><div class="operator">.</div><div class="ident">ErrorKey</div><div class="operator"></div>
-
-	<div class="ident">ruleWithContentResponse</div> <div class="operator">=</div> <div class="ident">nil</div><div class="operator"></div>
-	<div class="ident">success</div> <div class="operator">=</div> <div class="ident">false</div><div class="operator"></div>
-	<div class="ident">osdFiltered</div> <div class="operator">=</div> <div class="ident">false</div><div class="operator"></div>
-
-	<div class="ident">ruleWithContent</div><div class="operator">,</div> <div class="ident">err</div> <div class="operator">:=</div> <div class="ident">content</div><div class="operator">.</div><div class="ident">GetRuleWithErrorKeyContent</div><div class="operator">(</div><div class="ident">ruleID</div><div class="operator">,</div> <div class="ident">errorKey</div><div class="operator">)</div><div class="operator"></div>
-	<div class="keyword">if</div> <div class="ident">err</div> <div class="operator">!=</div> <div class="ident">nil</div> <div class="operator">{</div>
-		<div class="ident">log</div><div class="operator">.</div><div class="ident">Error</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Err</div><div class="operator">(</div><div class="ident">err</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Msgf</div><div class="operator">(</div>
-			<div class="literal">&#34;unable to get content for rule with id %v and error key %v&#34;</div><div class="operator">,</div> <div class="ident">ruleID</div><div class="operator">,</div> <div class="ident">errorKey</div><div class="operator">,</div>
-		<div class="operator">)</div><div class="operator"></div>
-		<div class="keyword">return</div><div class="operator"></div>
-	<div class="operator">}</div><div class="operator"></div>
-
-	<div class="keyword">if</div> <div class="ident">OSDEligible</div> <div class="operator">&amp;&amp;</div> <div class="operator">!</div><div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">NotRequireAdmin</div> <div class="operator">{</div>
-		<div class="ident">osdFiltered</div> <div class="operator">=</div> <div class="ident">true</div><div class="operator"></div>
-		<div class="keyword">return</div><div class="operator"></div>
-	<div class="operator">}</div><div class="operator"></div>
-
-	<div class="ident">ruleWithContentResponse</div> <div class="operator">=</div> <div class="operator">&amp;</div><div class="ident">proxy_types</div><div class="operator">.</div><div class="ident">RuleWithContentResponse</div><div class="operator">{</div>
-		<div class="ident">CreatedAt</div><div class="operator">:</div>       <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">PublishDate</div><div class="operator">.</div><div class="ident">UTC</div><div class="operator">(</div><div class="operator">)</div><div class="operator">.</div><div class="ident">Format</div><div class="operator">(</div><div class="ident">time</div><div class="operator">.</div><div class="ident">RFC3339</div><div class="operator">)</div><div class="operator">,</div>
-		<div class="ident">Description</div><div class="operator">:</div>     <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Description</div><div class="operator">,</div>
-		<div class="ident">ErrorKey</div><div class="operator">:</div>        <div class="ident">errorKey</div><div class="operator">,</div>
-		<div class="ident">Generic</div><div class="operator">:</div>         <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Generic</div><div class="operator">,</div>
-		<div class="ident">Reason</div><div class="operator">:</div>          <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Reason</div><div class="operator">,</div>
-		<div class="ident">Resolution</div><div class="operator">:</div>      <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Resolution</div><div class="operator">,</div>
-		<div class="ident">TotalRisk</div><div class="operator">:</div>       <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">TotalRisk</div><div class="operator">,</div>
-		<div class="ident">RiskOfChange</div><div class="operator">:</div>    <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">RiskOfChange</div><div class="operator">,</div>
-		<div class="ident">RuleID</div><div class="operator">:</div>          <div class="ident">ruleID</div><div class="operator">,</div>
-		<div class="ident">TemplateData</div><div class="operator">:</div>    <div class="ident">rule</div><div class="operator">.</div><div class="ident">TemplateData</div><div class="operator">,</div>
-		<div class="ident">Tags</div><div class="operator">:</div>            <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Tags</div><div class="operator">,</div>
-		<div class="ident">UserVote</div><div class="operator">:</div>        <div class="ident">rule</div><div class="operator">.</div><div class="ident">UserVote</div><div class="operator">,</div>
-		<div class="ident">Disabled</div><div class="operator">:</div>        <div class="ident">rule</div><div class="operator">.</div><div class="ident">Disabled</div><div class="operator">,</div>
-		<div class="ident">DisableFeedback</div><div class="operator">:</div> <div class="ident">rule</div><div class="operator">.</div><div class="ident">DisableFeedback</div><div class="operator">,</div>
-		<div class="ident">DisabledAt</div><div class="operator">:</div>      <div class="ident">rule</div><div class="operator">.</div><div class="ident">DisabledAt</div><div class="operator">,</div>
-		<div class="ident">Internal</div><div class="operator">:</div>        <div class="ident">ruleWithContent</div><div class="operator">.</div><div class="ident">Internal</div><div class="operator">,</div>
-	<div class="operator">}</div><div class="operator"></div>
-	<div class="ident">success</div> <div class="operator">=</div> <div class="ident">true</div><div class="operator"></div>
-	<div class="keyword">return</div><div class="operator"></div>
-<div class="operator">}</div><div class="operator"></div>
-
 <div class="keyword">func</div> <div class="operator">(</div><div class="ident">server</div> <div class="ident">HTTPServer</div><div class="operator">)</div> <div class="ident">fetchAggregatorReport</div><div class="operator">(</div>
 	<div class="ident">writer</div> <div class="ident">http</div><div class="operator">.</div><div class="ident">ResponseWriter</div><div class="operator">,</div> <div class="ident">request</div> <div class="operator">*</div><div class="ident">http</div><div class="operator">.</div><div class="ident">Request</div><div class="operator">,</div>
 <div class="operator">)</div> <div class="operator">(</div><div class="operator">*</div><div class="ident">types</div><div class="operator">.</div><div class="ident">ReportResponse</div><div class="operator">,</div> <div class="ident">bool</div><div class="operator">)</div> <div class="operator">{</div>
@@ -951,7 +892,7 @@ response structure is constructed from data returned by Aggregator.</p>
 	<div class="ident">rules</div> <div class="operator">:=</div> <div class="operator">[</div><div class="operator">]</div><div class="ident">proxy_types</div><div class="operator">.</div><div class="ident">RuleWithContentResponse</div><div class="operator">{</div><div class="operator">}</div><div class="operator"></div>
 	<div class="ident">rulesWithoutContent</div> <div class="operator">:=</div> <div class="literal">0</div><div class="operator"></div>
 	<div class="keyword">for</div> <div class="ident">_</div><div class="operator">,</div> <div class="ident">aggregatorRule</div> <div class="operator">:=</div> <div class="keyword">range</div> <div class="ident">aggregatorResponse</div><div class="operator">.</div><div class="ident">Report</div> <div class="operator">{</div>
-		<div class="ident">rule</div><div class="operator">,</div> <div class="ident">successful</div><div class="operator">,</div> <div class="ident">filtered</div> <div class="operator">:=</div> <div class="ident">server</div><div class="operator">.</div><div class="ident">fetchRuleContent</div><div class="operator">(</div><div class="ident">aggregatorRule</div><div class="operator">,</div> <div class="ident">server</div><div class="operator">.</div><div class="ident">getOSDFlag</div><div class="operator">(</div><div class="ident">request</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+		<div class="ident">rule</div><div class="operator">,</div> <div class="ident">successful</div><div class="operator">,</div> <div class="ident">filtered</div> <div class="operator">:=</div> <div class="ident">content</div><div class="operator">.</div><div class="ident">FetchRuleContent</div><div class="operator">(</div><div class="ident">aggregatorRule</div><div class="operator">,</div> <div class="ident">server</div><div class="operator">.</div><div class="ident">getOSDFlag</div><div class="operator">(</div><div class="ident">request</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
 
 		<div class="keyword">if</div> <div class="operator">!</div><div class="ident">successful</div> <div class="operator">{</div>
 			<div class="keyword">if</div> <div class="operator">!</div><div class="ident">filtered</div> <div class="operator">{</div>
@@ -1097,7 +1038,7 @@ clients can use as many cluster ID as the wont without any (real) limits.</p>
 		<div class="keyword">return</div><div class="operator"></div>
 	<div class="operator">}</div><div class="operator"></div>
 
-	<div class="ident">rule</div><div class="operator">,</div> <div class="ident">successful</div><div class="operator">,</div> <div class="ident">_</div> <div class="operator">=</div> <div class="ident">server</div><div class="operator">.</div><div class="ident">fetchRuleContent</div><div class="operator">(</div><div class="operator">*</div><div class="ident">aggregatorResponse</div><div class="operator">,</div> <div class="ident">server</div><div class="operator">.</div><div class="ident">getOSDFlag</div><div class="operator">(</div><div class="ident">request</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
+	<div class="ident">rule</div><div class="operator">,</div> <div class="ident">successful</div><div class="operator">,</div> <div class="ident">_</div> <div class="operator">=</div> <div class="ident">content</div><div class="operator">.</div><div class="ident">FetchRuleContent</div><div class="operator">(</div><div class="operator">*</div><div class="ident">aggregatorResponse</div><div class="operator">,</div> <div class="ident">server</div><div class="operator">.</div><div class="ident">getOSDFlag</div><div class="operator">(</div><div class="ident">request</div><div class="operator">)</div><div class="operator">)</div><div class="operator"></div>
 
 	<div class="keyword">if</div> <div class="operator">!</div><div class="ident">successful</div> <div class="operator">{</div>
 		<div class="ident">err</div> <div class="operator">:=</div> <div class="ident">responses</div><div class="operator">.</div><div class="ident">SendNotFound</div><div class="operator">(</div><div class="ident">writer</div><div class="operator">,</div> <div class="literal">&#34;Rule was not found&#34;</div><div class="operator">)</div><div class="operator"></div>

--- a/docs/packages/smart_proxy.html
+++ b/docs/packages/smart_proxy.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- Copyright 2020 Red Hat, Inc
+ Copyright 2021 Red Hat, Inc
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/docs/packages/smart_proxy_test.html
+++ b/docs/packages/smart_proxy_test.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
- Copyright 2020 Red Hat, Inc
+ Copyright 2021 Red Hat, Inc
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Description

fetchRuleContent shouldn't be in the server module. This commit moves it to content module, and adds some unit tests for it.

Fixes #361 

## Type of change

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)
- Documentation update

## Testing steps

new UTs; make test; make before_commit

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
