### PR TITLE
Read already acked rule via Aggregator's REST API

### DIFF
--- a/server/acks_handlers.go
+++ b/server/acks_handlers.go
@@ -30,7 +30,9 @@ const (
 	contentType = "Content-Type"
 	appJSON     = "application/json; charset=utf-8"
 
-	authTokenFormatError = "unable to read orgID and userID from auth. token!"
+	authTokenFormatError       = "unable to read orgID and userID from auth. token!"
+	improperRuleSelectorFormat = "improper rule selector format"
+	readRuleStatusError        = "read rule status error"
 )
 
 // method getAcknowledge retrieves the info about rule acknowledgement made
@@ -58,23 +60,18 @@ func (server *HTTPServer) getAcknowledge(writer http.ResponseWriter, request *ht
 
 	ruleID, errorKey, err := readRuleIDWithErrorKey(writer, request)
 	if err != nil {
-		log.Error().Err(err).Msg("improper rule selector format")
+		log.Error().Err(err).Msg(improperRuleSelectorFormat)
 		// server error has been handled already
 		return
 	}
 
 	// we seem to have all data -> let's display them
-	log.Info().
-		Int("org", int(orgID)).
-		Str("account", string(userID)).
-		Str("ruleID", string(ruleID)).
-		Str("errorKey", string(errorKey)).
-		Msg("Selector for acknowledged rule query")
+	logFullRuleSelector(orgID, userID, ruleID, errorKey)
 
 	// test if the rule has been acknowledged already
 	ruleAck, found, err := server.readRuleDisableStatus(types.Component(ruleID), errorKey, orgID, userID)
 	if err != nil {
-		log.Error().Err(err).Msg("read rule status error")
+		log.Error().Err(err).Msg(readRuleStatusError)
 		http.Error(writer, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -143,7 +140,7 @@ func (server *HTTPServer) acknowledgePost(writer http.ResponseWriter, request *h
 	// check if rule selector has the proper format
 	ruleID, errorKey, err := parsers.ParseRuleSelector(parameters.RuleSelector)
 	if err != nil {
-		log.Error().Err(err).Msg("improper rule selector format")
+		log.Error().Err(err).Msg(improperRuleSelectorFormat)
 		// return HTTP code 400 to client
 		http.Error(writer, err.Error(), http.StatusBadRequest)
 		return
@@ -158,7 +155,7 @@ func (server *HTTPServer) acknowledgePost(writer http.ResponseWriter, request *h
 	// test if the rule has been acknowledged already
 	_, found, err := server.readRuleDisableStatus(ruleID, errorKey, orgID, userID)
 	if err != nil {
-		log.Error().Err(err).Msg("read rule status error")
+		log.Error().Err(err).Msg(readRuleStatusError)
 		http.Error(writer, err.Error(), http.StatusBadRequest)
 		return
 	}
@@ -208,23 +205,18 @@ func (server *HTTPServer) deleteAcknowledge(writer http.ResponseWriter, request 
 
 	ruleID, errorKey, err := readRuleIDWithErrorKey(writer, request)
 	if err != nil {
-		log.Error().Err(err).Msg("improper rule selector format")
+		log.Error().Err(err).Msg(improperRuleSelectorFormat)
 		// server error has been handled already
 		return
 	}
 
 	// we seem to have all data -> let's display them
-	log.Info().
-		Int("org", int(orgID)).
-		Str("account", string(userID)).
-		Str("ruleID", string(ruleID)).
-		Str("errorKey", string(errorKey)).
-		Msg("Proper rule selector provided")
+	logFullRuleSelector(orgID, userID, ruleID, errorKey)
 
 	// test if the rule has been acknowledged already
 	_, found, err := server.readRuleDisableStatus(types.Component(ruleID), errorKey, orgID, userID)
 	if err != nil {
-		log.Error().Err(err).Msg("read rule status error")
+		log.Error().Err(err).Msg(readRuleStatusError)
 		http.Error(writer, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/server/acks_utils.go
+++ b/server/acks_utils.go
@@ -226,3 +226,13 @@ func formatNullTime(t sql.NullTime) string {
 	}
 	return t.Time.Format(time.RFC3339)
 }
+
+func logFullRuleSelector(orgID types.OrgID, userID types.UserID,
+	ruleID types.RuleID, errorKey types.ErrorKey) {
+	log.Info().
+		Int("org", int(orgID)).
+		Str("account", string(userID)).
+		Str("ruleID", string(ruleID)).
+		Str("errorKey", string(errorKey)).
+		Msg("Selector for rule acknowledgement")
+}

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -288,6 +288,41 @@
       }
     },
     "/ack/{rule_id}": {
+      "get": {
+        "operationId": "getAckRuleSystemWide",
+        "summary": "AckGetEndpoint read the acknowledgement info about disabled rule",
+        "description": "AckGetEndpoint read the acknowledgement info about disabled rule",
+        "tags": [
+          "prod"
+        ],
+        "parameters": [
+          {
+            "name": "rule_id",
+            "description": "Specification of rule selector (ID+error key) and a justification why rule has been disabled.",
+            "schema": {
+              "type": "string",
+              "example": "some.python.module|error_key"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/systemWideRuleDisable"
+                }
+              }
+            },
+            "description": "Rule ack has been found, the metadata is returned in response body"
+          },
+          "404": {
+            "description": "Rule has not been acked (disabled) previously"
+          }
+        }
+      },
       "delete": {
         "operationId": "deleteAckRuleSystemWide",
         "summary": "Deletes an acknowledgement for a rule",

--- a/server/endpoints_v2.go
+++ b/server/endpoints_v2.go
@@ -41,6 +41,11 @@ const (
 	// Endpoints to acknowledge rule and to manipulate with
 	// acknowledgements.
 
+	// AckGetEndpoint read the acknowledgement info about disabled rule.
+	// Acks are created, deleted, and queried by Insights rule ID, not
+	// by their own ack ID.
+	AckGetEndpoint = "ack/{rule_id}"
+
 	// AckAcknowledgePostEndpoint acknowledges (and therefore hides) a rule
 	// from view in an account. If there's already an acknowledgement of
 	// this rule by this account, then return that. Otherwise, a new ack is
@@ -93,6 +98,7 @@ func (server *HTTPServer) addV2RuleEndpointsToRouter(router *mux.Router, apiPref
 	// Acknowledgement-related endpoints. Please look into acks_handlers.go
 	// and acks_utils.go for more information about these endpoints
 	// prepared to be compatible with RHEL Insights Advisor.
+	router.HandleFunc(apiPrefix+AckGetEndpoint, server.getAcknowledge).Methods(http.MethodGet)
 	router.HandleFunc(apiPrefix+AckAcknowledgePostEndpoint, server.acknowledgePost).Methods(http.MethodPost)
 	router.HandleFunc(apiPrefix+AckDeleteEndpoint, server.deleteAcknowledge).Methods(http.MethodDelete)
 }


### PR DESCRIPTION
# Description

Read already acked rule via Aggregator's REST API

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
