### PR TITLE
Use POST endpoint instead of expand the cluster list

### DIFF
--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -691,9 +691,9 @@ func TestHTTPServer_OverviewWithClusterIDsEndpoint(t *testing.T) {
 		// prepare reports reponse
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method:       http.MethodGet,
-				Endpoint:     ira_server.ReportForListOfClustersEndpoint,
-				EndpointArgs: []interface{}{testdata.OrgID, data.ClusterIDInURL},
+				Method:       http.MethodPost,
+				Endpoint:     ira_server.ReportForListOfClustersPayloadEndpoint,
+				EndpointArgs: []interface{}{testdata.OrgID},
 			},
 			&helpers.APIResponse{
 				StatusCode: http.StatusOK,

--- a/server/server.go
+++ b/server/server.go
@@ -429,16 +429,23 @@ func (server HTTPServer) readAggregatorReportForClusterListFromBody(
 		return nil, false
 	}
 
+	return handleReportsResponse(aggregatorResp, writer)
+}
+
+// handleReportsResponse analyses the aggregator's response and
+// writes an appropriate response to the client, handling any
+// possible error in the meantime
+func handleReportsResponse(response *http.Response, writer http.ResponseWriter) (*types.ClusterReports, bool) {
 	var aggregatorResponse types.ClusterReports
 
-	responseBytes, err := ioutil.ReadAll(aggregatorResp.Body)
+	responseBytes, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		handleServerError(writer, err)
 		return nil, false
 	}
 
-	if aggregatorResp.StatusCode != http.StatusOK {
-		err := responses.Send(aggregatorResp.StatusCode, writer, responseBytes)
+	if response.StatusCode != http.StatusOK {
+		err := responses.Send(response.StatusCode, writer, responseBytes)
 		if err != nil {
 			log.Error().Err(err).Msg(responseDataError)
 		}
@@ -452,7 +459,6 @@ func (server HTTPServer) readAggregatorReportForClusterListFromBody(
 	}
 
 	return &aggregatorResponse, true
-
 }
 
 // readAggregatorRuleForClusterID reads report from aggregator,


### PR DESCRIPTION
# Description

`org_overview` endpoint currently used the GET endpoint to retrieve all the cluster reports from Aggregator. It can lead in some situations to very long URLs that can be handled differently depending on configuration.

This change makes the endpoint to use the POST endpoint version to retrieve the reports for a list of clusters, which will avoid the possible URL problems

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Regular CI

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
