### PR TITLE
add clowder app manifest

### DIFF
--- a/bonfire-config-devel.yaml
+++ b/bonfire-config-devel.yaml
@@ -1,0 +1,68 @@
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+     
+
+# Bonfire deployment configuration
+# Defines where to fetch the file that defines application configs
+
+appsFile:
+  host: gitlab
+  repo: insights-platform/cicd-common
+  path: bonfire_configs/ephemeral_apps.yaml
+
+apps:
+- name: ccx-data-pipeline
+  components:
+    - name: ccx-data-pipeline
+      host: gitlab
+      repo: ccx/ccx-data-pipeline
+      path: deploy/clowdapp.yaml
+      ref: master
+      parameters:
+        CLOWDER_ENABLED: "true"
+        IMAGE_TAG: qa
+    - name: insights-results-db
+      host: github
+      repo: RedHatInsights/insights-results-aggregator
+      path: deploy/irdb_clowdapp.yaml
+      ref: master
+      parameters:
+        CLOWDER_ENABLED: "true"
+        IMAGE_TAG: qa
+    - name: insights-results
+      host: github
+      repo: RedHatInsights/insights-results-aggregator
+      path: deploy/clowdapp.yaml
+      ref: master
+      parameters:
+        CLOWDER_ENABLED: "true"
+        IMAGE_TAG: qa
+    - name: ccx-smart-proxy
+      host: github
+      repo: <user>/insights-results-smart-proxy
+      path: deploy/clowdapp.yaml
+      ref: <branch>
+      parameters:
+        CLOWDER_ENABLED: "true"
+        IMAGE_TAG: <image tag>
+        IMAGE: quay.io/<user>/insights-results-smart-proxy
+    - name: insights-content-service
+      host: github
+      repo: RedHatInsights/insights-content-service
+      path: deploy/clowdapp.yaml
+      ref: <branch>
+      parameters:
+        CLOWDER_ENABLED: "true"
+        IMAGE_TAG: qa

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -84,21 +84,6 @@ var Config struct {
 	KafkaZerologConf  logger.KafkaZerologConfiguration  `mapstructure:"kafka_zerolog" toml:"kafka_zerolog"`
 }
 
-func setupClowderConfiguration(config *clowder.AppConfig) error {
-	// TODO: insert logic to replace SELECTED configuration variables
-	return nil
-}
-
-func envSupportsClowder() bool {
-	clowderEnabled := os.Getenv("CLOWDER_ENABLED")
-	if clowderEnabled == "True" ||
-		clowderEnabled == "true" ||
-		clowderEnabled == "1" ||
-		clowderEnabled == "yes" {
-		return true
-	}
-	return false
-}
 // LoadConfiguration loads configuration from defaultConfigFile, file set in
 // configFileEnvVariableName or from env
 func LoadConfiguration(defaultConfigFile string) error {
@@ -150,9 +135,8 @@ func LoadConfiguration(defaultConfigFile string) error {
 		return fmt.Errorf("fatal error config file: %s", err)
 	}
 
-	if clowder.IsClowderEnabled() && envSupportsClowder() {
+	if clowder.IsClowderEnabled() {
 		fmt.Println("Clowder is enabled")
-		return setupClowderConfiguration(clowder.LoadedConfig)
 	} else {
 		fmt.Println("Clowder is disabled")
 	}
@@ -213,7 +197,7 @@ func GetKafkaZerologConfiguration() logger.KafkaZerologConfiguration {
 // otherwise it returns corresponding error
 func checkIfFileExists(path string) error {
 	if len(path) == 0 {
-		return fmt.Errorf("Empty path provided")
+		return fmt.Errorf("empty path provided")
 	}
 	fileInfo, err := os.Stat(path)
 	if os.IsNotExist(err) {

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -84,11 +84,21 @@ var Config struct {
 	KafkaZerologConf  logger.KafkaZerologConfiguration  `mapstructure:"kafka_zerolog" toml:"kafka_zerolog"`
 }
 
-func setupClowderConfiguration(config *clowder.AppConfig) error{
+func setupClowderConfiguration(config *clowder.AppConfig) error {
 	// TODO: insert logic to replace SELECTED configuration variables
 	return nil
 }
 
+func envSupportsClowder() bool {
+	clowderEnabled := os.Getenv("CLOWDER_ENABLED")
+	if clowderEnabled == "True" ||
+		clowderEnabled == "true" ||
+		clowderEnabled == "1" ||
+		clowderEnabled == "yes" {
+		return true
+	}
+	return false
+}
 // LoadConfiguration loads configuration from defaultConfigFile, file set in
 // configFileEnvVariableName or from env
 func LoadConfiguration(defaultConfigFile string) error {
@@ -140,7 +150,7 @@ func LoadConfiguration(defaultConfigFile string) error {
 		return fmt.Errorf("fatal error config file: %s", err)
 	}
 
-	if clowder.IsClowderEnabled() {
+	if clowder.IsClowderEnabled() && envSupportsClowder() {
 		fmt.Println("Clowder is enabled")
 		return setupClowderConfiguration(clowder.LoadedConfig)
 	} else {

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -202,14 +202,25 @@ func TestLoadConfigurationFromEnv(t *testing.T) {
 }
 
 
-// TestLoadConfigurationFromEnvVariableClowderEnabled tests loading the config.
-// file for testing from an environment variable. Clowder config is enabled in
-// this case.
-func TestLoadConfigurationFromEnvVariableClowderEnabled(t *testing.T) {
+// TestLoadConfigurationFromEnvVariableClowderEnabledNotSupported tests loading.
+// the config file for testing from an environment variable. Clowder config is
+// available but clowder is not supported in this environment.
+func TestLoadConfigurationFromEnvVariableClowderEnabledNotSupported(t *testing.T) {
 	os.Clearenv()
 
 	mustSetEnv(t, "CCX_NOTIFICATION_SERVICE_CONFIG_FILE", "tests/config1")
 	mustSetEnv(t, "ACG_CONFIG", "tests/clowder_config.json")
+	mustLoadConfiguration("CCX_NOTIFICATION_SERVICE_CONFIG_FILE")
+}
+
+// TestLoadConfigurationFromEnvVariableClowderEnabledNotSupported tests loading.
+// the config file for testing from an environment variable. Clowder config is
+// available and clowder is supported in this environment.
+func TestLoadConfigurationFromEnvVariableClowderEnabledAndSupported(t *testing.T) {
+	os.Clearenv()
+	mustSetEnv(t, "CCX_NOTIFICATION_SERVICE_CONFIG_FILE", "tests/config1")
+	mustSetEnv(t, "ACG_CONFIG", "tests/clowder_config.json")
+	mustSetEnv(t, "CLOWDER_ENABLED", "true")
 	mustLoadConfiguration("CCX_NOTIFICATION_SERVICE_CONFIG_FILE")
 }
 

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -201,7 +201,6 @@ func TestLoadConfigurationFromEnv(t *testing.T) {
 	}, conf.GetServicesConfiguration())
 }
 
-
 // TestLoadConfigurationFromEnvVariableClowderEnabledNotSupported tests loading.
 // the config file for testing from an environment variable. Clowder config is
 // available but clowder is not supported in this environment.

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -201,6 +201,18 @@ func TestLoadConfigurationFromEnv(t *testing.T) {
 	}, conf.GetServicesConfiguration())
 }
 
+
+// TestLoadConfigurationFromEnvVariableClowderEnabled tests loading the config.
+// file for testing from an environment variable. Clowder config is enabled in
+// this case.
+func TestLoadConfigurationFromEnvVariableClowderEnabled(t *testing.T) {
+	os.Clearenv()
+
+	mustSetEnv(t, "CCX_NOTIFICATION_SERVICE_CONFIG_FILE", "tests/config1")
+	mustSetEnv(t, "ACG_CONFIG", "tests/clowder_config.json")
+	mustLoadConfiguration("CCX_NOTIFICATION_SERVICE_CONFIG_FILE")
+}
+
 func setEnvVariables(t *testing.T) {
 	os.Clearenv()
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1,3 +1,17 @@
+# Copyright 2021 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 ---
 apiVersion: v1
 kind: Template

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -28,6 +28,8 @@ objects:
     envName: ${ENV_NAME}
     dependencies:
       - ingress
+      - insights-results
+      - insights-content-service
     deployments:
       - name: smart-proxy
         minReplicas: ${{MIN_REPLICAS}}
@@ -80,26 +82,6 @@ objects:
               value: ${HABERDASHER_LABELS}
             - name: HABERDASHER_TAGS
               value: ${HABERDASHER_TAGS}
-            - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__LOG_GROUP
-              valueFrom:
-                secretKeyRef:
-                  key: log_group_name
-                  name: cloudwatch
-            - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__AWS_REGION
-              valueFrom:
-                secretKeyRef:
-                  key: aws_region
-                  name: cloudwatch
-            - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__AWS_ACCESS_ID
-              valueFrom:
-                secretKeyRef:
-                  key: aws_access_key_id
-                  name: cloudwatch
-            - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__AWS_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  key: aws_secret_access_key
-                  name: cloudwatch
           image: ${IMAGE}:${IMAGE_TAG}
           resources:
             requests:
@@ -126,10 +108,19 @@ parameters:
   value: '1'
 - description: Minimum number of pods to use when autoscaling is enabled
   name: MAX_REPLICAS
-  value: '16'
-- name: PAYLOAD_TRACKER_TOPIC
-  description: Kafka topic for publishing updated for the Payload Tracker service
-  value: platform.payload-status
+  value: '1'
+- name: DEBUG
+  value: "true"
+- name: AUTH
+  value: "true"
+- name: IRSP_ENABLE_INTERNAL_ORGANIZATIONS
+  value: "false"
+- name: INSIGHTS_RESULTS_AGGREGATOR_SERVICE_URL
+  value: "http://insights-results-aggregator:8080/api/v1/"
+- name: INSIGHTS_CONTENT_SERVICE_URL
+  value: "http://ccx-insights-content-service:8080/api/v1/"
+- name: INSIGHTS_CONTENT_SERVICE_POLL_TIME
+  value: "60s"
 - name: HABERDASHER_EMITTER
   description: Emitter for haberdasher logs [stderr|kafka]
   value: stderr
@@ -139,7 +130,22 @@ parameters:
 - name: HABERDASHER_KAFKA_TOPIC
   description: Kafka topic for haberdasher kafka emitter
   value: "platform.logging.logs"
-- name: DEBUG
-  value: "true"
-- name: AUTH
+- name: HABERDASHER_TAGS
+  description: Haberdasher tags for unstructured logs
+  value: '["ccx"]'
+- name: HABERDASHER_LABELS
+  description: Haberdasher labels for unstructured logs
+  value: '{"app": "ccx-smart-proxy"}'
+- name: IRSP_API_PREFIX
+  required: true
+  value: /api/insights-results-aggregator/v1/
+- name: LOGGING_TO_CLOUD_WATCH_ENABLED
   value: "false"
+  required: true
+- name: CLOUDWATCH_DEBUG
+  value: "false"
+  required: true
+- name: IRSP_LOG_STREAM
+  value: $HOSTNAME
+- name: CREATE_STREAM_IF_NOT_EXISTS
+  value: "true"

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -123,7 +123,7 @@ parameters:
   required: true
 - description: Minimum number of pods to use when autoscaling is enabled
   name: MIN_REPLICAS
-  value: '2'
+  value: '1'
 - description: Minimum number of pods to use when autoscaling is enabled
   name: MAX_REPLICAS
   value: '16'

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -1,0 +1,145 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: ccx-smart-proxy
+objects:
+
+- kind: HorizontalPodAutoscaler
+  apiVersion: autoscaling/v1
+  metadata:
+    labels:
+      app: ccx-smart-proxy
+    name: ccx-smart-proxy
+  spec:
+    minReplicas: ${{MIN_REPLICAS}}
+    maxReplicas: ${{MAX_REPLICAS}}
+    scaleTargetRef:
+      apiVersion: v1
+      kind: Deployment
+      name: ccx-smart-proxy
+    targetCPUUtilizationPercentage: 80
+
+- apiVersion: cloud.redhat.com/v1alpha1
+  kind: ClowdApp
+  metadata:
+    name: ccx-smart-proxy
+  spec:
+    envName: ${ENV_NAME}
+    dependencies:
+      - ingress
+    deployments:
+      - name: smart-proxy
+        minReplicas: ${{MIN_REPLICAS}}
+        webServices:
+          public:
+            enabled: false
+          private:
+            enabled: false
+          metrics:
+            enabled: true
+        podSpec:
+          env:
+            - name: INSIGHTS_RESULTS_SMART_PROXY__SERVER__ADDRESS
+              value: ":8080"
+            - name: INSIGHTS_RESULTS_SMART_PROXY__SERVER__API_PREFIX
+              value: "${IRSP_API_PREFIX}"
+            - name: INSIGHTS_RESULTS_SMART_PROXY__SERVER__API_SPEC_FILE
+              value: "/openapi/openapi.json"
+            - name: INSIGHTS_RESULTS_SMART_PROXY__SERVER__DEBUG
+              value: "${DEBUG}"
+            - name: INSIGHTS_RESULTS_SMART_PROXY__SERVER__AUTH
+              value: "${AUTH}"
+            - name: INSIGHTS_RESULTS_SMART_PROXY__SERVER__AUTH_TYPE
+              value: "xrh"
+            - name: INSIGHTS_RESULTS_SMART_PROXY__SERVER__ENABLE_INTERNAL_RULES_ORGANIZATIONS
+              value: "${IRSP_ENABLE_INTERNAL_ORGANIZATIONS}"
+            - name: INSIGHTS_RESULTS_SMART_PROXY__SERVICES__AGGREGATOR
+              value: ${INSIGHTS_RESULTS_AGGREGATOR_SERVICE_URL}
+            - name: INSIGHTS_RESULTS_SMART_PROXY__SERVICES__CONTENT
+              value: ${INSIGHTS_CONTENT_SERVICE_URL}
+            - name: INSIGHTS_RESULTS_SMART_PROXY__SERVICES__GROUPS_POLL_TIME
+              value: ${INSIGHTS_CONTENT_SERVICE_POLL_TIME}
+            - name: INSIGHTS_RESULTS_SMART_PROXY__SETUP__INTERNAL_RULES_ORGANIZATIONS_CSV_FILE
+              value: /etc/ccx-smart-proxy-secrets/internal_rules_organizations.csv
+            - name: INSIGHTS_RESULTS_SMART_PROXY__LOGGING__LOGGING_TO_CLOUD_WATCH_ENABLED
+              value: ${LOGGING_TO_CLOUD_WATCH_ENABLED}
+            - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__DEBUG
+              value: ${CLOUDWATCH_DEBUG}
+            - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__STREAM_NAME
+              value: ${IRSP_LOG_STREAM}
+            - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__CREATE_STREAM_IF_NOT_EXISTS
+              value: ${CREATE_STREAM_IF_NOT_EXISTS}
+            - name: HABERDASHER_EMITTER
+              value: ${HABERDASHER_EMITTER}
+            - name: HABERDASHER_KAFKA_BOOTSTRAP
+              value: ${HABERDASHER_KAFKA_BOOTSTRAP}
+            - name: HABERDASHER_KAFKA_TOPIC
+              value: ${HABERDASHER_KAFKA_TOPIC}
+            - name: HABERDASHER_LABELS
+              value: ${HABERDASHER_LABELS}
+            - name: HABERDASHER_TAGS
+              value: ${HABERDASHER_TAGS}
+            - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__LOG_GROUP
+              valueFrom:
+                secretKeyRef:
+                  key: log_group_name
+                  name: cloudwatch
+            - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__AWS_REGION
+              valueFrom:
+                secretKeyRef:
+                  key: aws_region
+                  name: cloudwatch
+            - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__AWS_ACCESS_ID
+              valueFrom:
+                secretKeyRef:
+                  key: aws_access_key_id
+                  name: cloudwatch
+            - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__AWS_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: aws_secret_access_key
+                  name: cloudwatch
+          image: ${IMAGE}:${IMAGE_TAG}
+          resources:
+            requests:
+              cpu: 100m
+              memory: 300Mi
+            limits:
+              cpu: 250m
+              memory: 600Mi
+parameters:
+- description: Image name
+  name: IMAGE
+  value: quay.io/cloudservices/ccx-smart-proxy
+- description: Image tag
+  name: IMAGE_TAG
+  required: true
+- description: Determines Clowder deployment
+  name: CLOWDER_ENABLED
+  value: "true"
+- description: ClowdEnv Name
+  name: ENV_NAME
+  required: true
+- description: Minimum number of pods to use when autoscaling is enabled
+  name: MIN_REPLICAS
+  value: '2'
+- description: Minimum number of pods to use when autoscaling is enabled
+  name: MAX_REPLICAS
+  value: '16'
+- name: PAYLOAD_TRACKER_TOPIC
+  description: Kafka topic for publishing updated for the Payload Tracker service
+  value: platform.payload-status
+- name: HABERDASHER_EMITTER
+  description: Emitter for haberdasher logs [stderr|kafka]
+  value: stderr
+- name: HABERDASHER_KAFKA_BOOTSTRAP
+  description: Bootstrap server for haberdasher kafka emitter
+  value: "mq-kafka:29092"
+- name: HABERDASHER_KAFKA_TOPIC
+  description: Kafka topic for haberdasher kafka emitter
+  value: "platform.logging.logs"
+- name: DEBUG
+  value: "true"
+- name: AUTH
+  value: "false"

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/prometheus/client_golang v1.10.0
+	github.com/redhatinsights/app-common-go v1.5.1
 	github.com/rs/zerolog v1.21.0
 	github.com/spf13/viper v1.7.2-0.20210415161207-7fdb267c730d
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
# Description
adds clowder manifest to allow the smart-proxy to be deployed into ephemeral envs

Fixes # CCXDEV-4921

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

run

`bonfire deploy -c ./bonfire-config-devel.yaml  -n ephemeral-## ccx-data-pipeline` and check

## Checklist
* [ ] `make before_commit` passes
