### PR TITLE
Fix feedback endpoints, missing error_key keyword

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -275,7 +275,7 @@
         "description": "Puts like for the rule(ruleId) with cluster(clusterId) for current user(from auth token)"
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/{errorKey}/dislike": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/dislike": {
       "put": {
         "tags": [
           "rule",
@@ -339,7 +339,7 @@
         "description": "Puts dislike for the rule(ruleId) with cluster(clusterId) for current user(from auth token)"
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/{errorKey}/reset_vote": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/reset_vote": {
       "put": {
         "tags": [
           "rule",
@@ -680,7 +680,7 @@
         "description": "The static content is taken from the cache periodically updated from the content service"
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/{errorKey}/disable": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/disable": {
       "put": {
         "tags": [
           "rule",
@@ -744,7 +744,7 @@
         "description": "Disables a rule (ruleId) for cluster (clusterId) for current organization/user"
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/{errorKey}/disable_feedback": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/disable_feedback": {
       "post": {
         "requestBody": {
           "content": {
@@ -827,7 +827,7 @@
         "description": "Returns rule/health check's disable feedback"
       }
     },
-    "/clusters/{clusterId}/rules/{ruleId}/{errorKey}/enable": {
+    "/clusters/{clusterId}/rules/{ruleId}/error_key/{errorKey}/enable": {
       "put": {
         "tags": [
           "rule",

--- a/server/endpoints.go
+++ b/server/endpoints.go
@@ -50,19 +50,19 @@ const (
 	// MetricsEndpoint returns prometheus metrics
 	MetricsEndpoint = "metrics"
 	// LikeRuleEndpoint likes rule with {rule_id} for {cluster} using current user(from auth header)
-	LikeRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/like"
+	LikeRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/like"
 	// DislikeRuleEndpoint dislikes rule with {rule_id} for {cluster} using current user(from auth header)
-	DislikeRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/dislike"
+	DislikeRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/dislike"
 	// ResetVoteOnRuleEndpoint resets vote on rule with {rule_id} for {cluster} using current user(from auth header)
-	ResetVoteOnRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/reset_vote"
+	ResetVoteOnRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/reset_vote"
 	// GetVoteOnRuleEndpoint is an endpoint to get vote on rule. DEBUG only
-	GetVoteOnRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/get_vote"
+	GetVoteOnRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/get_vote"
 	// DisableRuleForClusterEndpoint disables a rule for specified cluster
-	DisableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/disable"
+	DisableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/disable"
 	// EnableRuleForClusterEndpoint re-enables a rule for specified cluster
-	EnableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/enable"
+	EnableRuleForClusterEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/enable"
 	// DisableRuleFeedbackEndpoint accepts a feedback from user when (s)he disables a rule
-	DisableRuleFeedbackEndpoint = "clusters/{cluster}/rules/{rule_id}/{error_key}/disable_feedback"
+	DisableRuleFeedbackEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/disable_feedback"
 	// OverviewEndpoint returns some overview data for the clusters belonging to the org id
 	OverviewEndpoint = "org_overview"
 


### PR DESCRIPTION
# Description

Small fix for missing keywords in endpoint definitions on smart-proxy, which leads to an incorrect redirection to a wrong endpoint in aggregator.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Regular CI

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
