### PR TITLE
Not using functions from Go 1.16, base image cannot be upgraded yet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,7 @@
 
 language: go
 go:
-- "1.15"
-
+- "1.16"
 jobs:
   include:
     - stage: style

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@
 
 language: go
 go:
-- 1.16
+- "1.15"
 
 jobs:
   include:

--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -18,7 +18,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 
@@ -421,7 +421,7 @@ func readInfoAPIEndpoint(url string) (map[string]string, error) {
 		}
 	}()
 
-	body, err := io.ReadAll(response.Body)
+	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		err = errors.New("Problem reading response from /info endpoint")
 		return nil, err


### PR DESCRIPTION
# Description

Right now the conainter image build of Smart Proxy are failing because Go 1.15 doesn't have `io.ReadAll` function (added in 1.16). As long as we cannot use go-toolset:1.16 version yet, we should stick to 1.15 version.

Downgrading Travis CI version to 1.15 too

Fixes #705

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Bump-up dependent library (no changes in the code)

## Testing steps

Container image built locally without any problem

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
