### PR TITLE
Bump-up `utils` version to 1.18.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20210614100534-366b353ab4be
-	github.com/RedHatInsights/insights-operator-utils v1.17.0
+	github.com/RedHatInsights/insights-operator-utils v1.18.0
 	github.com/RedHatInsights/insights-results-aggregator v1.1.4
 	github.com/RedHatInsights/insights-results-aggregator-data v1.1.0
 	github.com/aws/aws-sdk-go v1.38.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,7 @@ github.com/RedHatInsights/insights-operator-utils v1.16.0 h1:viE9oEDX40JkkRwaO75
 github.com/RedHatInsights/insights-operator-utils v1.16.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-operator-utils v1.17.0 h1:yKzcOWIJWAuZ90PDGOx+Wwx0RQKtQp3G/Xk7GVmZGM4=
 github.com/RedHatInsights/insights-operator-utils v1.17.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
+github.com/RedHatInsights/insights-operator-utils v1.18.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator v1.1.4 h1:6hlYIXrCnY4V1/8lDRpQxREiS1WPvyb7mBX18FTkX7M=
 github.com/RedHatInsights/insights-results-aggregator v1.1.4/go.mod h1:QkGAVvCkqDJm9viNdusrO1acDrGuf8poxG6W22mDUEk=

--- a/go.sum
+++ b/go.sum
@@ -54,6 +54,7 @@ github.com/RedHatInsights/insights-operator-utils v1.16.0 h1:viE9oEDX40JkkRwaO75
 github.com/RedHatInsights/insights-operator-utils v1.16.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-operator-utils v1.17.0 h1:yKzcOWIJWAuZ90PDGOx+Wwx0RQKtQp3G/Xk7GVmZGM4=
 github.com/RedHatInsights/insights-operator-utils v1.17.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
+github.com/RedHatInsights/insights-operator-utils v1.18.0 h1:sGzvXitvVChwVE8G/hJe3BtvPedKtDC4ULXYirTN/58=
 github.com/RedHatInsights/insights-operator-utils v1.18.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator v1.1.4 h1:6hlYIXrCnY4V1/8lDRpQxREiS1WPvyb7mBX18FTkX7M=


### PR DESCRIPTION
# Description

Bump-up `utils` version to 1.18.0

Fixes #631

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
