### PR TITLE
clusters_detail endpoint - return rule_id instead of rule_selector in metadata 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.15
 require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20211019165101-b56df7efd84f
-	github.com/RedHatInsights/insights-operator-utils v1.21.3
-	github.com/RedHatInsights/insights-results-aggregator v1.1.9
+	github.com/RedHatInsights/insights-operator-utils v1.21.4
+	github.com/RedHatInsights/insights-results-aggregator v1.1.10
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.2
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -78,11 +78,11 @@ github.com/RedHatInsights/insights-operator-utils v1.8.3/go.mod h1:L6alrkNSM+uBz
 github.com/RedHatInsights/insights-operator-utils v1.12.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-operator-utils v1.21.0/go.mod h1:B2hizFGwXCc8MT34QqVJ1A8ANTyGQZQWXQw/gSCEsaU=
 github.com/RedHatInsights/insights-operator-utils v1.21.2/go.mod h1:3Pfsgsi7GCu2wgIqQlt1llpyQyyxsDWEGdgnPvadM40=
-github.com/RedHatInsights/insights-operator-utils v1.21.3 h1:ZQ1nrLp4LrBUnJkn9TLbHWru8+QCiJObfgg1MQBgMgQ=
-github.com/RedHatInsights/insights-operator-utils v1.21.3/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
+github.com/RedHatInsights/insights-operator-utils v1.21.4 h1:bWDLMfQLuJ3928e6gcUMJhJUNxnJbeR+eDbopE7TSzI=
+github.com/RedHatInsights/insights-operator-utils v1.21.4/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
-github.com/RedHatInsights/insights-results-aggregator v1.1.9 h1:EmHo8DRimqdbCMk54OmA4mIXWiMJmjgsdk3MBuNgOJY=
-github.com/RedHatInsights/insights-results-aggregator v1.1.9/go.mod h1:8DjesUL8aaWyY3iKFsC7jecO1fhGOa9JrYh/5bh5ZtE=
+github.com/RedHatInsights/insights-results-aggregator v1.1.10 h1:CTsDETDDea5j+MGYqOH42ZnUiL1mKmSrIfG0J0AZVv0=
+github.com/RedHatInsights/insights-results-aggregator v1.1.10/go.mod h1:nhqdWy9kwjdXoQ1uuuzKA1GxmPvtxTyU4bVQ22RhHyw=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -76,7 +76,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 		"data":[{"cluster":"5d5892d3-1f74-4ccf-91af-548dfc9767bb"}],
 		"meta":{
 			"count":1,
-			"rule_selector":"ccx_rules_ocp.external.rules.container_max_root_partition_size|ek1"
+			"rule_id":"ccx_rules_ocp.external.rules.container_max_root_partition_size|ek1"
 		},
 		"status":"ok"
 	}


### PR DESCRIPTION
# Description

Return `rule_id` in response sent to smart_proxy instead of `rule_selector`, for consistency on the client side.

- The rule_selector type will only be used internally for now, until we can refactor it all.
- This change only affects /rule/{rule_selector}/clusters_detail endpoint.

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

CI + local testing

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
