### PR TITLE
No content when rules are hitting is no longer causing 500s

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -94,6 +94,14 @@ var (
 		Report: &SmartProxyReport1RuleNoContent,
 	}
 
+	SmartProxyReportResponse3Rules2NoContent = struct {
+		Status string                  `json:"status"`
+		Report *types.SmartProxyReport `json:"report"`
+	}{
+		Status: "ok",
+		Report: &SmartProxyReport3Rules2NoContent,
+	}
+
 	SmartProxyReportResponse3Rules = struct {
 		Status string                  `json:"status"`
 		Report *types.SmartProxyReport `json:"report"`
@@ -104,11 +112,12 @@ var (
 
 	SmartProxyReport1RuleNoContent = types.SmartProxyReport{
 		Meta: types.ReportResponseMeta{
-			Count:         1,
+			Count:         0,
 			LastCheckedAt: types.Timestamp(testdata.LastCheckedAt.UTC().Format(time.RFC3339)),
 		},
 		Data: []types.RuleWithContentResponse{},
 	}
+
 	SmartProxyReport3Rules = types.SmartProxyReport{
 		Meta: types.ReportResponseMeta{
 			Count:         3,
@@ -162,6 +171,31 @@ var (
 				UserVote:     types.UserVoteNone,
 				TemplateData: testdata.Rule3ExtraData,
 				Tags:         testdata.RuleErrorKey3.Tags,
+			},
+		},
+	}
+
+	SmartProxyReport3Rules2NoContent = types.SmartProxyReport{
+		Meta: types.ReportResponseMeta{
+			Count:         3,
+			LastCheckedAt: types.Timestamp(testdata.LastCheckedAt.UTC().Format(time.RFC3339)),
+		},
+		Data: []types.RuleWithContentResponse{
+			{
+				RuleID:       testdata.Rule1.Module,
+				ErrorKey:     testdata.RuleErrorKey1.ErrorKey,
+				CreatedAt:    testdata.RuleErrorKey1.PublishDate.UTC().Format(time.RFC3339),
+				Description:  testdata.RuleErrorKey1.Description,
+				Generic:      testdata.RuleErrorKey1.Generic,
+				Reason:       testdata.Rule1.Reason,
+				Resolution:   testdata.Rule1.Resolution,
+				MoreInfo:     testdata.Rule1.MoreInfo,
+				TotalRisk:    calculateTotalRisk(testdata.RuleErrorKey1.Impact, testdata.RuleErrorKey1.Likelihood),
+				RiskOfChange: 0,
+				Disabled:     testdata.Rule1Disabled,
+				UserVote:     types.UserVoteNone,
+				TemplateData: testdata.Rule1ExtraData,
+				Tags:         testdata.RuleErrorKey1.Tags,
 			},
 		},
 	}


### PR DESCRIPTION
# Description
I totally ignored the if statement when I started working on it because I misread it and considered it an impossible scenario "sanity" check... 

This case should appear as "No issues found" in customer-facing applications, because the only we could show is rule module + error key, which have no informational value to customers, so now this edge case will appear as if the cluster had no issues in OCM, which is actually true from the customer's POV, since we can't even describe the problem, let alone provide resolution.

Fixes (hopefully) https://bugzilla.redhat.com/show_bug.cgi?id=1977858

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
`make before_commit`, two unit test cases can now be considered as reproducers

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
