### PR TITLE
Bump-up utils to 1.15.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20210614100534-366b353ab4be
-	github.com/RedHatInsights/insights-operator-utils v1.14.0
+	github.com/RedHatInsights/insights-operator-utils v1.15.0
 	github.com/RedHatInsights/insights-results-aggregator v1.1.3
 	github.com/RedHatInsights/insights-results-aggregator-data v1.1.0
 	github.com/aws/aws-sdk-go v1.38.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/RedHatInsights/insights-operator-utils v1.12.0 h1:cQVdkkRRlQ23QVGFgXL
 github.com/RedHatInsights/insights-operator-utils v1.12.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-operator-utils v1.14.0 h1:bROfP6PaOnxuFBiYDVsyzerKgy5FRlCV0UBATKHuTt8=
 github.com/RedHatInsights/insights-operator-utils v1.14.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
+github.com/RedHatInsights/insights-operator-utils v1.15.0 h1:EQr79jONoR+x32eltxFN+tTHy52lXDrcoyNgvpyz9KI=
+github.com/RedHatInsights/insights-operator-utils v1.15.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator v1.1.3 h1:Bs1qr9Q72bsllSTnrvzwgBCzfLk+HC/YstQumiUrkq8=
 github.com/RedHatInsights/insights-results-aggregator v1.1.3/go.mod h1:SOIyk+qDoNsfMK9CrwesXHCrfvb9uGGVUg33aR4j4AY=


### PR DESCRIPTION
# Description

Bump-up utils to 1.15.0

Fixes #619

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
