### PR TITLE
Update feedback endpoints

### DIFF
--- a/check_openapi.sh
+++ b/check_openapi.sh
@@ -22,3 +22,10 @@ else
     echo "OpenAPI spec file validation failed"
     exit 1
 fi
+
+if docker run --rm -v "${PWD}":/local/:Z openapitools/openapi-generator-cli validate -i ./local/openapi_dev.json; then
+    echo "OpenAPI [DEV] spec file is OK"
+else
+    echo "OpenAPI [DEV] spec file validation failed"
+    exit 1
+fi

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20210614100534-366b353ab4be
 	github.com/RedHatInsights/insights-operator-utils v1.10.0
-	github.com/RedHatInsights/insights-results-aggregator v1.1.2
+	github.com/RedHatInsights/insights-results-aggregator v1.1.3
 	github.com/RedHatInsights/insights-results-aggregator-data v1.0.1-0.20210614072933-b25730b1e023
 	github.com/aws/aws-sdk-go v1.38.9 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/RedHatInsights/insights-operator-utils v1.10.0/go.mod h1:mN5jURLpSG+j
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator v1.1.2 h1:U0WZ1XBIF8LdPxR0Sg+7qEV/qaEIbWoG52VLGJDUlfk=
 github.com/RedHatInsights/insights-results-aggregator v1.1.2/go.mod h1:ZZBfzSrDtfz8ek0vEMiOcSwujSNviGA2tw2UPsBW4bw=
+github.com/RedHatInsights/insights-results-aggregator v1.1.3 h1:Bs1qr9Q72bsllSTnrvzwgBCzfLk+HC/YstQumiUrkq8=
+github.com/RedHatInsights/insights-results-aggregator v1.1.3/go.mod h1:SOIyk+qDoNsfMK9CrwesXHCrfvb9uGGVUg33aR4j4AY=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=

--- a/openapi.json
+++ b/openapi.json
@@ -211,7 +211,7 @@
         "description": "Reports that are going to be returned are specified by list of cluster IDs that is part of path."
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/like": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/like": {
       "put": {
         "tags": [
           "rule",
@@ -219,27 +219,37 @@
         ],
         "parameters": [
           {
-            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266",
             "name": "clusterId",
+            "in": "path",
+            "required": true,
             "description": "ID of the cluster which must conform to UUID format.",
             "schema": {
-              "format": "uuid",
-              "maxLength": 36,
+              "type": "string",
               "minLength": 36,
-              "type": "string"
+              "maxLength": 36,
+              "format": "uuid"
             },
-            "in": "path",
-            "required": true
+            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266"
           },
           {
-            "example": "some.python.module",
             "name": "ruleId",
+            "in": "path",
+            "required": true,
             "description": "ID of a rule",
             "schema": {
               "type": "string"
             },
+            "example": "some.python.module"
+          },
+          {
+            "name": "errorKey",
             "in": "path",
-            "required": true
+            "required": true,
+            "description": "ID of the error key",
+            "schema": {
+              "type": "string"
+            },
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "responses": {
@@ -265,7 +275,7 @@
         "description": "Puts like for the rule(ruleId) with cluster(clusterId) for current user(from auth token)"
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/dislike": {
+    "/clusters/{clusterId}/rules/{ruleId}/{errorKey}/dislike": {
       "put": {
         "tags": [
           "rule",
@@ -273,27 +283,37 @@
         ],
         "parameters": [
           {
-            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266",
             "name": "clusterId",
+            "in": "path",
+            "required": true,
             "description": "ID of the cluster which must conform to UUID format",
             "schema": {
-              "format": "uuid",
-              "maxLength": 36,
+              "type": "string",
               "minLength": 36,
-              "type": "string"
+              "maxLength": 36,
+              "format": "uuid"
             },
-            "in": "path",
-            "required": true
+            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266"
           },
           {
-            "example": "some.python.module",
             "name": "ruleId",
+            "in": "path",
+            "required": true,
             "description": "ID of a rule",
             "schema": {
               "type": "string"
             },
+            "example": "some.python.module"
+          },
+          {
+            "name": "errorKey",
             "in": "path",
-            "required": true
+            "required": true,
+            "description": "ID of the error key",
+            "schema": {
+              "type": "string"
+            },
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "responses": {
@@ -319,7 +339,7 @@
         "description": "Puts dislike for the rule(ruleId) with cluster(clusterId) for current user(from auth token)"
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/reset_vote": {
+    "/clusters/{clusterId}/rules/{ruleId}/{errorKey}/reset_vote": {
       "put": {
         "tags": [
           "rule",
@@ -327,27 +347,37 @@
         ],
         "parameters": [
           {
-            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266",
             "name": "clusterId",
-            "description": "ID of the cluster which must conform to UUID format.",
-            "schema": {
-              "format": "uuid",
-              "maxLength": 36,
-              "minLength": 36,
-              "type": "string"
-            },
             "in": "path",
-            "required": true
+            "required": true,
+            "description": "ID of the cluster which must conform to UUID format.",
+            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266",
+            "schema": {
+              "type": "string",
+              "minLength": 36,
+              "maxLength": 36,
+              "format": "uuid"
+            }
           },
           {
-            "example": "some.python.module",
             "name": "ruleId",
+            "in": "path",
+            "required": true,
             "description": "ID of a rule",
+            "example": "some.python.module",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "errorKey",
+            "in": "path",
+            "required": true,
+            "description": "ID of the error key",
             "schema": {
               "type": "string"
             },
-            "in": "path",
-            "required": true
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "responses": {
@@ -650,7 +680,7 @@
         "description": "The static content is taken from the cache periodically updated from the content service"
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/disable": {
+    "/clusters/{clusterId}/rules/{ruleId}/{errorKey}/disable": {
       "put": {
         "tags": [
           "rule",
@@ -658,27 +688,37 @@
         ],
         "parameters": [
           {
-            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266",
             "name": "clusterId",
+            "in": "path",
+            "required": true,
             "description": "ID of the cluster which must conform to UUID format",
             "schema": {
-              "format": "uuid",
-              "maxLength": 36,
+              "type": "string",
               "minLength": 36,
-              "type": "string"
+              "maxLength": 36,
+              "format": "uuid"
             },
-            "in": "path",
-            "required": true
+            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266"
           },
           {
-            "example": "some.python.module",
             "name": "ruleId",
+            "in": "path",
+            "required": true,
             "description": "ID of a rule",
             "schema": {
               "type": "string"
             },
+            "example": "some.python.module"
+          },
+          {
+            "name": "errorKey",
             "in": "path",
-            "required": true
+            "required": true,
+            "description": "ID of the error key",
+            "schema": {
+              "type": "string"
+            },
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "responses": {
@@ -704,7 +744,7 @@
         "description": "Disables a rule (ruleId) for cluster (clusterId) for current organization/user"
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/disable_feedback": {
+    "/clusters/{clusterId}/rules/{ruleId}/{errorKey}/disable_feedback": {
       "post": {
         "requestBody": {
           "content": {
@@ -727,27 +767,37 @@
         ],
         "parameters": [
           {
-            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266",
             "name": "clusterId",
+            "in": "path",
+            "required": true,
             "description": "ID of the cluster which must conform to UUID format",
             "schema": {
-              "format": "uuid",
-              "maxLength": 36,
+              "type": "string",
               "minLength": 36,
-              "type": "string"
+              "maxLength": 36,
+              "format": "uuid"
             },
-            "in": "path",
-            "required": true
+            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266"
           },
           {
-            "example": "some.python.module",
             "name": "ruleId",
-            "description": "ID of the rule",
+            "in": "path",
+            "required": true,
+            "description": "ID of a rule",
             "schema": {
               "type": "string"
             },
+            "example": "some.python.module"
+          },
+          {
+            "name": "errorKey",
             "in": "path",
-            "required": true
+            "required": true,
+            "description": "ID of the error key",
+            "schema": {
+              "type": "string"
+            },
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "responses": {
@@ -777,7 +827,7 @@
         "description": "Returns rule/health check's disable feedback"
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/enable": {
+    "/clusters/{clusterId}/rules/{ruleId}/{errorKey}/enable": {
       "put": {
         "tags": [
           "rule",
@@ -785,27 +835,37 @@
         ],
         "parameters": [
           {
-            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266",
             "name": "clusterId",
+            "in": "path",
+            "required": true,
             "description": "ID of the cluster which must conform to UUID format",
             "schema": {
-              "format": "uuid",
-              "maxLength": 36,
+              "type": "string",
               "minLength": 36,
-              "type": "string"
+              "maxLength": 36,
+              "format": "uuid"
             },
-            "in": "path",
-            "required": true
+            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266"
           },
           {
-            "example": "some.python.module",
             "name": "ruleId",
+            "in": "path",
+            "required": true,
             "description": "ID of a rule",
             "schema": {
               "type": "string"
             },
+            "example": "some.python.module"
+          },
+          {
+            "name": "errorKey",
             "in": "path",
-            "required": true
+            "required": true,
+            "description": "ID of the error key",
+            "schema": {
+              "type": "string"
+            },
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "responses": {

--- a/openapi_dev.json
+++ b/openapi_dev.json
@@ -521,7 +521,7 @@
         ]
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/like": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/like": {
       "put": {
         "summary": "Puts like for the rule with cluster for current user",
         "operationId": "addLikeToRule",
@@ -549,6 +549,16 @@
               "type": "string"
             },
             "example": "some.python.module"
+          },
+          {
+            "name": "errorKey",
+            "in": "path",
+            "required": true,
+            "description": "ID of the error key",
+            "schema": {
+              "type": "string"
+            },
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "responses": {
@@ -575,7 +585,7 @@
         ]
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/dislike": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/dislike": {
       "put": {
         "summary": "Puts dislike for the rule with cluster for current user",
         "operationId": "addDislikeToRule",
@@ -603,6 +613,16 @@
               "type": "string"
             },
             "example": "some.python.module"
+          },
+          {
+            "name": "errorKey",
+            "in": "path",
+            "required": true,
+            "description": "ID of the error key",
+            "schema": {
+              "type": "string"
+            },
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "responses": {
@@ -629,7 +649,7 @@
         ]
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/reset_vote": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/reset_vote": {
       "put": {
         "summary": "Resets vote for the rule with cluster for current user",
         "operationId": "resetVoteForRule",
@@ -657,6 +677,16 @@
             "schema": {
               "type": "string"
             }
+          },
+          {
+            "name": "errorKey",
+            "in": "path",
+            "required": true,
+            "description": "ID of the error key",
+            "schema": {
+              "type": "string"
+            },
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "responses": {
@@ -683,7 +713,7 @@
         ]
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/get_vote": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/get_vote": {
       "get": {
         "summary": "Returns vote for the rule with cluster for current user",
         "operationId": "getVoteForRule",
@@ -711,6 +741,16 @@
               "type": "string"
             },
             "example": "some.python.module"
+          },
+          {
+            "name": "errorKey",
+            "in": "path",
+            "required": true,
+            "description": "ID of the error key",
+            "schema": {
+              "type": "string"
+            },
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "responses": {
@@ -1171,7 +1211,7 @@
         }
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/disable": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/disable": {
       "put": {
         "summary": "Disables a rule/health check recommendation for specified cluster",
         "operationId": "disableRule",
@@ -1199,6 +1239,16 @@
               "type": "string"
             },
             "example": "some.python.module"
+          },
+          {
+            "name": "errorKey",
+            "in": "path",
+            "required": true,
+            "description": "ID of the error key",
+            "schema": {
+              "type": "string"
+            },
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "responses": {
@@ -1225,7 +1275,7 @@
         ]
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/disable_feedback": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}disable_feedback": {
       "post": {
         "summary": "Returns rule/health check's disable feedback",
         "operationId": "disableRuleFeedback",
@@ -1248,11 +1298,21 @@
             "name": "ruleId",
             "in": "path",
             "required": true,
-            "description": "ID of the rule",
+            "description": "ID of a rule",
             "schema": {
               "type": "string"
             },
             "example": "some.python.module"
+          },
+          {
+            "name": "errorKey",
+            "in": "path",
+            "required": true,
+            "description": "ID of the error key",
+            "schema": {
+              "type": "string"
+            },
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "requestBody": {
@@ -1298,7 +1358,7 @@
         ]
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/enable": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/enable": {
       "put": {
         "summary": "Re-enables a rule/health check recommendation for specified cluster",
         "operationId": "enableRule",
@@ -1307,8 +1367,8 @@
           {
             "name": "clusterId",
             "in": "path",
-            "description": "ID of the cluster which must conform to UUID format",
             "required": true,
+            "description": "ID of the cluster which must conform to UUID format",
             "schema": {
               "type": "string",
               "minLength": 36,
@@ -1326,6 +1386,16 @@
               "type": "string"
             },
             "example": "some.python.module"
+          },
+          {
+            "name": "errorKey",
+            "in": "path",
+            "required": true,
+            "description": "ID of the error key",
+            "schema": {
+              "type": "string"
+            },
+            "example": "ERROR_COOL_NAME"
           }
         ],
         "responses": {

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -50,19 +50,19 @@ const (
 	// MetricsEndpoint returns prometheus metrics
 	MetricsEndpoint = "metrics"
 	// LikeRuleEndpoint likes rule with {rule_id} for {cluster} using current user(from auth header)
-	LikeRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/like"
+	LikeRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/like"
 	// DislikeRuleEndpoint dislikes rule with {rule_id} for {cluster} using current user(from auth header)
-	DislikeRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/dislike"
+	DislikeRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/dislike"
 	// ResetVoteOnRuleEndpoint resets vote on rule with {rule_id} for {cluster} using current user(from auth header)
-	ResetVoteOnRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/reset_vote"
+	ResetVoteOnRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/reset_vote"
 	// GetVoteOnRuleEndpoint is an endpoint to get vote on rule. DEBUG only
-	GetVoteOnRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/get_vote"
+	GetVoteOnRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/get_vote"
 	// DisableRuleForClusterEndpoint disables a rule for specified cluster
-	DisableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/disable"
+	DisableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/disable"
 	// EnableRuleForClusterEndpoint re-enables a rule for specified cluster
-	EnableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/enable"
+	EnableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/enable"
 	// DisableRuleFeedbackEndpoint accepts a feedback from user when (s)he disables a rule
-	DisableRuleFeedbackEndpoint = "clusters/{cluster}/rules/{rule_id}/disable_feedback"
+	DisableRuleFeedbackEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/disable_feedback"
 	// OverviewEndpoint returns some overview data for the clusters belonging to the org id
 	OverviewEndpoint = "org_overview"
 

--- a/server/endpoints_test.go
+++ b/server/endpoints_test.go
@@ -57,7 +57,7 @@ func TestHTTPServer_ProxyTo_VoteEndpointsExtractUserID(t *testing.T) {
 				helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
 					Method:       testCase.method,
 					Endpoint:     testCase.newEndpoint,
-					EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.UserID},
+					EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.UserID},
 				}, &helpers.APIResponse{
 					StatusCode: http.StatusOK,
 					Body:       `{"status": "ok"}`,
@@ -66,7 +66,7 @@ func TestHTTPServer_ProxyTo_VoteEndpointsExtractUserID(t *testing.T) {
 				helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
 					Method:       testCase.method,
 					Endpoint:     testCase.endpoint,
-					EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID},
+					EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1},
 					UserID:       testdata.UserID,
 					OrgID:        testdata.OrgID,
 				}, &helpers.APIResponse{
@@ -85,7 +85,7 @@ func TestHTTPServer_ProxyTo_VoteEndpointBadCharacter(t *testing.T) {
 	helpers.AssertAPIRequest(t, &helpers.DefaultServerConfig, &helpers.DefaultServicesConfig, nil, &helpers.APIRequest{
 		Method:       http.MethodPut,
 		Endpoint:     server.LikeRuleEndpoint,
-		EndpointArgs: []interface{}{badClusterName, testdata.Rule1ID},
+		EndpointArgs: []interface{}{badClusterName, testdata.Rule1ID, testdata.ErrorKey1},
 		UserID:       testdata.UserID,
 		OrgID:        testdata.OrgID,
 	}, &helpers.APIResponse{


### PR DESCRIPTION
# Description

This PR updates the endpoints used for voting, enabling, disabling and giving feedback for the rule hits from an Smart Proxy client. Now, it will require the "error key", not only the rule id, because some of the rules have more than 1 valid error key

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Regular CI

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
