### PR TITLE
Run openapi checks on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,15 @@ jobs:
       after_success:
         - env
         - bash <(curl -s https://codecov.io/bash)
+    - stage: openapi-checks
+      language: node_js
+      node_js:
+        - node
+      script:
+        - npm install -g @openapitools/openapi-generator-cli
+        - openapi-generator-cli validate -i server/api/v1/openapi.json
+        - openapi-generator-cli validate -i server/api/v2/openapi.json
+        - openapi-generator-cli validate -i server/api/dbg/openapi.json
     - stage: integration tests
       script:
         - make integration_tests
@@ -35,4 +44,5 @@ jobs:
 stages:
   - style
   - unit tests
+  - openapi-checks
   - integration tests


### PR DESCRIPTION
# Description

Add a new CI stage to check the OpenAPI specifications in Travis. It cannot use directly our check_openapi.sh script because it takes the validation program from a container instead of installing thourgh `npm`. As Travis run in "virtual machines", we don't care about the trash we left behind :-D

## Type of change

- Improve CI

## Testing steps

Tested on forked repository (https://app.travis-ci.com/github/joselsegura/insights-results-smart-proxy/builds/240794152). It failed, but it is a known bug right now with a pending PR

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
