### PR TITLE
Use a different go version for some job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,18 @@
 language: go
 go:
 - "1.16"
+
 jobs:
   include:
+    - name: "Build 1.15"
+      stage: build
+      go: "1.15"
+      script:
+        - make
+    - name: "Build 1.16"
+      stage: build
+      script:
+        - make
     - stage: style
       script:
         - make style
@@ -41,6 +51,7 @@ jobs:
         - make integration_tests
 
 stages:
+  - build
   - style
   - unit tests
   - openapi-checks


### PR DESCRIPTION
# Description

Added a new build stage to CI, trying to build there with different Go versions

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

I was launching a lot of Travis builds during the afternoon with different configurations :-)

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
