### PR TITLE
Fix on fix: openapi v2 should be accesible without auth

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -33,6 +33,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+
 	// we just have to import this package in order to expose pprof
 	// interface in debug mode
 	// disable "G108 (CWE-): Profiling endpoint is automatically exposed on /debug/pprof"
@@ -134,7 +135,7 @@ func (server *HTTPServer) Initialize() http.Handler {
 
 	metricsURL := apiPrefix + MetricsEndpoint
 	openAPIv1URL := apiPrefix + filepath.Base(server.Config.APIv1SpecFile)
-	openAPIv2URL := apiPrefix + filepath.Base(server.Config.APIv2SpecFile)
+	openAPIv2URL := server.Config.APIv2Prefix + filepath.Base(server.Config.APIv2SpecFile)
 
 	// enable authentication, but only if it is setup in configuration
 	if server.Config.Auth {


### PR DESCRIPTION
# Description

OpenAPI v2 specification is on a different path from the one expected to avoid authentication mechanisms. Fixing it to make it publicly available.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Regular CI

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [ x added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
