### PR TITLE
incerase AMS API page size to 1500 as the separate requests still take longer

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -259,4 +259,4 @@ parameters:
 - name: AMS_API_URL
   value: "https://api.stage.openshift.com"
 - name: AMS_API_PAGESIZE
-  value: "500"
+  value: "1500"


### PR DESCRIPTION
# Description
let's find the soft limit of AMS API because making more requests currently seems slower than fewer but bigger requests. Currently over 90% of time is spent talking with AMS API with an organization with >4400 clusters. The rest, even inclduing talking with aggregator takes just a couple of tenths


## Type of change


- New feature (non-breaking change which adds functionality)

## Testing steps
n/a

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
