### PR TITLE
Bump-up utils version to 1.21.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20210614100534-366b353ab4be
-	github.com/RedHatInsights/insights-operator-utils v1.19.2
+	github.com/RedHatInsights/insights-operator-utils v1.21.1
 	github.com/RedHatInsights/insights-results-aggregator v1.1.6
 	github.com/RedHatInsights/insights-results-aggregator-data v1.1.2
 	github.com/aws/aws-sdk-go v1.38.9 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.15
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20210614100534-366b353ab4be
-	github.com/RedHatInsights/insights-operator-utils v1.21.1
+	github.com/RedHatInsights/insights-operator-utils v1.21.0
 	github.com/RedHatInsights/insights-results-aggregator v1.1.6
 	github.com/RedHatInsights/insights-results-aggregator-data v1.1.2
 	github.com/aws/aws-sdk-go v1.38.9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -51,6 +51,8 @@ github.com/RedHatInsights/insights-operator-utils v1.18.0 h1:sGzvXitvVChwVE8G/hJ
 github.com/RedHatInsights/insights-operator-utils v1.18.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-operator-utils v1.19.2 h1:tJ6DHdNJMUorQf4R1hd0eZVS/wADYI/HixsSVA2kCxM=
 github.com/RedHatInsights/insights-operator-utils v1.19.2/go.mod h1:B2hizFGwXCc8MT34QqVJ1A8ANTyGQZQWXQw/gSCEsaU=
+github.com/RedHatInsights/insights-operator-utils v1.21.0 h1:P688UpKrbLJ5pbLj0j3qRanROPl/eKv4ieFm7UyUSB4=
+github.com/RedHatInsights/insights-operator-utils v1.21.0/go.mod h1:B2hizFGwXCc8MT34QqVJ1A8ANTyGQZQWXQw/gSCEsaU=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator v1.1.6 h1:hBD2GL841PrsbC8GmbxHuMEg3xYD+AF8afGtXL5hoOc=
 github.com/RedHatInsights/insights-results-aggregator v1.1.6/go.mod h1:FJATJc7d1LzfAQ/0gjC18ZUrUrCxMRsuZCggP6szBgY=


### PR DESCRIPTION
# Description

Bump-up `utils` version to 1.21.0

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

Done on CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
