### PR TITLE
Upgrade to go-toolset 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/rhel8/go-toolset:1.14 AS builder
+FROM registry.redhat.io/rhel8/go-toolset:1.15 AS builder
 
 COPY . .
 


### PR DESCRIPTION
# Description

Last version of Smart Proxy are not being built because a dependency problem. Now, using Go 1.15 for building is mandatory for the package and need to be reflected in the base image used

Fixed #636 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Locally: `docker build -t ccx-smart-proxy:latest .`
Remote: after merging, check https://ci.ext.devshift.net/job/RedHatInsights-insights-results-smart-proxy-gh-build-master/

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
