### PR TITLE
Fix amsclient search string generation

### DIFF
--- a/amsclient/utils.go
+++ b/amsclient/utils.go
@@ -24,12 +24,12 @@ func generateSearchParameter(orgID string, allowedStatuses, disallowedStatuses [
 	searchQuery := fmt.Sprintf("organization_id is '%s'", orgID)
 
 	if len(allowedStatuses) > 0 {
-		clusterIDQuery := " and status in ('" + strings.Join(allowedStatuses, "',") + "')"
+		clusterIDQuery := " and status in ('" + strings.Join(allowedStatuses, "','") + "')"
 		searchQuery = searchQuery + clusterIDQuery
 	}
 
 	if len(disallowedStatuses) > 0 {
-		clusterIDQuery := " and status not in ('" + strings.Join(disallowedStatuses, "',") + "')"
+		clusterIDQuery := " and status not in ('" + strings.Join(disallowedStatuses, "','") + "')"
 		searchQuery = searchQuery + clusterIDQuery
 	}
 


### PR DESCRIPTION
# Description

`amsclient` code has a bug that doesn't generate properly the search string when there is more than 1 status to filter (it misses some of the quotes)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps

Regular CI

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
