### PR TITLE
[CCXDEV-4468] openapi fix likelihood data type

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -484,7 +484,7 @@
                                     "type": "string"
                                   },
                                   "likelihood": {
-                                    "type": "number"
+                                    "type": "integer"
                                   },
                                   "publish_date": {
                                     "type": "string"
@@ -612,7 +612,7 @@
                                       "type": "string"
                                     },
                                     "likelihood": {
-                                      "type": "number"
+                                      "type": "integer"
                                     },
                                     "publish_date": {
                                       "type": "string"

--- a/openapi_dev.json
+++ b/openapi_dev.json
@@ -978,7 +978,7 @@
                                     "type": "string"
                                   },
                                   "likelihood": {
-                                    "type": "number"
+                                    "type": "integer"
                                   },
                                   "publish_date": {
                                     "type": "string"
@@ -1107,7 +1107,7 @@
                                       "type": "string"
                                     },
                                     "likelihood": {
-                                      "type": "number"
+                                      "type": "integer"
                                     },
                                     "publish_date": {
                                       "type": "string"


### PR DESCRIPTION
# Description

'likelihood' in openapi.json is of a type 'integer' not 'number' (float or double).

Fixes CCXDEV-4468

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
