### PR TITLE
Make AMS API fallback mechanism configurable

### DIFF
--- a/amsclient/amsclient_test.go
+++ b/amsclient/amsclient_test.go
@@ -81,67 +81,6 @@ func TestClientCreationError(t *testing.T) {
 	assert.NotEqual(t, nil, err)
 }
 
-func TestGetOrganization(t *testing.T) {
-	defer helpers.CleanAfterGock(t)
-	c, err := amsclient.NewAMSClientWithTransport(defaultConfig, gock.DefaultTransport)
-	helpers.FailOnError(t, err)
-
-	// prepare organizations response
-	helpers.GockExpectAPIRequest(t, defaultConfig.URL, &helpers.APIRequest{
-		Method:       http.MethodGet,
-		Endpoint:     organizationsSearchEndpoint,
-		EndpointArgs: []interface{}{testdata.ExternalOrgID},
-	}, &helpers.APIResponse{
-		StatusCode: http.StatusOK,
-		Headers: map[string]string{
-			"Content-Type": "application/json",
-		},
-		Body: helpers.ToJSONString(testdata.OrganizationResponse),
-	})
-
-	orgID, err := c.GetInternalOrgIDFromExternal(testdata.ExternalOrgID)
-	helpers.FailOnError(t, err)
-	assert.Equal(t, testdata.InternalOrgID, orgID)
-}
-
-func TestOrganizationBadResponses(t *testing.T) {
-	c, err := amsclient.NewAMSClientWithTransport(defaultConfig, gock.DefaultTransport)
-	helpers.FailOnError(t, err)
-	defer helpers.CleanAfterGock(t)
-
-	// prepare 3 responses that will cause different errors
-	// response OK, but unexpected data
-	helpers.GockExpectAPIRequest(t, defaultConfig.URL, &helpers.APIRequest{
-		Method:       http.MethodGet,
-		Endpoint:     organizationsSearchEndpoint,
-		EndpointArgs: []interface{}{testdata.ExternalOrgID},
-	}, &helpers.APIResponse{
-		StatusCode: http.StatusOK,
-		Headers: map[string]string{
-			"Content-Type": "application/json",
-		},
-		Body: helpers.ToJSONString(testdata.OrganizationResponse2IDs),
-	})
-
-	// response Error
-	helpers.GockExpectAPIRequest(t, defaultConfig.URL, &helpers.APIRequest{
-		Method:       http.MethodGet,
-		Endpoint:     organizationsSearchEndpoint,
-		EndpointArgs: []interface{}{testdata.ExternalOrgID},
-	}, &helpers.APIResponse{
-		StatusCode: http.StatusNotFound,
-		Headers: map[string]string{
-			"Content-Type": "application/json",
-		},
-	})
-
-	_, err = c.GetInternalOrgIDFromExternal(testdata.ExternalOrgID)
-	assert.NotEqual(t, nil, err)
-
-	_, err = c.GetInternalOrgIDFromExternal(testdata.ExternalOrgID)
-	assert.NotEqual(t, nil, err)
-}
-
 func TestClusterForOrganization(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
 	c, err := amsclient.NewAMSClientWithTransport(defaultConfig, gock.DefaultTransport)

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -36,4 +36,5 @@ type Configuration struct {
 	EnableInternalRulesOrganizations bool          `mapstructure:"enable_internal_rules_organizations" toml:"enable_internal_rules_organizations"`
 	InternalRulesOrganizations       []types.OrgID `mapstructure:"internal_rules_organizations" toml:"internal_rules_organizations"`
 	LogAuthToken                     bool          `mapstructure:"log_auth_token" toml:"log_auth_token"`
+	UseOrgClustersFallback           bool          `mapstructure:"org_clusters_fallback" toml:"org_clusters_fallback"`
 }

--- a/server/server.go
+++ b/server/server.go
@@ -74,15 +74,14 @@ const (
 
 // HTTPServer is an implementation of Server interface
 type HTTPServer struct {
-	Config                 Configuration
-	InfoParams             map[string]string
-	ServicesConfig         services.Configuration
-	amsClient              amsclient.AMSClient
-	GroupsChannel          chan []groups.Group
-	ErrorFoundChannel      chan bool
-	ErrorChannel           chan error
-	useOrgClustersFallback bool
-	Serv                   *http.Server
+	Config            Configuration
+	InfoParams        map[string]string
+	ServicesConfig    services.Configuration
+	amsClient         amsclient.AMSClient
+	GroupsChannel     chan []groups.Group
+	ErrorFoundChannel chan bool
+	ErrorChannel      chan error
+	Serv              *http.Server
 }
 
 // RequestModifier is a type of function which modifies request when proxying
@@ -108,14 +107,13 @@ func New(config Configuration,
 ) *HTTPServer {
 
 	return &HTTPServer{
-		Config:                 config,
-		InfoParams:             make(map[string]string),
-		ServicesConfig:         servicesConfig,
-		amsClient:              amsClient,
-		GroupsChannel:          groupsChannel,
-		ErrorFoundChannel:      errorFoundChannel,
-		ErrorChannel:           errorChannel,
-		useOrgClustersFallback: config.UseOrgClustersFallback,
+		Config:            config,
+		InfoParams:        make(map[string]string),
+		ServicesConfig:    servicesConfig,
+		amsClient:         amsClient,
+		GroupsChannel:     groupsChannel,
+		ErrorFoundChannel: errorFoundChannel,
+		ErrorChannel:      errorChannel,
 	}
 }
 
@@ -369,10 +367,9 @@ func (server HTTPServer) readClusterIDsForOrgID(orgID types.OrgID) ([]types.Clus
 		}
 
 		log.Error().Err(err).Msg("Error accessing amsclient")
-		return nil, err
 	}
 
-	if !server.useOrgClustersFallback {
+	if !server.Config.UseOrgClustersFallback {
 		err := fmt.Errorf("amsclient not initialized")
 		log.Error().Err(err).Msg("")
 		return nil, err

--- a/server/server.go
+++ b/server/server.go
@@ -77,7 +77,7 @@ type HTTPServer struct {
 	Config            Configuration
 	InfoParams        map[string]string
 	ServicesConfig    services.Configuration
-	amsClient         *amsclient.AMSClient
+	amsClient         amsclient.AMSClient
 	GroupsChannel     chan []groups.Group
 	ErrorFoundChannel chan bool
 	ErrorChannel      chan error
@@ -100,19 +100,11 @@ type ProxyOptions struct {
 // New function constructs new implementation of Server interface.
 func New(config Configuration,
 	servicesConfig services.Configuration,
-	amsConfig amsclient.Configuration,
+	amsClient amsclient.AMSClient,
 	groupsChannel chan []groups.Group,
 	errorFoundChannel chan bool,
 	errorChannel chan error,
 ) *HTTPServer {
-
-	amsClient, err := amsclient.NewAMSClient(amsConfig)
-	if err != nil {
-		log.Error().Err(err).Msg("Cannot init the AMSClient, using old approach")
-		amsClient = nil
-	} else {
-		log.Info().Msg("AMSClient succesfully created")
-	}
 
 	return &HTTPServer{
 		Config:            config,
@@ -374,30 +366,13 @@ func (server HTTPServer) readClusterIDsForOrgID(orgID types.OrgID) ([]types.Clus
 			return clusters, err
 		}
 
-		log.Warn().Err(err).Msg("amsclient is initialized, but the cluster list cannot be retrieved. Using fallback method")
-	} else {
-		log.Info().Msg("amsclient not initialized, retrieving cluster list from aggregator database")
-	}
-
-	aggregatorURL := httputils.MakeURLToEndpoint(
-		server.ServicesConfig.AggregatorBaseEndpoint,
-		ira_server.ClustersForOrganizationEndpoint,
-		orgID,
-	)
-
-	// #nosec G107
-	response, err := http.Get(aggregatorURL)
-	if err != nil {
+		log.Error().Err(err).Msg("Error accessing amsclient")
 		return nil, err
 	}
 
-	var recvMsg struct {
-		Status   string              `json:"status"`
-		Clusters []types.ClusterName `json:"clusters"`
-	}
-
-	err = json.NewDecoder(response.Body).Decode(&recvMsg)
-	return recvMsg.Clusters, err
+	err := fmt.Errorf("amsclient not initialized")
+	log.Error().Err(err).Msg("")
+	return nil, err
 }
 
 // readAggregatorReportForClusterID reads report from aggregator,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -24,8 +24,11 @@ import (
 	"time"
 
 	"github.com/RedHatInsights/insights-content-service/groups"
+	"github.com/RedHatInsights/insights-operator-utils/responses"
+	iou_helpers "github.com/RedHatInsights/insights-operator-utils/tests/helpers"
 	iou_types "github.com/RedHatInsights/insights-operator-utils/types"
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
+	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
@@ -843,6 +846,55 @@ func TestAddCORSHeaders(t *testing.T) {
 			"Access-Control-Allow-Headers":     "X-Csrf-Token,Content-Type,Content-Length",
 		},
 	})
+}
+
+//
+// TestHTTPServer_OverviewEndpointWithFallback
+func TestHTTPServer_OverviewEndpointWithFallback(t *testing.T) {
+	defer content.ResetContent()
+	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+	assert.Nil(t, err)
+
+	helpers.RunTestWithTimeout(t, func(t testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		// prepare list of organizations response
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ClustersForOrganizationEndpoint,
+			EndpointArgs: []interface{}{testdata.OrgID},
+		}, &helpers.APIResponse{
+			StatusCode: http.StatusOK,
+			Body:       helpers.ToJSONString(responses.BuildOkResponseWithData("clusters", []string{string(testdata.ClusterName)})),
+		})
+
+		// prepare report for cluster
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ReportEndpoint,
+			EndpointArgs: []interface{}{testdata.OrgID, testdata.ClusterName, testdata.UserID},
+		}, &helpers.APIResponse{
+			StatusCode: http.StatusOK,
+			Body:       testdata.Report3RulesExpectedResponse,
+		})
+
+		config := helpers.DefaultServerConfig
+		config.UseOrgClustersFallback = true
+		testServer := helpers.CreateHTTPServer(&config, nil, nil, nil, nil, nil)
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			helpers.DefaultServerConfig.APIv1Prefix,
+			&helpers.APIRequest{
+				Method:   http.MethodGet,
+				Endpoint: server.OverviewEndpoint,
+				OrgID:    testdata.OrgID,
+				UserID:   testdata.UserID,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       helpers.ToJSONString(OverviewResponse),
+			})
+	}, testTimeout)
 }
 
 func ruleIDsChecker(t testing.TB, expected, got []byte) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/RedHatInsights/insights-results-smart-proxy/amsclient"
 	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/services"
@@ -816,7 +815,7 @@ func TestServerStartError(t *testing.T) {
 		ContentBaseEndpoint:    "http://localhost:8082/api/v1/",
 		// GroupsPollingTime:      2 * time.Minute,
 	},
-		amsclient.Configuration{},
+		nil,
 		nil,
 		nil,
 		nil,

--- a/tests/helpers/amsclient.go
+++ b/tests/helpers/amsclient.go
@@ -1,0 +1,49 @@
+// Copyright 2021 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"fmt"
+
+	"github.com/RedHatInsights/insights-operator-utils/types"
+	"github.com/RedHatInsights/insights-results-smart-proxy/amsclient"
+)
+
+type mockAMSClient struct {
+	clustersPerOrg map[types.OrgID][]types.ClusterName
+}
+
+func (m *mockAMSClient) GetClustersForOrganization(
+	orgID types.OrgID,
+	unused1, unused2 []string,
+) ([]types.ClusterName, error) {
+
+	clusters, ok := m.clustersPerOrg[orgID]
+	if !ok {
+		return nil, fmt.Errorf("No clusters")
+	}
+
+	return clusters, nil
+}
+
+// AMSClientWithOrgResults creates a mock of AMSClient interface that returns the results
+// defined by orgID and clusters parameters
+func AMSClientWithOrgResults(orgID types.OrgID, clusters []types.ClusterName) amsclient.AMSClient {
+	return &mockAMSClient{
+		clustersPerOrg: map[types.OrgID][]types.ClusterName{
+			orgID: clusters,
+		},
+	}
+}


### PR DESCRIPTION
# Description

With this PR the fallback mechanism in case that AMS API is not configured or it isn't working is configurable.

Refactored the amsclient and its usages to make it easier to use a test double.
Refactored unit tests that rely on the fallback mechanism
Added new UT for testing fallback mechanism in case it is needed

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Tested though unit tests

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
