### PR TITLE
WIP: CCXDEV-5093 Create a POST /rating endpoint

### DIFF
--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -404,6 +404,53 @@
         "summary": "Get all static content for the given ruleId",
         "description": "The static content is taken from the cache periodically updated from the content service"
       }
+    },
+    "/rating": {
+      "post": {
+        "tags": [
+          "prod"
+        ],
+        "requestBody": {
+          "description": "A JSON object with the current rule and its rating.",
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ratingPostRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ratingPostResponse"
+                }
+              }
+            },
+            "description": "The current rating value for the rule"
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ratingPostResponse"
+                }
+              }
+            },
+            "description": "The current rating value for the rule"
+          },
+          "400": {
+            "description": "Invalid request, usually caused when some rule identifier doesn't exist"
+          }
+        },
+        "deprecated": false,
+        "operationId": "sendRating",
+        "summary": "Send the new rating for a given rule",
+        "description": "Return the new rating. Any previous rating for this rule by this user is amended to the current value. This does not attempt to delete a rating by this user of thus rule if the rating is zero."
+      }
     }
   },
   "components": {
@@ -563,6 +610,35 @@
           "meta": {
             "$ref": "#/components/schemas/reportMeta",
             "description": ""
+          }
+        }
+      },
+      "ratingPostRequest": {
+        "description": "",
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "rule": {
+              "type": "string"
+            },
+            "rating": {
+              "type": "integer"
+            }
+          }
+        }
+      },
+      "ratingPostResponse": {
+        "description": "",
+        "type": "object",
+        "properties": {
+          "rule": {
+            "type": "string",
+            "description": "The updated rule"
+          },
+          "rating": {
+            "type": "integer",
+            "description": "The rule rating (-1, 0 or +1)"
           }
         }
       }


### PR DESCRIPTION
# Description

**WIP** A new POST endpoint for rating is needed in Smart Proxy. Exposes the same functionallity as voting endpoints in the v1 API, but using the API expected by Advisor

Fixes CCXDEV-5093

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Unit tests (no changes in the code)
- REST API tests
- Documentation update

## Testing steps
Regular CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
