### PR TITLE
Better info endpoint containing also info from Content Service and from Insights Results Aggregator

### DIFF
--- a/server/api/v1/openapi.json
+++ b/server/api/v1/openapi.json
@@ -51,12 +51,12 @@
     },
     "/info": {
       "get": {
-        "summary": "Returns basic information about Smart Proxy.",
-        "description": "InfoEndpoint returns basic information about Smart Proxy version, utils repository version, commit hash etc.",
+        "summary": "Returns basic information about Smart Proxy, Insights Results Aggregator, and Content Service.",
+        "description": "InfoEndpoint returns basic information about Smart Proxy, Insights Results Aggregator, and Content Service version, utils repository version, commit hash etc.",
         "operationId": "InfoEndpoint",
         "responses": {
           "200": {
-            "description": "A map containing information about Smart Proxy.",
+            "description": "An object containing information about Smart Proxy, Insights Results Aggregator, and Content Service.",
             "content": {
               "application/json": {
                 "schema": {
@@ -64,8 +64,25 @@
                   "properties": {
                     "info": {
                       "type": "object",
-                      "additionalProperties": {
-                         "type": "string"
+                      "properties": {
+                        "SmartProxy": {
+                          "type": "object",
+                          "additionalProperties": {
+                             "type": "string"
+                          }
+                        },
+                        "Aggregator": {
+                          "type": "object",
+                          "additionalProperties": {
+                             "type": "string"
+                          }
+                        },
+                        "ContentService": {
+                          "type": "object",
+                          "additionalProperties": {
+                             "type": "string"
+                          }
+                        }
                       }
                     },
                     "status": {

--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -412,7 +412,13 @@ func readInfoAPIEndpoint(url string) (map[string]string, error) {
 	}
 
 	// try to read response body
-	defer response.Body.Close()
+	defer func() {
+		err = response.Body.Close()
+		if err != nil {
+			log.Error().Err(err).Msg("Closing response body failed")
+		}
+	}()
+
 	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		err = errors.New("Problem reading response from /info endpoint")

--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -104,6 +104,7 @@ func (server HTTPServer) getContentV1(writer http.ResponseWriter, request *http.
 
 	var rules []sptypes.RuleContentV1
 
+	// #nosec G107
 	if err := server.checkInternalRulePermissions(request); err != nil {
 		for _, rule := range allRules {
 			if !content.IsRuleInternal(types.RuleID(rule.Plugin.PythonModule)) {

--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -104,7 +104,6 @@ func (server HTTPServer) getContentV1(writer http.ResponseWriter, request *http.
 
 	var rules []sptypes.RuleContentV1
 
-	// #nosec G107
 	if err := server.checkInternalRulePermissions(request); err != nil {
 		for _, rule := range allRules {
 			if !content.IsRuleInternal(types.RuleID(rule.Plugin.PythonModule)) {
@@ -400,6 +399,7 @@ func infoFromService(url string) map[string]string {
 // returned response
 func readInfoAPIEndpoint(url string) (map[string]string, error) {
 	// perform GET request to given service
+	// #nosec G107
 	response, err := http.Get(url)
 
 	// error happening during GET request

--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -29,6 +29,8 @@ import (
 	sptypes "github.com/RedHatInsights/insights-results-smart-proxy/types"
 )
 
+const filledIn = "ok"
+
 // getGroups sends the latest valid groups configuration to the client in
 // standard HTTP response
 func (server *HTTPServer) getGroups(writer http.ResponseWriter, _ *http.Request) {
@@ -307,22 +309,9 @@ func generateOrgOverview(aggregatorReport *types.ClusterReports) (sptypes.OrgOve
 // infoMap returns map of additional information about this service, Insights
 // Results Aggregator, and Smart Proxy
 func (server *HTTPServer) infoMap(writer http.ResponseWriter, request *http.Request) {
-	const filledIn = "ok"
 
 	var response sptypes.InfoResponse
-
-	if server.InfoParams == nil {
-		const msg = "InfoParams is empty"
-		err := errors.New(msg)
-		log.Error().Err(err)
-
-		// don't fail, just fill in the field
-		response.SmartProxy = make(map[string]string)
-		response.SmartProxy["status"] = msg
-	} else {
-		response.SmartProxy = server.InfoParams
-		response.SmartProxy["status"] = filledIn
-	}
+	response.SmartProxy = server.fillInSmartProxyInfoParams()
 
 	err := responses.SendOK(writer, responses.BuildOkResponseWithData("info", response))
 	if err != nil {
@@ -330,4 +319,23 @@ func (server *HTTPServer) infoMap(writer http.ResponseWriter, request *http.Requ
 		handleServerError(writer, err)
 		return
 	}
+}
+
+func (server *HTTPServer) fillInSmartProxyInfoParams() map[string]string {
+	// fill-in info params for Smart Proxy
+	if server.InfoParams == nil {
+		const msg = "InfoParams is empty"
+		err := errors.New(msg)
+		log.Error().Err(err)
+
+		// don't fail, just fill in the field
+		m := make(map[string]string)
+		m["status"] = msg
+		return m
+	}
+
+	// info params for Smart Proxy is filled-in properly
+	m := server.InfoParams
+	m["status"] = filledIn
+	return m
 }

--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -32,6 +32,7 @@ import (
 )
 
 const filledIn = "ok"
+const infoEndpoint = "info"
 
 // infoEndpointStruct represent response for /info endpoint from Insights
 // Results Aggregator or from Content Service
@@ -361,7 +362,7 @@ func (server *HTTPServer) fillInContentServiceInfoParams() map[string]string {
 	// try to access Content Service
 	url := httputils.MakeURLToEndpoint(
 		server.ServicesConfig.ContentBaseEndpoint,
-		"info")
+		infoEndpoint)
 	return infoFromService(url)
 }
 
@@ -371,7 +372,7 @@ func (server *HTTPServer) fillInAggregatorInfoParams() map[string]string {
 	// try to access Insights Results Aggregator
 	url := httputils.MakeURLToEndpoint(
 		server.ServicesConfig.AggregatorBaseEndpoint,
-		"info")
+		infoEndpoint)
 	return infoFromService(url)
 }
 

--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -304,16 +304,27 @@ func generateOrgOverview(aggregatorReport *types.ClusterReports) (sptypes.OrgOve
 	}, nil
 }
 
-// infoMap returns map of additional information about this service
+// infoMap returns map of additional information about this service, Insights
+// Results Aggregator, and Smart Proxy
 func (server *HTTPServer) infoMap(writer http.ResponseWriter, request *http.Request) {
+	const filledIn = "ok"
+
+	var response sptypes.InfoResponse
+
 	if server.InfoParams == nil {
-		err := errors.New("InfoParams is empty")
+		const msg = "InfoParams is empty"
+		err := errors.New(msg)
 		log.Error().Err(err)
-		handleServerError(writer, err)
-		return
+
+		// don't fail, just fill in the field
+		response.SmartProxy = make(map[string]string)
+		response.SmartProxy["status"] = msg
+	} else {
+		response.SmartProxy = server.InfoParams
+		response.SmartProxy["status"] = filledIn
 	}
 
-	err := responses.SendOK(writer, responses.BuildOkResponseWithData("info", server.InfoParams))
+	err := responses.SendOK(writer, responses.BuildOkResponseWithData("info", response))
 	if err != nil {
 		log.Error().Err(err)
 		handleServerError(writer, err)

--- a/types/types.go
+++ b/types/types.go
@@ -246,3 +246,10 @@ type ErrorKeyMetadataV2 struct {
 	Status      string   `yaml:"status" json:"status"`
 	Tags        []string `yaml:"tags" json:"tags"`
 }
+
+// InfoResponse is a data structure returned by /info REST API endpoint
+type InfoResponse struct {
+	SmartProxy     map[string]string `json:"SmartProxy"`
+	Aggregator     map[string]string `json:"Aggregator"`
+	ContentService map[string]string `json:"ContentService"`
+}


### PR DESCRIPTION
# Description

Better info endpoint containing also info from Content Service and from Insights Results Aggregator

An example of output (where one service does not work on purpose):

```$ curl localhost:8081/api/v1/info | jq .

{
  "info": {
    "SmartProxy": {
      "BuildBranch": "better-info-endpoint",
      "BuildCommit": "1c65f4cc42149c51387964ad13fc74d4f42f6bcc",
      "BuildTime": "Tue 02 Nov 2021 01:47:40 PM CET",
      "BuildVersion": "0.1",
      "UtilsVersion": "v1.21.4",
      "status": "ok"
    },
    "ContentService": {
      "BuildBranch": "info-endpoint",
      "BuildCommit": "da46251d58da07a885fd4ba362be4fb013b769b3",
      "BuildTime": "Tue 02 Nov 2021 12:54:58 PM CET",
      "BuildVersion": "0.5",
      "UtilsVersion": "v1.21.2",
      "status": "ok"
    },
    "Aggregator": {
      "status": "Get \"http://localhost:8082/api/v1/info\": dial tcp 127.0.0.1:8082: connect: connection refused"
    }
  },
  "status": "ok"
}
```
** Please note that `utils` version don't match - on purpose there**

## Type of change

- New feature (non-breaking change which adds functionality)
- Documentation update

## Testing steps

Can be done using the `curl` mentioned above.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
