### PR TITLE
Add fallback mechanism when amsclient doesn't work

### DIFF
--- a/amsclient/amsclient.go
+++ b/amsclient/amsclient.go
@@ -88,13 +88,16 @@ func NewAMSClientWithTransport(conf Configuration, transport http.RoundTripper) 
 
 // GetClustersForOrganization retrieves the clusters for a given organization using the default client
 // it allows to filter the clusters by their status (statusNegativeFilter will exclude the clusters with status in that list)
-func (c *AMSClient) GetClustersForOrganization(orgID types.OrgID, statusFilter, statusNegativeFilter []string) []types.ClusterName {
+func (c *AMSClient) GetClustersForOrganization(orgID types.OrgID, statusFilter, statusNegativeFilter []string) (
+	[]types.ClusterName,
+	error,
+) {
 	log.Debug().Uint32(orgIDTag, uint32(orgID)).Msg("Looking cluster for the organization")
 	var retval []types.ClusterName = []types.ClusterName{}
 
 	internalOrgID, err := c.GetInternalOrgIDFromExternal(orgID)
 	if err != nil {
-		return retval
+		return retval, err
 	}
 
 	searchQuery := generateSearchParameter(internalOrgID, statusFilter, statusNegativeFilter)
@@ -109,7 +112,7 @@ func (c *AMSClient) GetClustersForOrganization(orgID types.OrgID, statusFilter, 
 			Send()
 
 		if err != nil {
-			return retval
+			return retval, err
 		}
 
 		// When an empty page is returned, then exit the loop
@@ -132,7 +135,7 @@ func (c *AMSClient) GetClustersForOrganization(orgID types.OrgID, statusFilter, 
 		}
 	}
 
-	return retval
+	return retval, nil
 }
 
 // GetInternalOrgIDFromExternal will retrieve the internal organization ID from an external one using AMS API

--- a/amsclient/amsclient_test.go
+++ b/amsclient/amsclient_test.go
@@ -185,7 +185,8 @@ func TestClusterForOrganization(t *testing.T) {
 		Body: helpers.ToJSONString(testdata.SubscriptionEmptyResponse),
 	})
 
-	clusterList := c.GetClustersForOrganization(testdata.ExternalOrgID, nil, nil)
+	clusterList, err := c.GetClustersForOrganization(testdata.ExternalOrgID, nil, nil)
+	helpers.FailOnError(t, err)
 	assert.Equal(t, 2, len(clusterList))
 }
 
@@ -232,10 +233,23 @@ func TestClusterForOrganizationWithFiltering(t *testing.T) {
 		Body: helpers.ToJSONString(testdata.SubscriptionEmptyResponse),
 	})
 
-	clusterList := c.GetClustersForOrganization(
+	clusterList, err := c.GetClustersForOrganization(
 		testdata.ExternalOrgID,
 		[]string{amsclient.StatusArchived, amsclient.StatusDeprovisioned},
 		nil,
 	)
+
+	helpers.FailOnError(t, err)
 	assert.Equal(t, 2, len(clusterList))
+}
+
+func TestGetClustersForOrganizationOnError(t *testing.T) {
+	client, err := amsclient.NewAMSClient(defaultConfig)
+	helpers.FailOnError(t, err) // Doesn't fail because ocm-sdk doesn't perform any checks
+
+	clusters, err := client.GetClustersForOrganization(testdata.ExternalOrgID, nil, nil)
+	if err == nil {
+		t.Fail()
+	}
+	assert.Equal(t, 0, len(clusters))
 }

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -515,11 +515,15 @@ func (server HTTPServer) getClustersDetailForRule(writer http.ResponseWriter, re
 	activeClusters := make([]types.ClusterName, 0)
 	// Get list of active clusters if AMS client is available
 	if server.amsClient != nil {
-		activeClusters = server.amsClient.GetClustersForOrganization(
+		activeClusters, err = server.amsClient.GetClustersForOrganization(
 			orgID,
 			nil,
 			[]string{amsclient.StatusDeprovisioned, amsclient.StatusArchived},
 		)
+
+		if err != nil {
+			log.Error().Err(err).Msg("amsclient was unable to retrieve the active clusters")
+		}
 	}
 
 	// get the list of clusters affected by given rule from aggregator and send to client

--- a/server/server.go
+++ b/server/server.go
@@ -359,11 +359,16 @@ func copyHeader(srcHeaders, dstHeaders http.Header) {
 // organization from aggregator
 func (server HTTPServer) readClusterIDsForOrgID(orgID types.OrgID) ([]types.ClusterName, error) {
 	if server.amsClient != nil {
-		return server.amsClient.GetClustersForOrganization(
+		clusters, err := server.amsClient.GetClustersForOrganization(
 			orgID,
 			nil,
 			[]string{amsclient.StatusDeprovisioned, amsclient.StatusArchived},
-		), nil
+		)
+		if err == nil {
+			return clusters, err
+		}
+
+		log.Warn().Err(err).Msg("amsclient is not able to retrieve cluster list. Using fallback method")
 	}
 
 	aggregatorURL := httputils.MakeURLToEndpoint(


### PR DESCRIPTION
# Description

Make that every try to use `amsclient`, if fails, can be handled to use a different method to retrieve the list of active clusters.

Fixes #678 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
Added new unit test to check that in case of error, an error is returned. Manually tested almost every `make before_commit` commands because OpenAPI check is currently failing on master

## Checklist
* [ ] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
