### PR TITLE
Wait for goroutine with content-servicing code to finished in deref

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -211,7 +211,7 @@ func RunUpdateContentLoop(servicesConf services.Configuration) {
 	ticker := time.NewTicker(servicesConf.GroupsPollingTime)
 
 	for {
-		updateContent(servicesConf)
+		UpdateContent(servicesConf)
 
 		select {
 		case <-ticker.C:
@@ -226,7 +226,8 @@ func StopUpdateContentLoop() {
 	stopUpdateContentLoop <- struct{}{}
 }
 
-func updateContent(servicesConf services.Configuration) {
+// UpdateContent function updates rule content
+func UpdateContent(servicesConf services.Configuration) {
 	var err error
 
 	contentServiceDirectory, err := services.GetContent(servicesConf)

--- a/content/export_test.go
+++ b/content/export_test.go
@@ -25,6 +25,5 @@ package content
 // to see why this trick is needed for using package internal
 // symbols (externally invisible) in unit tests.
 var (
-	UpdateContent             = updateContent
 	RuleContentDirectoryReady = ruleContentDirectoryReady
 )

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -43,13 +43,19 @@ var (
 )
 
 func startUpdateContentLoop(servicesConf services.Configuration) {
-	// synchronized first update!
-	content.UpdateContent(servicesConf)
 	go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
+}
+
+// timeToBreathe make sure the content-servicing goroutine is cleaned up (it
+// would be better to use some form of better synchronization, but it will need
+// code change just for the sake of unit tests).
+func timeToBreathe() {
+	time.Sleep(2 * time.Second)
 }
 
 // TODO: test more cases for report endpoint
 func TestHTTPServer_ReportEndpoint(t *testing.T) {
+	timeToBreathe()
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
@@ -86,7 +92,7 @@ func TestHTTPServer_ReportEndpoint(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
-	time.Sleep(1 * time.Second)
+	timeToBreathe()
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -125,7 +131,7 @@ func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpoint_WithOnlyOSDEndpoint(t *testing.T) {
-	time.Sleep(1 * time.Second)
+	timeToBreathe()
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -163,7 +169,7 @@ func TestHTTPServer_ReportEndpoint_WithOnlyOSDEndpoint(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpoint_WithDisabledRules(t *testing.T) {
-	time.Sleep(1 * time.Second)
+	timeToBreathe()
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -245,8 +251,8 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRules(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpoint_WithDisabledRulesAndMissingContent(t *testing.T) {
+	timeToBreathe()
 	content.ResetContent()
-	time.Sleep(1 * time.Second)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -285,7 +291,7 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRulesAndMissingContent(t *testing
 
 // TODO: test more cases for rule endpoint
 func TestHTTPServer_RuleEndpoint(t *testing.T) {
-	time.Sleep(1 * time.Second)
+	timeToBreathe()
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -328,7 +334,7 @@ func TestHTTPServer_RuleEndpoint(t *testing.T) {
 }
 
 func TestHTTPServer_RuleEndpoint_WithOSD(t *testing.T) {
-	time.Sleep(1 * time.Second)
+	timeToBreathe()
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -371,7 +377,7 @@ func TestHTTPServer_RuleEndpoint_WithOSD(t *testing.T) {
 }
 
 func TestHTTPServer_RuleEndpoint_WithNotOSDRule(t *testing.T) {
-	time.Sleep(1 * time.Second)
+	timeToBreathe()
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -415,6 +421,7 @@ func TestHTTPServer_RuleEndpoint_WithNotOSDRule(t *testing.T) {
 
 // TestHTTPServer_GetContent
 func TestHTTPServer_GetContent(t *testing.T) {
+	timeToBreathe()
 	content.ResetContent()
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
@@ -444,7 +451,7 @@ func TestHTTPServer_GetContent(t *testing.T) {
 
 // TestHTTPServer_OverviewEndpoint
 func TestHTTPServer_OverviewEndpoint(t *testing.T) {
-	time.Sleep(1 * time.Second)
+	timeToBreathe()
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -27,6 +27,7 @@ import (
 	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
+	"github.com/RedHatInsights/insights-results-smart-proxy/services"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
 )
 

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -44,7 +44,7 @@ var (
 
 func startUpdateContentLoop(servicesConf services.Configuration) {
 	// synchronized first update!
-	UpdateContent(servicesConf)
+	content.UpdateContent(servicesConf)
 	go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
 }
 

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -41,6 +41,12 @@ var (
 	}
 )
 
+func startUpdateContentLoop(servicesConf services.Configuration) {
+	// synchronized first update!
+	UpdateContent(servicesConf)
+	go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
+}
+
 // TODO: test more cases for report endpoint
 func TestHTTPServer_ReportEndpoint(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
@@ -62,7 +68,7 @@ func TestHTTPServer_ReportEndpoint(t *testing.T) {
 			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
 		})
 
-		go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
+		startUpdateContentLoop(helpers.DefaultServicesConfig)
 		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
@@ -101,7 +107,7 @@ func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
 			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
 		})
 
-		go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
+		startUpdateContentLoop(helpers.DefaultServicesConfig)
 		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
@@ -139,7 +145,7 @@ func TestHTTPServer_ReportEndpoint_WithOnlyOSDEndpoint(t *testing.T) {
 			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
 		})
 
-		go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
+		startUpdateContentLoop(helpers.DefaultServicesConfig)
 		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
@@ -197,7 +203,7 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRules(t *testing.T) {
 			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory5Rules),
 		})
 
-		go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
+		startUpdateContentLoop(helpers.DefaultServicesConfig)
 		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
@@ -260,7 +266,7 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRulesAndMissingContent(t *testing
 			Body:       helpers.MustGobSerialize(t, RuleContentDirectoryOnly1Rule),
 		})
 
-		go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
+		startUpdateContentLoop(helpers.DefaultServicesConfig)
 		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
@@ -304,7 +310,7 @@ func TestHTTPServer_RuleEndpoint(t *testing.T) {
 			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
 		})
 
-		go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
+		startUpdateContentLoop(helpers.DefaultServicesConfig)
 		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
@@ -347,7 +353,7 @@ func TestHTTPServer_RuleEndpoint_WithOSD(t *testing.T) {
 			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
 		})
 
-		go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
+		startUpdateContentLoop(helpers.DefaultServicesConfig)
 		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
@@ -390,7 +396,7 @@ func TestHTTPServer_RuleEndpoint_WithNotOSDRule(t *testing.T) {
 			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
 		})
 
-		go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
+		startUpdateContentLoop(helpers.DefaultServicesConfig)
 		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
@@ -420,7 +426,7 @@ func TestHTTPServer_GetContent(t *testing.T) {
 			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
 		})
 
-		go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
+		startUpdateContentLoop(helpers.DefaultServicesConfig)
 		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
@@ -470,7 +476,7 @@ func TestHTTPServer_OverviewEndpoint(t *testing.T) {
 			Body:       testdata.Report3RulesExpectedResponse,
 		})
 
-		go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
+		startUpdateContentLoop(helpers.DefaultServicesConfig)
 		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{


### PR DESCRIPTION
# Description

Update rule content synchronously

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Done on CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
