### PR TITLE
[CCXDEV-4859] Fix some types in openapi.json

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -1064,22 +1064,22 @@
           "total_risk": {
             "description": "Total risk - calculated from rule impact and likelihood.",
             "enum": [
-              "0",
-              "1",
-              "2",
-              "3",
-              "4"
+              0,
+              1,
+              2,
+              3,
+              4
             ],
             "type": "integer"
           },
           "risk_of_change": {
             "description": "Risk of change - values paired with corresponding UI elements. 0 returned when not defined, therefore to hide the UI.",
             "enum": [
-              "0",
-              "1",
-              "2",
-              "3",
-              "4"
+              0,
+              1,
+              2,
+              3,
+              4
             ],
             "type": "integer"
           },

--- a/openapi.json
+++ b/openapi.json
@@ -1070,7 +1070,7 @@
               "3",
               "4"
             ],
-            "type": "string"
+            "type": "integer"
           },
           "risk_of_change": {
             "description": "Risk of change - values paired with corresponding UI elements. 0 returned when not defined, therefore to hide the UI.",
@@ -1081,7 +1081,7 @@
               "3",
               "4"
             ],
-            "type": "string"
+            "type": "integer"
           },
           "disabled": {
             "description": "If this rule result disabled or not. This field can be used in the UI to show only specific set of rules results.",


### PR DESCRIPTION
# Description

Fixed discrepancy in data types for `total_risk` and `risk_of_change` in openapi.json.

Fixes # (issue)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
