### PR TITLE
add more specific log message to readClusterIDsForOrgID

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -372,7 +372,9 @@ func (server HTTPServer) readClusterIDsForOrgID(orgID types.OrgID) ([]types.Clus
 			return clusters, err
 		}
 
-		log.Warn().Err(err).Msg("amsclient is not able to retrieve cluster list. Using fallback method")
+		log.Warn().Err(err).Msg("amsclient is initialized, but the cluster list cannot be retrieved. Using fallback method")
+	} else {
+		log.Info().Msg("amsclient not initialized, retrieving cluster list from aggregator database")
 	}
 
 	aggregatorURL := httputils.MakeURLToEndpoint(


### PR DESCRIPTION
# Description

I was trying to find the `amsclient is not able to retrieve cluster list. Using fallback method`, which wasn't to be found in logs, so I assumed it was using the AMS API correctly, but I didn't notice that that part is only ran if `amsClient` is initialized, which isn't the case on QA I suppose.

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
