### PR TITLE
make status and publish_date optional but disallow GIGO

### DIFF
--- a/content/content_test.go
+++ b/content/content_test.go
@@ -298,3 +298,95 @@ func TestFetchRuleContent_RuleDoesNotExist(t *testing.T) {
 
 	}, testTimeout)
 }
+
+func TestUpdateContentInvalidStatus(t *testing.T) {
+	defer content.ResetContent()
+
+	ruleContent := testdata.RuleContent4
+	ek := ruleContent.ErrorKeys[testdata.ErrorKey4]
+	ek.Metadata.Status = "foo"
+	ruleContent.ErrorKeys[testdata.ErrorKey4] = ek
+
+	ruleContentDirectory := types.RuleContentDirectory{
+		Config: types.GlobalRuleConfig{
+			Impact: testdata.ImpactStrToInt,
+		},
+		Rules: map[string]types.RuleContent{
+			"rc4": ruleContent,
+		},
+	}
+
+	content.LoadRuleContent(&ruleContentDirectory)
+
+	_, err := content.GetRuleWithErrorKeyContent(testdata.Rule4ID, testdata.ErrorKey4)
+	assert.NotNil(t, err)
+}
+
+func TestUpdateContentMissingStatus(t *testing.T) {
+	defer content.ResetContent()
+
+	ruleContent := testdata.RuleContent4
+	ek := ruleContent.ErrorKeys[testdata.ErrorKey4]
+	ek.Metadata.Status = ""
+	ruleContent.ErrorKeys[testdata.ErrorKey4] = ek
+
+	ruleContentDirectory := types.RuleContentDirectory{
+		Config: types.GlobalRuleConfig{
+			Impact: testdata.ImpactStrToInt,
+		},
+		Rules: map[string]types.RuleContent{
+			"rc4": ruleContent,
+		},
+	}
+
+	content.LoadRuleContent(&ruleContentDirectory)
+
+	_, err := content.GetRuleWithErrorKeyContent(testdata.Rule4ID, testdata.ErrorKey4)
+	helpers.FailOnError(t, err)
+}
+
+func TestUpdateContentInvalidPublishDate(t *testing.T) {
+	defer content.ResetContent()
+
+	ruleContent := testdata.RuleContent4
+	ek := ruleContent.ErrorKeys[testdata.ErrorKey4]
+	ek.Metadata.PublishDate = "invalid date"
+	ruleContent.ErrorKeys[testdata.ErrorKey4] = ek
+
+	ruleContentDirectory := types.RuleContentDirectory{
+		Config: types.GlobalRuleConfig{
+			Impact: testdata.ImpactStrToInt,
+		},
+		Rules: map[string]types.RuleContent{
+			"rc4": ruleContent,
+		},
+	}
+
+	content.LoadRuleContent(&ruleContentDirectory)
+
+	_, err := content.GetRuleWithErrorKeyContent(testdata.Rule4ID, testdata.ErrorKey4)
+	assert.NotNil(t, err)
+}
+
+func TestUpdateContentMissingPublishDate(t *testing.T) {
+	defer content.ResetContent()
+
+	ruleContent := testdata.RuleContent4
+	ek := ruleContent.ErrorKeys[testdata.ErrorKey4]
+	ek.Metadata.PublishDate = ""
+	ruleContent.ErrorKeys[testdata.ErrorKey4] = ek
+
+	ruleContentDirectory := types.RuleContentDirectory{
+		Config: types.GlobalRuleConfig{
+			Impact: testdata.ImpactStrToInt,
+		},
+		Rules: map[string]types.RuleContent{
+			"rc4": ruleContent,
+		},
+	}
+
+	content.LoadRuleContent(&ruleContentDirectory)
+
+	_, err := content.GetRuleWithErrorKeyContent(testdata.Rule4ID, testdata.ErrorKey4)
+	helpers.FailOnError(t, err)
+}

--- a/content/parsing.go
+++ b/content/parsing.go
@@ -118,20 +118,20 @@ func commaSeparatedStrToTags(str string) []string {
 	return strings.Split(str, ",")
 }
 
-func timeParse(value string) (time.Time, bool, error) {
-	var err error
-	missing := false
+func timeParse(value string) (publishDate time.Time, missing bool, err error) {
+	missing = false
+	publishDate = time.Time{}
 
 	if value == "" {
 		missing = true
-		return time.Time{}, missing, nil
+		return
 	}
 
 	for _, datetimeLayout := range timeParseFormats {
-		parsedDate, err := time.Parse(datetimeLayout, value)
+		publishDate, err = time.Parse(datetimeLayout, value)
 
 		if err == nil {
-			return parsedDate, missing, err
+			return
 		}
 
 		log.Info().Msgf(
@@ -146,7 +146,7 @@ func timeParse(value string) (time.Time, bool, error) {
 		err = errors.New("invalid format of publish_date")
 	}
 
-	return time.Time{}, missing, err
+	return
 }
 
 // Reads Status string, first returned bool is active status, second bool is a success check

--- a/content/parsing.go
+++ b/content/parsing.go
@@ -15,6 +15,7 @@
 package content
 
 import (
+	"errors"
 	"strings"
 	"time"
 
@@ -47,16 +48,22 @@ func LoadRuleContent(contentDir *types.RuleContentDirectory) {
 				continue
 			}
 
-			isActive, success := getActiveStatus(errorProperties.Metadata.Status)
+			// we allow empty/missing, but not incorrect
+			active, success, missing := getActiveStatus(errorProperties.Metadata.Status)
 			if success != true {
-				log.Error().Msgf(`fatal: rule ID %v with key %v has invalid status`, ruleID, errorKey)
-				return
+				log.Error().Msgf(`rule ID %v with key %v has invalid status attribute`, ruleID, errorKey)
+				continue
+			} else if missing {
+				log.Warn().Msgf(`rule ID %v with key %v has missing status attribute`, ruleID, errorKey)
 			}
 
-			publishDate, err := timeParse(errorProperties.Metadata.PublishDate)
+			// we allow empty/missing, but not incorrect format
+			publishDate, missing, err := timeParse(errorProperties.Metadata.PublishDate)
 			if err != nil {
-				log.Error().Msgf(`fatal: rule ID %v with key %v has improper datetime attribute`, ruleID, errorKey)
-				return
+				log.Error().Err(err).Msgf(`rule ID %v with key %v has improper publish_date attribute`, ruleID, errorKey)
+				continue
+			} else if missing {
+				log.Warn().Msgf(`rule ID %v with key %v has missing publish_date attribute`, ruleID, errorKey)
 			}
 
 			totalRisk := calculateTotalRisk(impact, errorProperties.Metadata.Likelihood)
@@ -80,7 +87,7 @@ func LoadRuleContent(contentDir *types.RuleContentDirectory) {
 				TotalRisk:       totalRisk,
 				RiskOfChange:    calculateRiskOfChange(impact, errorProperties.Metadata.Likelihood),
 				PublishDate:     publishDate,
-				Active:          isActive,
+				Active:          active,
 				Internal:        IsRuleInternal(ruleID),
 				Generic:         errorProperties.Generic,
 				Tags:            errorProperties.Metadata.Tags,
@@ -111,13 +118,20 @@ func commaSeparatedStrToTags(str string) []string {
 	return strings.Split(str, ",")
 }
 
-func timeParse(value string) (time.Time, error) {
+func timeParse(value string) (time.Time, bool, error) {
 	var err error
+	missing := false
+
+	if value == "" {
+		missing = true
+		return time.Time{}, missing, nil
+	}
+
 	for _, datetimeLayout := range timeParseFormats {
 		parsedDate, err := time.Parse(datetimeLayout, value)
 
 		if err == nil {
-			return parsedDate, nil
+			return parsedDate, missing, err
 		}
 
 		log.Info().Msgf(
@@ -126,28 +140,35 @@ func timeParse(value string) (time.Time, error) {
 		)
 	}
 
-	log.Error().Err(err)
+	if err != nil {
+		log.Error().Msgf("problem parsing publish_date: %v", err)
+	} else {
+		err = errors.New("invalid format of publish_date")
+	}
 
-	return time.Time{}, err
+	return time.Time{}, missing, err
 }
 
 // Reads Status string, first returned bool is active status, second bool is a success check
-func getActiveStatus(status string) (bool, bool) {
-	var isActive, success bool
+func getActiveStatus(status string) (active, success, missing bool) {
+	active, success, missing = false, false, false
 
-	switch strings.ToLower(strings.TrimSpace(status)) {
+	status = strings.ToLower(strings.TrimSpace(status))
+
+	switch status {
 	case "active":
-		isActive = true
+		active = true
 		success = true
 	case "inactive":
-		isActive = false
 		success = true
+	case "":
+		success = true
+		missing = true
 	default:
 		log.Error().Msgf("invalid rule error key status: '%s'", status)
-		success = false
 	}
 
-	return isActive, success
+	return
 }
 
 // IsRuleInternal tries to look for the word "internal" in the ruleID / rule module,


### PR DESCRIPTION
# Description

This PR makes the `status` and `publish_date` attributes of error keys optional, but does not allow garbage in, garbage out.
With the checks performed by Martin's script, we should be safe.

Fixes CCXDEV-5442

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps
smart-proxy gets 141 rules from content-service and with these changes, smart-proxy provides content for all 141 rules, `make before_commit` and also checked visually if there is no garbage in the current content

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
