### PR TITLE
[CCXDEV-5376] Fix POST /org_overview counts disabled rules

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -426,10 +426,10 @@ var (
 	}{
 		Status: "ok",
 		Overview: map[string]interface{}{
-			"clusters_hit": 1,
+			"clusters_hit": 2,
 			"hit_by_risk": map[string]int{
 				"1": 1,
-				"2": 1,
+				"2": 2,
 			},
 			"hit_by_tag": map[string]int{
 				"openshift":            1,

--- a/tests/testdata/testdata.go
+++ b/tests/testdata/testdata.go
@@ -50,6 +50,13 @@ var (
 		},
 	}
 
+	ReportCluster2 = types.ReportRules{
+		HitRules: []types.RuleOnReport{
+			testdata.RuleOnReport5,
+			testdata.RuleOnReport2,
+		},
+	}
+
 	// AggregatorReportForClusterList
 	AggregatorReportForClusterList = types.ClusterReports{
 		ClusterList: []types.ClusterName{
@@ -60,7 +67,7 @@ var (
 		Errors: []types.ClusterName{},
 		Reports: map[types.ClusterName]json.RawMessage{
 			ClusterName1: whateverToJSONRawMessage(ReportCluster1),
-			ClusterName2: json.RawMessage([]byte("{}")),
+			ClusterName2: whateverToJSONRawMessage(ReportCluster2),
 			ClusterName3: json.RawMessage([]byte("{}")),
 		},
 		GeneratedAt: GeneratedAt,


### PR DESCRIPTION
# Description

The org_overview is aggregating all the reported rules, even when they are disabled. This is being seen as a misbehaviour.

Fixes #CCXDEV-5376

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Regular CI

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
