### PR TITLE
Fix clusters_detail endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.15
 require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20211019165101-b56df7efd84f
-	github.com/RedHatInsights/insights-operator-utils v1.21.4
-	github.com/RedHatInsights/insights-results-aggregator v1.1.10
+	github.com/RedHatInsights/insights-operator-utils v1.21.5
+	github.com/RedHatInsights/insights-results-aggregator v1.1.11
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.2
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -78,11 +78,11 @@ github.com/RedHatInsights/insights-operator-utils v1.8.3/go.mod h1:L6alrkNSM+uBz
 github.com/RedHatInsights/insights-operator-utils v1.12.0/go.mod h1:mN5jURLpSG+j7y3VPAUTPyHsTWSxrqSHSerSacDBgFU=
 github.com/RedHatInsights/insights-operator-utils v1.21.0/go.mod h1:B2hizFGwXCc8MT34QqVJ1A8ANTyGQZQWXQw/gSCEsaU=
 github.com/RedHatInsights/insights-operator-utils v1.21.2/go.mod h1:3Pfsgsi7GCu2wgIqQlt1llpyQyyxsDWEGdgnPvadM40=
-github.com/RedHatInsights/insights-operator-utils v1.21.4 h1:bWDLMfQLuJ3928e6gcUMJhJUNxnJbeR+eDbopE7TSzI=
-github.com/RedHatInsights/insights-operator-utils v1.21.4/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
+github.com/RedHatInsights/insights-operator-utils v1.21.5 h1:hnb2M4sbzbfp7LzQeMxY58MwC2WAXnmzLYRsA1K2W4A=
+github.com/RedHatInsights/insights-operator-utils v1.21.5/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
-github.com/RedHatInsights/insights-results-aggregator v1.1.10 h1:CTsDETDDea5j+MGYqOH42ZnUiL1mKmSrIfG0J0AZVv0=
-github.com/RedHatInsights/insights-results-aggregator v1.1.10/go.mod h1:nhqdWy9kwjdXoQ1uuuzKA1GxmPvtxTyU4bVQ22RhHyw=
+github.com/RedHatInsights/insights-results-aggregator v1.1.11 h1:yLQs4DaP53msGDOefpGFL3WmKJ5gIGWwy0vI5EiiqKo=
+github.com/RedHatInsights/insights-results-aggregator v1.1.11/go.mod h1:iXmFvFVgWb2GArjpnRyX1wGouS0FDvFXfk7BD6N21c8=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=

--- a/server/endpoints_v2.go
+++ b/server/endpoints_v2.go
@@ -29,7 +29,7 @@ const (
 	ReportEndpointV2 = "cluster/{cluster}/reports"
 
 	// ClustersDetail https://issues.redhat.com/browse/CCXDEV-5088
-	ClustersDetail = "rule/{rule_selector}/clusters_detail/"
+	ClustersDetail = "rule/{rule_selector}/clusters_detail"
 
 	// RecommendationsListEndpoint lists all recommendations with a number of impacted clusters.
 	RecommendationsListEndpoint = "rule/"

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -523,6 +523,7 @@ func (server HTTPServer) getClustersDetailForRule(writer http.ResponseWriter, re
 
 		if err != nil {
 			log.Error().Err(err).Msg("amsclient was unable to retrieve the active clusters")
+			activeClusters = make([]types.ClusterName, 0)
 		}
 	}
 


### PR DESCRIPTION
# Description

- New version of `insights-results-aggregator` dependency (see https://github.com/RedHatInsights/insights-results-aggregator/releases/tag/v1.1.11), which includes fix of the SQL query used for getting `clusters_detail` endpoint's data.
- Ensure body is empty when ams client returns an error in `handlers_v2::getClustersDetailForRule`method.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

local tests + CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
