### PR TITLE
Keeping the gitleaks configuration file on gh-pages branch

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -31,6 +31,8 @@ jobs:
           go-version: '^1.14.1'
       - name: Generate docgo
         run: make godoc
+      - name: Store the Gitleaks file
+        run: mkdir docs/build && cp docs/.gitleaks.toml docs/build
       - name: Generate Jekyll site
         uses: helaili/jekyll-action@v2
         with:

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -22,3 +22,6 @@ exclude:
   - Gemfile
   - Gemfile.lock
   - vendor/
+
+keep_files:
+  - .gitleaks.toml


### PR DESCRIPTION
# Description

Fix minor problem in CI to kkep the .gitleaks.toml file in the gh-pages branch

## Type of change
- Documentation update
- CI pipeline update

## Testing steps

Regular CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
