### PR TITLE
Return empty list and 200OK when no impacted clusters found for given recommendation

### DIFF
--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -436,6 +436,67 @@ func (server HTTPServer) getContentWithGroups(writer http.ResponseWriter, reques
 	}
 }
 
+// getImpactedClustersFromAggregator sends GET to aggregator with or without content
+// depending on the list of active clusters provided by the AMS client.
+func getImpactedClustersFromAggregator(
+	url string,
+	activeClusters []types.ClusterName,
+) (resp *http.Response, err error) {
+	if len(activeClusters) < 0 {
+		// #nosec G107
+		resp, err = http.Get(url)
+		return
+	}
+
+	// generate JSON payload of the format "clusters": []clusters
+	var jsonBody []byte
+	jsonBody, err = json.Marshal(
+		map[string][]types.ClusterName{"clusters": activeClusters})
+	if err != nil {
+		log.Err(err).Msg("Couldn't encode list of active clusters to valid JSON, aborting")
+		return
+	}
+
+	// GET method with list of active clusters in payload to avoid possible URL length problems
+	var req *http.Request
+	req, err = http.NewRequest(http.MethodGet, url, bytes.NewBuffer(jsonBody))
+	if err != nil {
+		return
+	}
+
+	req.Header.Set(contentTypeHeader, JSONContentType)
+	client := &http.Client{}
+	resp, err = client.Do(req)
+	return
+}
+
+// proxyImpactedClusters sends the list of clusters impacted by the
+// recommendation to the client, if any.
+func proxyImpactedClusters(
+	writer http.ResponseWriter,
+	selector types.RuleSelector,
+	aggregatorResp *http.Response,
+) error {
+	// If we received a 404 - no entries found for given orgID+selector in DB
+	// We return an empty list and a 200 OK
+	if aggregatorResp.StatusCode == http.StatusNotFound {
+		resp := responses.BuildOkResponse()
+		resp["meta"] = types.HittingClustersMetadata{
+			Count:    0,
+			Selector: selector,
+		}
+		resp["data"] = []types.HittingClustersData{}
+		return responses.SendOK(writer, resp)
+	}
+
+	//Proxy the other responses as they came
+	responseBytes, e := ioutil.ReadAll(aggregatorResp.Body)
+	if e != nil {
+		return e
+	}
+	return responses.Send(aggregatorResp.StatusCode, writer, responseBytes)
+}
+
 // getImpactedClusters retrieves a list of clusters affected by the given recommendation from aggregator
 func (server HTTPServer) getImpactedClusters(
 	writer http.ResponseWriter,
@@ -453,61 +514,13 @@ func (server HTTPServer) getImpactedClusters(
 		userID,
 	)
 
-	var aggregatorResp *http.Response = nil
-	var err error
-
-	if len(activeClusters) < 0 {
-		// #nosec G107
-		aggregatorResp, err = http.Get(aggregatorURL)
-		// if http.Get fails for whatever reason
-		if err != nil {
-			handleServerError(writer, err)
-			return err
-		}
-	} else {
-		// generate JSON payload of the format "clusters": []clusters
-		jsonBody, e := json.Marshal(
-			map[string][]types.ClusterName{"clusters": activeClusters})
-		if e != nil {
-			log.Err(e).Msg("Couldn't encode list of active clusters to valid JSON, aborting")
-			return e
-		}
-
-		// GET method with list of active clusters in payload to avoid possible URL length problems
-		req, e := http.NewRequest(http.MethodGet, aggregatorURL, bytes.NewBuffer(jsonBody))
-		if e != nil {
-			return e
-		}
-
-		req.Header.Set(contentTypeHeader, JSONContentType)
-		client := &http.Client{}
-		aggregatorResp, err = client.Do(req)
-		// if http.Get fails for whatever reason
-		if err != nil {
-			handleServerError(writer, err)
-			return err
-		}
-	}
-
-	// If we received a 404 - no entries found for given orgID+selector in DB
-	// We return an empty list and a 200 OK
-	if aggregatorResp.StatusCode == http.StatusNotFound {
-		resp := responses.BuildOkResponse()
-		resp["meta"] = types.HittingClustersMetadata{
-			Count:    0,
-			Selector: selector,
-		}
-		resp["data"] = []types.HittingClustersData{}
-		err = responses.SendOK(writer, resp)
-	} else {
-		//Proxy the other responses as they came
-		responseBytes, e := ioutil.ReadAll(aggregatorResp.Body)
-		if e != nil {
-			return e
-		}
-		err = responses.Send(aggregatorResp.StatusCode, writer, responseBytes)
-	}
+	aggregatorResp, err := getImpactedClustersFromAggregator(aggregatorURL, activeClusters)
+	// if http.Get fails for whatever reason
 	if err != nil {
+		handleServerError(writer, err)
+		return err
+	}
+	if err = proxyImpactedClusters(writer, selector, aggregatorResp); err != nil {
 		log.Error().Err(err).Msgf(problemSendingResponseError)
 		handleServerError(writer, err)
 		return err

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -16,6 +16,8 @@ package server_test
 
 import (
 	"fmt"
+	"github.com/RedHatInsights/insights-results-smart-proxy/content"
+	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
 
@@ -70,6 +72,10 @@ func TestHTTPServer_SetRating(t *testing.T) {
 // forwarded to the client
 func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
+	defer content.ResetContent()
+
+	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+	assert.Nil(t, err)
 
 	aggregatorResponse := `
 	{
@@ -120,6 +126,10 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 // forwarded to the client
 func TestHTTPServer_ClustersDetailEndpointAggregatorResponse400(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
+	defer content.ResetContent()
+
+	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+	assert.Nil(t, err)
 
 	aggregatorResponse := `{"status":"Error during parsing param 'rule_selector' with value X"}`
 
@@ -161,8 +171,22 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponse400(t *testing.T) {
 // forwarded to the client
 func TestHTTPServer_ClustersDetailEndpointAggregatorResponse404(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
+	defer content.ResetContent()
+
+	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+	assert.Nil(t, err)
 
 	aggregatorResponse := `{"status":"Item with ID plugin.1|EK_1 was not found in the storage"}`
+	proxyResponse := `
+	{
+		"data":[],
+		"meta":{
+			"count":0,
+			"rule_id":"ccx_rules_ocp.external.rules.node_installer_degraded|ek1"
+		},
+		"status":"ok"
+	}
+	`
 
 	helpers.GockExpectAPIRequest(
 		t,
@@ -191,8 +215,8 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponse404(t *testing.T) {
 			EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
 			AuthorizationToken: goodJWTAuthBearer,
 		}, &helpers.APIResponse{
-			StatusCode: http.StatusNotFound,
-			Body:       aggregatorResponse,
+			StatusCode: http.StatusOK,
+			Body:       proxyResponse,
 		},
 	)
 }
@@ -202,6 +226,10 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponse404(t *testing.T) {
 // forwarded to the client
 func TestHTTPServer_ClustersDetailEndpointAggregatorResponse500(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
+	defer content.ResetContent()
+
+	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+	assert.Nil(t, err)
 
 	aggregatorResponse := `{"status": "Internal Server Error"}`
 	helpers.GockExpectAPIRequest(


### PR DESCRIPTION
# Description

- With this change, the recommendation provided to the `rule/{rule_selector}/clusters_detail` endpoint is first checked for existence, and in case it is not in the existing external rules, a 404 is returned.
- If the rule exists and the DB returns an ItemNotFound error, the proxy will return a JSON with an empty `data` field and a `200 OK` status instead of proxying the 404 error to the client. 

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Updated UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
