### PR TITLE
change behaviour of impacting param on GET /rule/

### DIFF
--- a/docs/rest_api.md
+++ b/docs/rest_api.md
@@ -6,7 +6,7 @@ nav_order: 3
 
 The API is currently split into two versions, see the [corresponding README](https://github.com/RedHatInsights/insights-results-smart-proxy/blob/master/server/api/README.md) for more info.
 Aggregator service provides information about its REST API schema via endpoint
-`api/v1/openapi.json` and `api/v1/openapi.json` respectively.
+`api/v1/openapi.json` and `api/v2/openapi.json` respectively.
 OpenAPI 3.0 is used to describe the schema; it can be read by human and consumed
 by computers.
 

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -586,11 +586,10 @@
         "parameters": [
           {
             "name": "impacting",
-            "description": "If set to false, endpoint will return all available rules including those that don't hit any clusters at the moment.",
+            "description": "If param is missing, endpoint will return all available rules including those that don't hit any clusters at the moment. If set to true, only returns impacting rules. If false, only returns those that aren't imapcting.",
             "in": "query",
             "schema": {
-              "type": "boolean",
-              "default": true
+              "type": "boolean"
             },
             "required": false
           }

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -586,7 +586,7 @@
         "parameters": [
           {
             "name": "impacting",
-            "description": "If param is missing, endpoint will return all available rules including those that don't hit any clusters at the moment. If set to true, only returns impacting rules. If false, only returns those that aren't imapcting.",
+            "description": "If param is missing, endpoint will return all available rules including those that don't hit any clusters at the moment. If set to true, only returns impacting rules. If false, only returns those that aren't impacting.",
             "in": "query",
             "schema": {
               "type": "boolean"

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -771,8 +771,8 @@ func TestHTTPServer_OverviewWithClusterIDsEndpoint_UnavailableContentService(t *
 	}, testTimeout)
 }
 
-// TestHTTPServer_RecommendationsListEndpoint2Rules
-func TestHTTPServer_RecommendationsListEndpoint2Rules(t *testing.T) {
+// TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing
+func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing(t *testing.T) {
 	defer content.ResetContent()
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
@@ -996,7 +996,7 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 
 		helpers.AssertAPIv2Request(t, &serverConfigJWT, nil, nil, nil, nil, &helpers.APIRequest{
 			Method:             http.MethodGet,
-			Endpoint:           server.RecommendationsListEndpoint,
+			Endpoint:           server.RecommendationsListEndpoint + "?" + server.ImpactingParam + "=true",
 			AuthorizationToken: goodJWTAuthBearer,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
@@ -1058,6 +1058,133 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 		}, &helpers.APIResponse{
 			StatusCode:  http.StatusOK,
 			Body:        helpers.ToJSONString(GetRecommendationsResponse2Rules0Clusters),
+			BodyChecker: recommendationInResponseChecker,
+		})
+	}, testTimeout)
+}
+
+// TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_ImpactingFalse
+func TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_ImpactingMissing(t *testing.T) {
+	defer content.ResetContent()
+	err := loadMockRuleContentDir(
+		createRuleContentDirectoryFromRuleContent(
+			[]types.RuleContent{testdata.RuleContent1, RuleContentInternal1},
+		),
+	)
+	assert.Nil(t, err)
+
+	helpers.RunTestWithTimeout(t, func(t testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		clusterList := make([]types.ClusterName, 2)
+		for i := range clusterList {
+			clusterList[i] = testdata.GetRandomClusterID()
+		}
+
+		reqBody, _ := json.Marshal(clusterList)
+
+		respBody := `{"recommendations":{"%v":%v},"status":"ok"}`
+		respBody = fmt.Sprintf(respBody,
+			testdata.Rule1CompositeID, 2,
+		)
+
+		// prepare response from aggregator for list of clusters
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ClustersForOrganizationEndpoint,
+			EndpointArgs: []interface{}{testdata.OrgID},
+		}, &helpers.APIResponse{
+			StatusCode: http.StatusOK,
+			Body:       helpers.ToJSONString(responses.BuildOkResponseWithData("clusters", clusterList)),
+		})
+
+		// prepare response from aggregator for recommendations
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+			&helpers.APIRequest{
+				Method:       http.MethodPost,
+				Endpoint:     ira_server.RecommendationsListEndpoint,
+				EndpointArgs: []interface{}{testdata.OrgID, userIDOnGoodJWTAuthBearer},
+				Body:         reqBody,
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       respBody,
+			},
+		)
+
+		helpers.AssertAPIv2Request(t, &serverConfigJWT, nil, nil, nil, nil, &helpers.APIRequest{
+			Method:             http.MethodGet,
+			Endpoint:           server.RecommendationsListEndpoint,
+			AuthorizationToken: goodJWTAuthBearer,
+		}, &helpers.APIResponse{
+			StatusCode:  http.StatusOK,
+			Body:        helpers.ToJSONString(GetRecommendationsResponse1Rule2Cluster),
+			BodyChecker: recommendationInResponseChecker,
+		})
+	}, testTimeout)
+}
+
+// TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_ImpactingFalse
+func TestHTTPServer_RecommendationsListEndpoint4Rules1Internal2Clusters_ImpactingMissing(t *testing.T) {
+	defer content.ResetContent()
+	err := loadMockRuleContentDir(
+		createRuleContentDirectoryFromRuleContent(
+			[]types.RuleContent{
+				testdata.RuleContent1,
+				testdata.RuleContent2,
+				testdata.RuleContent3,
+				RuleContentInternal1,
+			},
+		),
+	)
+	assert.Nil(t, err)
+
+	helpers.RunTestWithTimeout(t, func(t testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		clusterList := make([]types.ClusterName, 2)
+		for i := range clusterList {
+			clusterList[i] = testdata.GetRandomClusterID()
+		}
+
+		reqBody, _ := json.Marshal(clusterList)
+
+		respBody := `{"recommendations":{"%v":%v},"status":"ok"}`
+		respBody = fmt.Sprintf(respBody,
+			testdata.Rule1CompositeID, 1,
+		)
+
+		// prepare response from aggregator for list of clusters
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ClustersForOrganizationEndpoint,
+			EndpointArgs: []interface{}{testdata.OrgID},
+		}, &helpers.APIResponse{
+			StatusCode: http.StatusOK,
+			Body:       helpers.ToJSONString(responses.BuildOkResponseWithData("clusters", clusterList)),
+		})
+
+		// prepare response from aggregator for recommendations
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+			&helpers.APIRequest{
+				Method:       http.MethodPost,
+				Endpoint:     ira_server.RecommendationsListEndpoint,
+				EndpointArgs: []interface{}{testdata.OrgID, userIDOnGoodJWTAuthBearer},
+				Body:         reqBody,
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       respBody,
+			},
+		)
+
+		helpers.AssertAPIv2Request(t, &serverConfigJWT, nil, nil, nil, nil, &helpers.APIRequest{
+			Method:             http.MethodGet,
+			Endpoint:           server.RecommendationsListEndpoint,
+			AuthorizationToken: goodJWTAuthBearer,
+		}, &helpers.APIResponse{
+			StatusCode:  http.StatusOK,
+			Body:        helpers.ToJSONString(GetRecommendationsResponse3Rules1Cluster),
 			BodyChecker: recommendationInResponseChecker,
 		})
 	}, testTimeout)

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -31,7 +31,6 @@ import (
 	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
 
 	"github.com/RedHatInsights/insights-results-smart-proxy/content"
-	sptypes "github.com/RedHatInsights/insights-results-smart-proxy/types"
 	stypes "github.com/RedHatInsights/insights-results-smart-proxy/types"
 )
 
@@ -141,7 +140,7 @@ func (server HTTPServer) getRecommendations(writer http.ResponseWriter, request 
 
 func getRecommendationsFillImpacted(
 	impactingRecommendations types.RecommendationImpactedClusters,
-	impactingFlag sptypes.ImpactingFlag,
+	impactingFlag stypes.ImpactingFlag,
 ) (
 	recommendationList []stypes.RecommendationListView,
 	err error,

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -24,6 +24,8 @@ import (
 	httputils "github.com/RedHatInsights/insights-operator-utils/http"
 	"github.com/RedHatInsights/insights-operator-utils/types"
 	"github.com/rs/zerolog/log"
+
+	sptypes "github.com/RedHatInsights/insights-results-smart-proxy/types"
 )
 
 const (
@@ -79,10 +81,9 @@ func readRuleIDWithErrorKey(writer http.ResponseWriter, request *http.Request) (
 func (server HTTPServer) readParamsGetRecommendations(writer http.ResponseWriter, request *http.Request) (
 	userID types.UserID,
 	orgID types.OrgID,
-	impacting bool,
+	impactingFlag sptypes.ImpactingFlag,
 	err error,
 ) {
-	impacting = true
 
 	orgID, userID, err = server.readOrgIDAndUserIDFromToken(writer, request)
 	if err != nil {
@@ -90,15 +91,29 @@ func (server HTTPServer) readParamsGetRecommendations(writer http.ResponseWriter
 		return
 	}
 
-	impactingParam, err := readImpactingParam(request)
+	impactingParam := request.URL.Query().Get(ImpactingParam)
+	if len(impactingParam) == 0 {
+		// impacting control flag is missing, display all recommendations
+		impactingFlag = IncludingImpacting
+		return
+	}
+
+	impactingParamBool, err := readImpactingParam(request)
 	if err != nil {
-		log.Err(err).Msgf("Error parsing `%s` URL parameter. Defaulting to true.", ImpactingParam)
+		log.Err(err).Msgf("Error parsing `%s` URL parameter.", ImpactingParam)
 		handleServerError(writer, &RouterParsingError{
 			paramName: ImpactingParam,
 			errString: "Unparsable boolean value",
 		})
+		return
+	}
+
+	if impactingParamBool {
+		// param impacting=true means to only include impacting recommendations
+		impactingFlag = OnlyImpacting
 	} else {
-		impacting = impactingParam
+		// param impacting=false means to return all rules that aren't impacting any clusters
+		impactingFlag = ExcludingImpacting
 	}
 
 	return

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -572,6 +572,54 @@ var (
 		},
 	}
 
+	GetRecommendationsResponse3Rules1Cluster = struct {
+		Status          string                         `json:"status"`
+		Recommendations []types.RecommendationListView `json:"recommendations"`
+	}{
+		Status: "ok",
+		Recommendations: []types.RecommendationListView{
+			{
+				RuleID:              testdata.Rule1CompositeID,
+				Description:         testdata.RuleErrorKey1.Description,
+				Generic:             testdata.RuleErrorKey1.Generic,
+				PublishDate:         testdata.RuleErrorKey1.PublishDate,
+				TotalRisk:           uint8(calculateTotalRisk(testdata.RuleErrorKey1.Impact, testdata.RuleErrorKey1.Likelihood)),
+				Impact:              uint8(testdata.RuleErrorKey1.Impact),
+				Likelihood:          uint8(testdata.RuleErrorKey1.Likelihood),
+				Tags:                testdata.RuleErrorKey1.Tags,
+				RuleStatus:          "",
+				RiskOfChange:        0,
+				ImpactedClustersCnt: 1,
+			},
+			{
+				RuleID:              testdata.Rule2CompositeID,
+				Description:         testdata.RuleErrorKey2.Description,
+				Generic:             testdata.RuleErrorKey2.Generic,
+				PublishDate:         testdata.RuleErrorKey2.PublishDate,
+				TotalRisk:           uint8(calculateTotalRisk(testdata.RuleErrorKey2.Impact, testdata.RuleErrorKey2.Likelihood)),
+				Impact:              uint8(testdata.RuleErrorKey2.Impact),
+				Likelihood:          uint8(testdata.RuleErrorKey2.Likelihood),
+				Tags:                testdata.RuleErrorKey2.Tags,
+				RuleStatus:          "",
+				RiskOfChange:        0,
+				ImpactedClustersCnt: 0,
+			},
+			{
+				RuleID:              testdata.Rule3CompositeID,
+				Description:         testdata.RuleErrorKey3.Description,
+				Generic:             testdata.RuleErrorKey3.Generic,
+				PublishDate:         testdata.RuleErrorKey3.PublishDate,
+				TotalRisk:           uint8(calculateTotalRisk(testdata.RuleErrorKey3.Impact, testdata.RuleErrorKey3.Likelihood)),
+				Impact:              uint8(testdata.RuleErrorKey3.Impact),
+				Likelihood:          uint8(testdata.RuleErrorKey3.Likelihood),
+				Tags:                testdata.RuleErrorKey3.Tags,
+				RuleStatus:          "",
+				RiskOfChange:        0,
+				ImpactedClustersCnt: 0,
+			},
+		},
+	}
+
 	GetRecommendationsResponse0Rules = struct {
 		Status          string                         `json:"status"`
 		Recommendations []types.RecommendationListView `json:"recommendations"`

--- a/types/types.go
+++ b/types/types.go
@@ -39,6 +39,9 @@ type RuleContent = types.RuleContent
 // RuleID is a rename for types.RuleID
 type RuleID = types.RuleID
 
+// ImpactingFlag controls the behaviour of 'impacting' param on GET /rule/
+type ImpactingFlag int
+
 // RuleWithContentResponse represents a single rule in the response of /report endpoint
 type RuleWithContentResponse struct {
 	RuleID          types.RuleID    `json:"rule_id"`


### PR DESCRIPTION
# Description
If param is missing, endpoint will return all available rules including those that don't hit any clusters at the moment. If set to true, only returns impacting rules. If false, only returns those that aren't imapcting."

Fixes CCXDEV-6177

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- REST API tests

## Testing steps

`make before_commit` + local

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
