### PR TITLE
Use internal tools for mocking instead Gock requests

### DIFF
--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	"github.com/RedHatInsights/insights-operator-utils/responses"
 	"github.com/RedHatInsights/insights-operator-utils/types"
@@ -49,13 +48,6 @@ var (
 		},
 	}
 )
-
-// timeToBreathe make sure the content-servicing goroutine is cleaned up (it
-// would be better to use some form of better synchronization, but it will need
-// code change just for the sake of unit tests).
-func timeToBreathe() {
-	time.Sleep(2 * time.Second)
-}
 
 // TODO: test more cases for report endpoint
 func TestHTTPServer_ReportEndpoint(t *testing.T) {

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -87,7 +87,6 @@ func TestHTTPServer_ReportEndpoint(t *testing.T) {
 
 // Reproducer for Bug 1977858
 func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
-	timeToBreathe()
 	loadMockRuleContentDir(testdata.RuleContentDirectory3Rules)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -20,15 +20,12 @@ import (
 	"testing"
 	"time"
 
-	ics_server "github.com/RedHatInsights/insights-content-service/server"
 	"github.com/RedHatInsights/insights-operator-utils/responses"
 	"github.com/RedHatInsights/insights-operator-utils/types"
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
 	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
 
-	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
-	"github.com/RedHatInsights/insights-results-smart-proxy/services"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
 	data "github.com/RedHatInsights/insights-results-smart-proxy/tests/testdata"
 )
@@ -53,10 +50,6 @@ var (
 	}
 )
 
-func startUpdateContentLoop(servicesConf services.Configuration) {
-	go content.RunUpdateContentLoop(helpers.DefaultServicesConfig)
-}
-
 // timeToBreathe make sure the content-servicing goroutine is cleaned up (it
 // would be better to use some form of better synchronization, but it will need
 // code change just for the sake of unit tests).
@@ -66,7 +59,8 @@ func timeToBreathe() {
 
 // TODO: test more cases for report endpoint
 func TestHTTPServer_ReportEndpoint(t *testing.T) {
-	timeToBreathe()
+	loadMockRuleContentDir(testdata.RuleContentDirectory3Rules)
+
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
@@ -77,17 +71,6 @@ func TestHTTPServer_ReportEndpoint(t *testing.T) {
 			StatusCode: http.StatusOK,
 			Body:       testdata.Report3RulesExpectedResponse,
 		})
-
-		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.ContentBaseEndpoint, &helpers.APIRequest{
-			Method:   http.MethodGet,
-			Endpoint: ics_server.AllContentEndpoint,
-		}, &helpers.APIResponse{
-			StatusCode: http.StatusOK,
-			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
-		})
-
-		startUpdateContentLoop(helpers.DefaultServicesConfig)
-		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
 			Method:       http.MethodGet,
@@ -105,6 +88,7 @@ func TestHTTPServer_ReportEndpoint(t *testing.T) {
 // Reproducer for Bug 1977858
 func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
 	timeToBreathe()
+	loadMockRuleContentDir(testdata.RuleContentDirectory3Rules)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -116,18 +100,6 @@ func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
 			StatusCode: http.StatusOK,
 			Body:       testdata.Report1RuleExpectedResponse,
 		})
-
-		// content-service responses with 3 rules
-		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.ContentBaseEndpoint, &helpers.APIRequest{
-			Method:   http.MethodGet,
-			Endpoint: ics_server.AllContentEndpoint,
-		}, &helpers.APIResponse{
-			StatusCode: http.StatusOK,
-			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
-		})
-
-		startUpdateContentLoop(helpers.DefaultServicesConfig)
-		defer content.StopUpdateContentLoop()
 
 		// previously was InternalServerError, but it was changed as an edge-case which will appear as "No issues found"
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
@@ -145,8 +117,7 @@ func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
 
 // Reproducer for Bug 1977858
 func TestHTTPServer_ReportEndpointNoContentFor2Rules(t *testing.T) {
-	timeToBreathe()
-	content.ResetContent()
+	loadMockRuleContentDir(RuleContentDirectoryOnly1Rule)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -158,18 +129,6 @@ func TestHTTPServer_ReportEndpointNoContentFor2Rules(t *testing.T) {
 			StatusCode: http.StatusOK,
 			Body:       testdata.Report3RulesExpectedResponse,
 		})
-
-		// content-service responses with only 1 rule
-		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.ContentBaseEndpoint, &helpers.APIRequest{
-			Method:   http.MethodGet,
-			Endpoint: ics_server.AllContentEndpoint,
-		}, &helpers.APIResponse{
-			StatusCode: http.StatusOK,
-			Body:       helpers.MustGobSerialize(t, RuleContentDirectoryOnly1Rule),
-		})
-
-		startUpdateContentLoop(helpers.DefaultServicesConfig)
-		defer content.StopUpdateContentLoop()
 
 		// 1 rule returned, but count = 3
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
@@ -186,7 +145,7 @@ func TestHTTPServer_ReportEndpointNoContentFor2Rules(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpoint_WithOnlyOSDEndpoint(t *testing.T) {
-	timeToBreathe()
+	loadMockRuleContentDir(testdata.RuleContentDirectory3Rules)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -198,17 +157,6 @@ func TestHTTPServer_ReportEndpoint_WithOnlyOSDEndpoint(t *testing.T) {
 			StatusCode: http.StatusOK,
 			Body:       testdata.Report3RulesExpectedResponse,
 		})
-
-		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.ContentBaseEndpoint, &helpers.APIRequest{
-			Method:   http.MethodGet,
-			Endpoint: ics_server.AllContentEndpoint,
-		}, &helpers.APIResponse{
-			StatusCode: http.StatusOK,
-			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
-		})
-
-		startUpdateContentLoop(helpers.DefaultServicesConfig)
-		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
 			Method:       http.MethodGet,
@@ -224,7 +172,7 @@ func TestHTTPServer_ReportEndpoint_WithOnlyOSDEndpoint(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpoint_WithDisabledRules(t *testing.T) {
-	timeToBreathe()
+	loadMockRuleContentDir(testdata.RuleContentDirectory5Rules)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -256,17 +204,6 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRules(t *testing.T) {
 			StatusCode: http.StatusOK,
 			Body:       testdata.Report3Rules1DisabledExpectedResponse,
 		})
-
-		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.ContentBaseEndpoint, &helpers.APIRequest{
-			Method:   http.MethodGet,
-			Endpoint: ics_server.AllContentEndpoint,
-		}, &helpers.APIResponse{
-			StatusCode: http.StatusOK,
-			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory5Rules),
-		})
-
-		startUpdateContentLoop(helpers.DefaultServicesConfig)
-		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
 			Method:       http.MethodGet,
@@ -306,8 +243,7 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRules(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpoint_WithDisabledRulesAndMissingContent(t *testing.T) {
-	timeToBreathe()
-	content.ResetContent()
+	loadMockRuleContentDir(RuleContentDirectoryOnlyDisabledRule)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -319,17 +255,6 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRulesAndMissingContent(t *testing
 			StatusCode: http.StatusOK,
 			Body:       testdata.Report3Rules1DisabledExpectedResponse,
 		})
-
-		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.ContentBaseEndpoint, &helpers.APIRequest{
-			Method:   http.MethodGet,
-			Endpoint: ics_server.AllContentEndpoint,
-		}, &helpers.APIResponse{
-			StatusCode: http.StatusOK,
-			Body:       helpers.MustGobSerialize(t, RuleContentDirectoryOnlyDisabledRule),
-		})
-
-		startUpdateContentLoop(helpers.DefaultServicesConfig)
-		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
 			Method:       http.MethodGet,
@@ -346,7 +271,7 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRulesAndMissingContent(t *testing
 
 // TODO: test more cases for rule endpoint
 func TestHTTPServer_RuleEndpoint(t *testing.T) {
-	timeToBreathe()
+	loadMockRuleContentDir(testdata.RuleContentDirectory3Rules)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -363,17 +288,6 @@ func TestHTTPServer_RuleEndpoint(t *testing.T) {
 			StatusCode: http.StatusOK,
 			Body:       testdata.Report3SingleRuleExpectedResponse,
 		})
-
-		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.ContentBaseEndpoint, &helpers.APIRequest{
-			Method:   http.MethodGet,
-			Endpoint: ics_server.AllContentEndpoint,
-		}, &helpers.APIResponse{
-			StatusCode: http.StatusOK,
-			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
-		})
-
-		startUpdateContentLoop(helpers.DefaultServicesConfig)
-		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
 			Method:       http.MethodGet,
@@ -389,7 +303,7 @@ func TestHTTPServer_RuleEndpoint(t *testing.T) {
 }
 
 func TestHTTPServer_RuleEndpoint_WithOSD(t *testing.T) {
-	timeToBreathe()
+	loadMockRuleContentDir(testdata.RuleContentDirectory3Rules)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -407,17 +321,6 @@ func TestHTTPServer_RuleEndpoint_WithOSD(t *testing.T) {
 			Body:       testdata.Report3SingleRuleExpectedResponse,
 		})
 
-		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.ContentBaseEndpoint, &helpers.APIRequest{
-			Method:   http.MethodGet,
-			Endpoint: ics_server.AllContentEndpoint,
-		}, &helpers.APIResponse{
-			StatusCode: http.StatusOK,
-			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
-		})
-
-		startUpdateContentLoop(helpers.DefaultServicesConfig)
-		defer content.StopUpdateContentLoop()
-
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
 			Method:       http.MethodGet,
 			Endpoint:     server.SingleRuleEndpoint + "?" + server.OSDEligibleParam + "=true",
@@ -432,7 +335,7 @@ func TestHTTPServer_RuleEndpoint_WithOSD(t *testing.T) {
 }
 
 func TestHTTPServer_RuleEndpoint_WithNotOSDRule(t *testing.T) {
-	timeToBreathe()
+	loadMockRuleContentDir(testdata.RuleContentDirectory3Rules)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -450,17 +353,6 @@ func TestHTTPServer_RuleEndpoint_WithNotOSDRule(t *testing.T) {
 			Body:       testdata.Report3SingleRule2ExpectedResponse,
 		})
 
-		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.ContentBaseEndpoint, &helpers.APIRequest{
-			Method:   http.MethodGet,
-			Endpoint: ics_server.AllContentEndpoint,
-		}, &helpers.APIResponse{
-			StatusCode: http.StatusOK,
-			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
-		})
-
-		startUpdateContentLoop(helpers.DefaultServicesConfig)
-		defer content.StopUpdateContentLoop()
-
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
 			Method:       http.MethodGet,
 			Endpoint:     server.SingleRuleEndpoint + "?" + server.OSDEligibleParam + "=true",
@@ -476,22 +368,9 @@ func TestHTTPServer_RuleEndpoint_WithNotOSDRule(t *testing.T) {
 
 // TestHTTPServer_GetContent
 func TestHTTPServer_GetContent(t *testing.T) {
-	timeToBreathe()
-	content.ResetContent()
+	loadMockRuleContentDir(testdata.RuleContentDirectory3Rules)
+
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
-		defer helpers.CleanAfterGock(t)
-		// Setup Content
-		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.ContentBaseEndpoint, &helpers.APIRequest{
-			Method:   http.MethodGet,
-			Endpoint: ics_server.AllContentEndpoint,
-		}, &helpers.APIResponse{
-			StatusCode: http.StatusOK,
-			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
-		})
-
-		startUpdateContentLoop(helpers.DefaultServicesConfig)
-		defer content.StopUpdateContentLoop()
-
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
 			Method:   http.MethodGet,
 			Endpoint: server.Content,
@@ -506,18 +385,9 @@ func TestHTTPServer_GetContent(t *testing.T) {
 
 // TestHTTPServer_OverviewEndpoint
 func TestHTTPServer_OverviewEndpoint(t *testing.T) {
-	timeToBreathe()
+	loadMockRuleContentDir(testdata.RuleContentDirectory3Rules)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
-
-		// prepare content
-		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.ContentBaseEndpoint, &helpers.APIRequest{
-			Method:   http.MethodGet,
-			Endpoint: ics_server.AllContentEndpoint,
-		}, &helpers.APIResponse{
-			StatusCode: http.StatusOK,
-			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
-		})
 
 		// prepare list of organizations response
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
@@ -539,9 +409,6 @@ func TestHTTPServer_OverviewEndpoint(t *testing.T) {
 			Body:       testdata.Report3RulesExpectedResponse,
 		})
 
-		startUpdateContentLoop(helpers.DefaultServicesConfig)
-		defer content.StopUpdateContentLoop()
-
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
 			Method:   http.MethodGet,
 			Endpoint: server.OverviewEndpoint,
@@ -555,7 +422,11 @@ func TestHTTPServer_OverviewEndpoint(t *testing.T) {
 }
 
 func TestInternalOrganizations(t *testing.T) {
-	loadMockRuleContentDir([]types.RuleContent{RuleContentInternal1})
+	loadMockRuleContentDir(
+		createRuleContentDirectoryFromRuleContent(
+			[]types.RuleContent{RuleContentInternal1},
+		),
+	)
 
 	for _, testCase := range []struct {
 		TestName           string
@@ -634,8 +505,11 @@ func TestRuleNames(t *testing.T) {
 
 // TestRuleNamesResponse checks the REST API status and response
 func TestRuleNamesResponse(t *testing.T) {
-	content.ResetContent()
-	loadMockRuleContentDir([]types.RuleContent{RuleContentInternal1, testdata.RuleContent1})
+	loadMockRuleContentDir(
+		createRuleContentDirectoryFromRuleContent(
+			[]types.RuleContent{RuleContentInternal1, testdata.RuleContent1},
+		),
+	)
 
 	expectedBody := `
 		{
@@ -675,18 +549,9 @@ func TestRuleNamesResponse(t *testing.T) {
 
 // TestHTTPServer_OverviewWithClusterIDsEndpoint
 func TestHTTPServer_OverviewWithClusterIDsEndpoint(t *testing.T) {
-	timeToBreathe()
+	loadMockRuleContentDir(testdata.RuleContentDirectory3Rules)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
-
-		// prepare content
-		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.ContentBaseEndpoint, &helpers.APIRequest{
-			Method:   http.MethodGet,
-			Endpoint: ics_server.AllContentEndpoint,
-		}, &helpers.APIResponse{
-			StatusCode: http.StatusOK,
-			Body:       helpers.MustGobSerialize(t, testdata.RuleContentDirectory3Rules),
-		})
 
 		// prepare reports reponse
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
@@ -700,9 +565,6 @@ func TestHTTPServer_OverviewWithClusterIDsEndpoint(t *testing.T) {
 				Body:       helpers.ToJSONString(data.AggregatorReportForClusterList),
 			},
 		)
-
-		startUpdateContentLoop(helpers.DefaultServicesConfig)
-		defer content.StopUpdateContentLoop()
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, &helpers.APIRequest{
 			Method:   http.MethodPost,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -486,7 +486,7 @@ func calculateTotalRisk(impact, likelihood int) int {
 	return (impact + likelihood) / 2
 }
 
-func loadMockRuleContentDir(rulesContent []iou_types.RuleContent) {
+func createRuleContentDirectoryFromRuleContent(rulesContent []iou_types.RuleContent) iou_types.RuleContentDirectory {
 	rules := make(map[string]iou_types.RuleContent)
 
 	for index, rule := range rulesContent {
@@ -499,9 +499,14 @@ func loadMockRuleContentDir(rulesContent []iou_types.RuleContent) {
 		},
 		Rules: rules,
 	}
+	return ruleContentDirectory
+}
 
-	content.LoadRuleContent(&ruleContentDirectory)
+func loadMockRuleContentDir(ruleContentDir iou_types.RuleContentDirectory) {
+	content.SetRuleContentDirectory(&ruleContentDir)
 	content.WaitForContentDirectoryToBeReady()
+	content.ResetContent()
+	content.LoadRuleContent(&ruleContentDir)
 }
 
 func init() {


### PR DESCRIPTION
# Description

From some time ago, the unit tests are suffering from race conditions, unwanted waiting times and difficult content mocking for develop our endpoint tests. This PR tries to reduce that technical debt and increase the speed when running our unit tests (very annoying issue when trying locally)

Fixes #650 

## Type of change
- Bug fix (non-breaking change which fixes an issue)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Regular CI

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
