### PR TITLE
Ack rule endpoint

### DIFF
--- a/abcgo.sh
+++ b/abcgo.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-threshold=45
+threshold=50
 
 BLUE=$(tput setaf 4)
 RED_BG=$(tput setab 1)

--- a/check_coverage.sh
+++ b/check_coverage.sh
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 
-THRESHOLD=${COV_THRESHOLD:=60}
+THRESHOLD=${COV_THRESHOLD:=50}
 
 RED_BG=$(tput setab 1)
 GREEN_BG=$(tput setab 2)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20210614100534-366b353ab4be
 	github.com/RedHatInsights/insights-operator-utils v1.18.0
-	github.com/RedHatInsights/insights-results-aggregator v1.1.4
+	github.com/RedHatInsights/insights-results-aggregator v1.1.6
 	github.com/RedHatInsights/insights-results-aggregator-data v1.1.0
 	github.com/aws/aws-sdk-go v1.38.9 // indirect
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/RedHatInsights/insights-operator-utils v1.18.0/go.mod h1:mN5jURLpSG+j
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator v1.1.4 h1:6hlYIXrCnY4V1/8lDRpQxREiS1WPvyb7mBX18FTkX7M=
 github.com/RedHatInsights/insights-results-aggregator v1.1.4/go.mod h1:QkGAVvCkqDJm9viNdusrO1acDrGuf8poxG6W22mDUEk=
+github.com/RedHatInsights/insights-results-aggregator v1.1.6 h1:hBD2GL841PrsbC8GmbxHuMEg3xYD+AF8afGtXL5hoOc=
+github.com/RedHatInsights/insights-results-aggregator v1.1.6/go.mod h1:FJATJc7d1LzfAQ/0gjC18ZUrUrCxMRsuZCggP6szBgY=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=

--- a/server/acks_handlers.go
+++ b/server/acks_handlers.go
@@ -94,7 +94,7 @@ func (server *HTTPServer) acknowledgePost(writer http.ResponseWriter, request *h
 		Str("errorKey", string(errorKey)).
 		Msg("Parsed rule selector")
 
-	// test if the rule has been acknowledget already
+	// test if the rule has been acknowledged already
 	_, found, err := server.readRuleDisableStatus(ruleID, errorKey, orgID, userID)
 	if err != nil {
 		log.Error().Err(err).Msg("read rule status error")

--- a/server/acks_handlers.go
+++ b/server/acks_handlers.go
@@ -1,0 +1,135 @@
+/*
+Copyright © 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"net/http"
+
+	"github.com/rs/zerolog/log"
+
+	"github.com/RedHatInsights/insights-operator-utils/parsers"
+)
+
+// HTTP response-related constants
+const (
+	contentType = "Content-Type"
+	appJSON     = "application/json; charset=utf-8"
+)
+
+// method acknowledgePost acknowledges (and therefore hides) a rule from view
+// in an account. If there's already an acknowledgement of this rule by this
+// account, then return that. Otherwise, a new ack is created.
+//
+// An example request:
+//
+// {
+//   "rule_id": "string",
+//   "justification": "string"
+// }
+//
+// An example response:
+//
+// {
+//   "rule": "string",
+//   "justification": "string",  <- can not be set by this call!!!
+//   "created_by": "string",
+//   "created_at": "2021-09-04T17:52:48.976Z",
+//   "updated_at": "2021-09-04T17:52:48.976Z"
+// }
+//
+// HTTP/1.1 200 OK is returned if rule has been already acked
+// HTTP/1.1 201 Created is returned if rule has been acked by this call
+func (server *HTTPServer) acknowledgePost(writer http.ResponseWriter, request *http.Request) {
+	const readRuleStatusError = "can not retrieve rule disable status from Aggregator"
+	const readRuleJustificationError = "can not retrieve rule disable justification from Aggregator"
+
+	writer.Header().Set(contentType, appJSON)
+
+	orgID, userID, err := server.readOrgIDAndUserIDFromToken(writer, request)
+	if err != nil {
+		// everything's handled already
+		return
+	}
+
+	parameters, err := readRuleSelectorAndJustificationFromBody(writer, request)
+	if err != nil {
+		// everything's handled already
+		return
+	}
+
+	// we seem to have all data -> let's display them
+	log.Info().
+		Int("org", int(orgID)).
+		Str("account", string(userID)).
+		Str("rule", string(parameters.RuleSelector)).
+		Str("value", parameters.Value).
+		Msg("Proper payload provided")
+
+	// check if rule selector has the proper format
+	ruleID, errorKey, err := parsers.ParseRuleSelector(parameters.RuleSelector)
+	if err != nil {
+		log.Error().Err(err).Msg("improper rule selector format")
+		// return HTTP code 400 to client
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// display parsed rule ID and error key
+	log.Info().
+		Str("ruleID", string(ruleID)).
+		Str("errorKey", string(errorKey)).
+		Msg("Parsed rule selector")
+
+	// test if the rule has been acknowledget already
+	_, found, err := server.readRuleDisableStatus(ruleID, errorKey, orgID, userID)
+	if err != nil {
+		log.Error().Err(err).Msg("read rule status error")
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// if acknowledgement has been found -> return 200 OK with the existing rule ack
+	// if acknowledgement has NOT been found -> return 201 Created with the created rule ack
+	if found {
+		writer.WriteHeader(http.StatusOK)
+		log.Info().Msg("Rule has been already disabled")
+	} else {
+		writer.WriteHeader(http.StatusCreated)
+		log.Info().Msg("Rule has not been disabled previously")
+
+		// acknowledge rule
+		err := server.ackRuleSystemWide(ruleID, errorKey, orgID, userID, parameters.Value)
+		if err != nil {
+			log.Error().Err(err).Msg(readRuleJustificationError)
+			http.Error(writer, err.Error(), http.StatusBadRequest)
+			return
+		}
+	}
+
+	// Aggregator REST API is source of truth - let's re-read rule status
+	// from it
+	updatedAcknowledgement, _, err := server.readRuleDisableStatus(ruleID, errorKey, orgID, userID)
+	if err != nil {
+		log.Error().Err(err).Msg(readRuleJustificationError)
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// we have the metadata about rule, let's send it into client in
+	// response payload
+	returnRuleAckToClient(writer, updatedAcknowledgement)
+}

--- a/server/acks_utils.go
+++ b/server/acks_utils.go
@@ -103,9 +103,18 @@ func (server *HTTPServer) ackRuleSystemWide(
 		ruleID, errorKey, orgID, userID,
 	)
 
-	// call PUT method, provide the required data in payload
+	// generate payload in JSON format
 	jsonReq, err := json.Marshal(j)
+	if err != nil {
+		return err
+	}
+
+	// call PUT method, provide the required data in payload
 	req, err := http.NewRequest(http.MethodPut, aggregatorURL, bytes.NewBuffer(jsonReq))
+	if err != nil {
+		return err
+	}
+
 	req.Header.Set("Content-Type", "application/json; charset=utf-8")
 	client := &http.Client{}
 	response, err := client.Do(req)

--- a/server/acks_utils.go
+++ b/server/acks_utils.go
@@ -1,0 +1,182 @@
+/*
+Copyright © 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+// Helper functions to be called from request handlers defined in the source
+// file acks_handlers.go.
+
+import (
+	"bytes"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/rs/zerolog/log"
+
+	httputils "github.com/RedHatInsights/insights-operator-utils/http"
+	"github.com/RedHatInsights/insights-operator-utils/types"
+	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
+)
+
+// readRuleSelectorAndJustificationFromBody function tries to read data
+// structure types.AcknowledgementRuleSelectorJustification from response
+// payload (body)
+func readRuleSelectorAndJustificationFromBody(writer http.ResponseWriter, request *http.Request) (
+	types.AcknowledgementRuleSelectorJustification, error) {
+
+	// try to read request body
+	var parameters types.AcknowledgementRuleSelectorJustification
+	err := json.NewDecoder(request.Body).Decode(&parameters)
+
+	if err != nil {
+		log.Error().Err(err).Msg("wrong payload provided by client")
+		// return HTTP code 400 to client
+		http.Error(writer, err.Error(), http.StatusBadRequest)
+		return parameters, err
+	}
+
+	// everything seems to be ok
+	return parameters, nil
+}
+
+// readOrgIDAndUserIDFromToken helper method reads organization ID and user ID
+// (account number) from the token
+func (server *HTTPServer) readOrgIDAndUserIDFromToken(writer http.ResponseWriter, request *http.Request) (
+	types.OrgID, types.UserID, error) {
+	// auth. token contains organization ID and user ID we need to use
+	authToken, err := server.GetAuthToken(request)
+	if err != nil {
+		handleServerError(writer, err)
+		return types.OrgID(0), types.UserID(""), err
+	}
+
+	// Organization ID and user ID are to be provided in the token
+	orgID := authToken.Internal.OrgID
+	userID := authToken.AccountNumber
+	return orgID, userID, nil
+}
+
+// returnRuleAckToClient returns information about selected rule ack to client.
+// This function also tries to process all errors.
+func returnRuleAckToClient(writer http.ResponseWriter, ack types.Acknowledgement) {
+	// serialize the above data structure into JSON format
+	bytes, err := json.MarshalIndent(ack, "", "\t")
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+		return
+	}
+
+	// and send the serialized structure to client
+	_, err = writer.Write(bytes)
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+	}
+}
+
+// ackRuleSystemWide method acknowledges rule via Insights Aggregator REST API
+func (server *HTTPServer) ackRuleSystemWide(
+	ruleID types.Component, errorKey types.ErrorKey,
+	orgID types.OrgID, userID types.UserID, justification string) error {
+	var j types.AcknowledgementJustification
+	j.Value = justification
+
+	// try to ack rule via Insights Aggregator REST API
+	aggregatorURL := httputils.MakeURLToEndpoint(
+		server.ServicesConfig.AggregatorBaseEndpoint,
+		ira_server.DisableRuleSystemWide,
+		ruleID, errorKey, orgID, userID,
+	)
+
+	// call PUT method, provide the required data in payload
+	jsonReq, err := json.Marshal(j)
+	req, err := http.NewRequest(http.MethodPut, aggregatorURL, bytes.NewBuffer(jsonReq))
+	req.Header.Set("Content-Type", "application/json; charset=utf-8")
+	client := &http.Client{}
+	response, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	// check the aggregator response
+	if response.StatusCode != http.StatusOK {
+		err := fmt.Errorf("Aggregator responded with improper HTTP code: %v", response.StatusCode)
+		return err
+	}
+
+	return nil
+}
+
+// readRuleDisableStatus method read system-wide rule disable status from
+// Insights Results Aggregator via REST API
+func (server *HTTPServer) readRuleDisableStatus(
+	ruleID types.Component, errorKey types.ErrorKey,
+	orgID types.OrgID, userID types.UserID) (types.Acknowledgement, bool, error) {
+
+	// wont be used anywhere else
+	type responsePayload struct {
+		Status      string                      `json:"status"`
+		RuleDisable types.SystemWideRuleDisable `json:"disabledRule"`
+	}
+
+	var acknowledgement types.Acknowledgement
+
+	// try to read rule disable status from aggregator
+	aggregatorURL := httputils.MakeURLToEndpoint(
+		server.ServicesConfig.AggregatorBaseEndpoint,
+		ira_server.ReadRuleSystemWide,
+		ruleID, errorKey, orgID, userID,
+	)
+
+	// #nosec G107
+	response, err := http.Get(aggregatorURL)
+	if err != nil {
+		return acknowledgement, false, err
+	}
+
+	// check the aggregator response
+	if response.StatusCode != http.StatusOK && response.StatusCode != http.StatusNotFound {
+		err := fmt.Errorf("Aggregator responded with improper HTTP code: %v", response.StatusCode)
+		return acknowledgement, false, err
+	}
+
+	var payload responsePayload
+
+	err = json.NewDecoder(response.Body).Decode(&payload)
+	if err != nil {
+		return acknowledgement, false, err
+	}
+
+	acknowledgement.Rule = string(payload.RuleDisable.RuleID) + "|" + string(payload.RuleDisable.ErrorKey)
+	acknowledgement.Justification = payload.RuleDisable.Justification
+	acknowledgement.CreatedBy = string(payload.RuleDisable.UserID)
+	acknowledgement.CreatedAt = formatNullTime(payload.RuleDisable.CreatedAt)
+	acknowledgement.UpdatedAt = formatNullTime(payload.RuleDisable.UpdatedAT)
+
+	acknowledgementFound := response.StatusCode == http.StatusOK
+	return acknowledgement, acknowledgementFound, nil
+}
+
+// format sql.NullTime value accordingly
+// TODO: move to utils repository as usual
+func formatNullTime(t sql.NullTime) string {
+	if !t.Valid {
+		return ""
+	}
+	return t.Time.Format(time.RFC3339)
+}

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -246,6 +246,47 @@
         "description": "The static content is taken from the cache periodically updated from the content service"
       }
     },
+    "/ack": {
+      "post": {
+        "operationId": "ackRuleSystemWide",
+        "summary": "Acknowledges/hide the rule for given account",
+        "description": "Acknowledges (and therefore hides) a rule from view in an account. If there's already an acknowledgement of this rule by this account, then return that. Othervise, a new ack is created.",
+        "tags": [
+          "prod"
+        ],
+        "requestBody": {
+          "description": "Specification of rule selector (ID+error key) and a justification why rule has been disabled.",
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/overview_response"
+                }
+              }
+            },
+            "description": "Rule has been disabled already"
+          },
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/systemWideRuleDisable"
+                }
+              }
+            },
+            "description": "Rule has been acked (disabled)"
+          }
+        }
+      }
+    },
     "/rule/{ruleId}": {
       "get": {
         "tags": [
@@ -546,6 +587,44 @@
           "status": {
             "description": "",
             "type": "string"
+          }
+        }
+      },
+      "systemWideRuleDisable": {
+        "description": "An information about rule that has been disabled for whole account",
+        "type": "object",
+        "properties": {
+          "status": {
+            "description": "Information about the operation status",
+            "type": "string",
+            "example": "ok"
+          },
+          "rule": {
+            "type": "string",
+            "description": "Rule selector: rule ID + error key",
+            "example": "foo.bar|baz"
+          },
+          "justification": {
+            "type": "string",
+            "description": "Justification (message) provided by user",
+            "example": "I don't like this rule!"
+          },
+          "created_by": {
+            "type": "string",
+            "description": "ID of user (account)",
+            "example": "42"
+          },
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the rule has been acked/disabled",
+            "example": "2021-09-05T16:29:33+02:00"
+          },
+          "updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp when the rule justification has been changed (can be empty)",
+            "example": "2021-09-05T16:29:33+02:00"
           }
         }
       },

--- a/server/endpoints_v2.go
+++ b/server/endpoints_v2.go
@@ -37,6 +37,15 @@ const (
 
 	// ContentV2 returns all the static content avaiable for the user
 	ContentV2 = "content"
+
+	// Endpoints to acknowledge rule and to manipulate with
+	// acknowledgements.
+
+	// AckAcknowledgePostEndpoint acknowledges (and therefore hides) a rule
+	// from view in an account. If there's already an acknowledgement of
+	// this rule by this account, then return that. Otherwise, a new ack is
+	// created.
+	AckAcknowledgePostEndpoint = "ack"
 )
 
 // addV2EndpointsToRouter adds API V2 specific endpoints to the router
@@ -76,7 +85,10 @@ func (server *HTTPServer) addV2ReportsEndpointsToRouter(router *mux.Router, apiP
 // addV2RuleEndpointsToRouter method registers handlers for endpoints that handle
 // rule-related operations (voting etc.)
 func (server *HTTPServer) addV2RuleEndpointsToRouter(router *mux.Router, apiPrefix string, aggregatorBaseEndpoint string) {
-	return
+	// Acknowledgement-related endpoints. Please look into acks_handlers.go
+	// and acks_utils.go for more information about these endpoints
+	// prepared to be compatible with RHEL Insights Advisor.
+	router.HandleFunc(apiPrefix+AckAcknowledgePostEndpoint, server.acknowledgePost).Methods(http.MethodPost)
 }
 
 // addV2ContentEndpointsToRouter method registers handlers for endpoints that


### PR DESCRIPTION
# Description

The first (of five) new `ack` endpoints implementation. This one is used to "ack" a rule. If the rule is already acked, different HTTP code is returned:

#### Ack new rule

Request to the service:

```
curl -v -X POST -H "Content-Type: application/json" --data '{"rule_id":"foo|bar", "justification":"xyzzy"}' "localhost:8080/api//v2/ack"
```

Response from the service:

```
< HTTP/1.1 201 Created
< Content-Type: application/json; charset=utf-8
< Date: Sun, 05 Sep 2021 14:29:33 GMT
< Content-Length: 168
< 
{
        "rule": "foo|bar",
        "justification": "xyzzy",
        "created_by": "onlineTester",
        "created_at": "2021-09-05T16:29:33+02:00",
        "updated_at": "2021-09-05T16:29:33+02:00"
}
```

#### Ack existing rule

Request to the service:

```
curl -v -X POST -H "Content-Type: application/json" --data '{"rule_id":"existing|rule", "justification":"xyzzy"}' "localhost:8080/api/v2/ack"
```

Response from the service:

```
< HTTP/1.1 200 OK
< Content-Type: application/json; charset=utf-8
< Date: Sun, 05 Sep 2021 14:35:51 GMT
< Content-Length: 168
< 
{
        "rule": "foo|bar",
        "justification": "xyzzy",
        "created_by": "onlineTester",
        "created_at": "2021-09-05T16:35:25+02:00",
        "updated_at": "2021-09-05T16:35:25+02:00"
}

```


Please note that `acks_utils.go` source file might look complicated, but these functions and method will be reused later.

Additionally, there are not unit tests prepared yet, as our "unit test framework" needs some improvements:

https://github.com/RedHatInsights/insights-results-smart-proxy/issues/638
https://github.com/RedHatInsights/insights-results-smart-proxy/issues/639

Also there's TODO to be done later (as we don't want to slow front-end work):
https://github.com/RedHatInsights/insights-results-smart-proxy/issues/640

## Type of change

- New feature (non-breaking change which adds functionality)
- Bump-up dependent library (no changes in the code)

## Testing steps

N/A at this moment, but can be tested against running Insights Results Aggregator (already performed of course)

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
