### PR TITLE
Adding display name to the results gathered by amsclient

### DIFF
--- a/amsclient/amsclient_test.go
+++ b/amsclient/amsclient_test.go
@@ -32,9 +32,10 @@ import (
 
 const (
 	organizationsSearchEndpoint = "api/accounts_mgmt/v1/organizations?fields=id%%2Cexternal_id&search=external_id+%%3D+{orgID}"
-	subscriptionsSearchEndpoint = "api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id&page={pageNum}&search=organization_id+is+%%27{orgID}%%27&size={pageSize}"
 
-	subscriptionsSearchEndpointWithFilter = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id&page={pageNum}&" +
+	subscriptionsSearchEndpoint = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id%%2Cdisplay_name&page={pageNum}&" +
+		"search=organization_id+is+%%27{orgID}%%27&size={pageSize}")
+	subscriptionsSearchEndpointWithFilter = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id%%2Cdisplay_name&page={pageNum}&" +
 		"search=organization_id+is+%%27{orgID}%%27+and+status+in+%%28%%27{status1}%%27%%2C%%27{status2}%%27%%29&size={pageSize}")
 )
 

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
 	data "github.com/RedHatInsights/insights-results-smart-proxy/tests/testdata"
+	stypes "github.com/RedHatInsights/insights-results-smart-proxy/types"
 )
 
 var (
@@ -493,7 +494,7 @@ func TestHTTPServer_OverviewEndpoint(t *testing.T) {
 		// prepare list of organizations response
 		amsClientMock := helpers.AMSClientWithOrgResults(
 			testdata.OrgID,
-			[]types.ClusterName{testdata.ClusterName},
+			data.ClusterInfoResult,
 		)
 
 		// prepare report for cluster
@@ -541,7 +542,7 @@ func TestHTTPServer_OverviewEndpoint_UnavailableContentService(t *testing.T) {
 		// prepare response from amsclient for list of clusters
 		amsClientMock := helpers.AMSClientWithOrgResults(
 			testdata.OrgID,
-			[]types.ClusterName{testdata.ClusterName},
+			data.ClusterInfoResult,
 		)
 
 		// prepare report for cluster
@@ -783,11 +784,12 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing(t *testin
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
-		clusterList := make([]types.ClusterName, 2)
-		for i := range clusterList {
-			clusterList[i] = testdata.GetRandomClusterID()
+		clusterInfoList := make([]stypes.ClusterInfo, 2)
+		for i := range clusterInfoList {
+			clusterInfoList[i] = data.GetRandomClusterInfo()
 		}
 
+		clusterList := stypes.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
 		respBody := `{"recommendations":{"%v":%v,"%v":%v},"status":"ok"}`
@@ -799,7 +801,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing(t *testin
 		// prepare response from amsclient for list of clusters
 		amsClientMock := helpers.AMSClientWithOrgResults(
 			testdata.OrgID,
-			clusterList,
+			clusterInfoList,
 		)
 
 		// prepare response from aggregator for recommendations
@@ -856,11 +858,12 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisab
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
-		clusterList := make([]types.ClusterName, 2)
-		for i := range clusterList {
-			clusterList[i] = testdata.GetRandomClusterID()
+		clusterInfoList := make([]stypes.ClusterInfo, 2)
+		for i := range clusterInfoList {
+			clusterInfoList[i] = data.GetRandomClusterInfo()
 		}
 
+		clusterList := stypes.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
 		respBody := `{"recommendations":{"%v":%v,"%v":%v},"status":"ok"}`
@@ -872,7 +875,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisab
 		// prepare response from amsclient for list of clusters
 		amsClientMock := helpers.AMSClientWithOrgResults(
 			testdata.OrgID,
-			clusterList,
+			clusterInfoList,
 		)
 
 		// prepare response from aggregator for recommendations
@@ -938,11 +941,12 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1MissingContent(t *testing.
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
-		clusterList := make([]types.ClusterName, 2)
-		for i := range clusterList {
-			clusterList[i] = testdata.GetRandomClusterID()
+		clusterInfoList := make([]stypes.ClusterInfo, 2)
+		for i := range clusterInfoList {
+			clusterInfoList[i] = data.GetRandomClusterInfo()
 		}
 
+		clusterList := stypes.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
 		respBody := `{"recommendations":{"%v":%v,"%v":%v},"status":"ok"}`
@@ -954,7 +958,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1MissingContent(t *testing.
 		// prepare response from amsclient for list of clusters
 		amsClientMock := helpers.AMSClientWithOrgResults(
 			testdata.OrgID,
-			clusterList,
+			clusterInfoList,
 		)
 
 		// prepare response from aggregator for recommendations
@@ -1002,11 +1006,12 @@ func TestHTTPServer_RecommendationsListEndpoint_NoRuleContent(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
-		clusterList := make([]types.ClusterName, 2)
-		for i := range clusterList {
-			clusterList[i] = testdata.GetRandomClusterID()
+		clusterInfoList := make([]stypes.ClusterInfo, 2)
+		for i := range clusterInfoList {
+			clusterInfoList[i] = data.GetRandomClusterInfo()
 		}
 
+		clusterList := stypes.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
 		respBody := `{"recommendations":{"%v":%v,"%v":%v,"%v":%v},"status":"ok"}`
@@ -1019,7 +1024,7 @@ func TestHTTPServer_RecommendationsListEndpoint_NoRuleContent(t *testing.T) {
 		// prepare response from amsclient for list of clusters
 		amsClientMock := helpers.AMSClientWithOrgResults(
 			testdata.OrgID,
-			clusterList,
+			clusterInfoList,
 		)
 
 		// prepare response from aggregator for recommendations
@@ -1075,11 +1080,12 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
-		clusterList := make([]types.ClusterName, 2)
-		for i := range clusterList {
-			clusterList[i] = testdata.GetRandomClusterID()
+		clusterInfoList := make([]stypes.ClusterInfo, 2)
+		for i := range clusterInfoList {
+			clusterInfoList[i] = data.GetRandomClusterInfo()
 		}
 
+		clusterList := stypes.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
 		respBody := `{"recommendations":{},"status":"ok"}`
@@ -1087,7 +1093,7 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 		// prepare response from amsClient for list of clusters
 		amsClientMock := helpers.AMSClientWithOrgResults(
 			testdata.OrgID,
-			clusterList,
+			clusterInfoList,
 		)
 
 		// prepare response from aggregator for recommendations
@@ -1143,11 +1149,12 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
-		clusterList := make([]types.ClusterName, 2)
-		for i := range clusterList {
-			clusterList[i] = testdata.GetRandomClusterID()
+		clusterInfoList := make([]stypes.ClusterInfo, 2)
+		for i := range clusterInfoList {
+			clusterInfoList[i] = data.GetRandomClusterInfo()
 		}
 
+		clusterList := stypes.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
 		respBody := `{"recommendations":{},"status":"ok"}`
@@ -1155,7 +1162,7 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 		// prepare response from amsclient for list of clusters
 		amsClientMock := helpers.AMSClientWithOrgResults(
 			testdata.OrgID,
-			clusterList,
+			clusterInfoList,
 		)
 
 		// prepare response from aggregator for recommendations
@@ -1212,11 +1219,12 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_Impactin
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
-		clusterList := make([]types.ClusterName, 2)
-		for i := range clusterList {
-			clusterList[i] = testdata.GetRandomClusterID()
+		clusterInfoList := make([]stypes.ClusterInfo, 2)
+		for i := range clusterInfoList {
+			clusterInfoList[i] = data.GetRandomClusterInfo()
 		}
 
+		clusterList := stypes.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
 		respBody := `{"recommendations":{"%v":%v},"status":"ok"}`
@@ -1227,7 +1235,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_Impactin
 		// prepare response from amsclient for list of clusters
 		amsClientMock := helpers.AMSClientWithOrgResults(
 			testdata.OrgID,
-			clusterList,
+			clusterInfoList,
 		)
 
 		// prepare response from aggregator for recommendations
@@ -1289,11 +1297,12 @@ func TestHTTPServer_RecommendationsListEndpoint4Rules1Internal2Clusters_Impactin
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
-		clusterList := make([]types.ClusterName, 2)
-		for i := range clusterList {
-			clusterList[i] = testdata.GetRandomClusterID()
+		clusterInfoList := make([]stypes.ClusterInfo, 2)
+		for i := range clusterInfoList {
+			clusterInfoList[i] = data.GetRandomClusterInfo()
 		}
 
+		clusterList := stypes.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
 		respBody := `{"recommendations":{"%v":%v},"status":"ok"}`
@@ -1304,7 +1313,7 @@ func TestHTTPServer_RecommendationsListEndpoint4Rules1Internal2Clusters_Impactin
 		// prepare response from amsclient for list of clusters
 		amsClientMock := helpers.AMSClientWithOrgResults(
 			testdata.OrgID,
-			clusterList,
+			clusterInfoList,
 		)
 
 		// prepare response from aggregator for recommendations

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -24,8 +24,6 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/RedHatInsights/insights-results-smart-proxy/amsclient"
-
 	"github.com/rs/zerolog/log"
 
 	"github.com/RedHatInsights/insights-content-service/groups"
@@ -36,6 +34,7 @@ import (
 
 	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
 
+	"github.com/RedHatInsights/insights-results-smart-proxy/amsclient"
 	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 	stypes "github.com/RedHatInsights/insights-results-smart-proxy/types"
 )
@@ -593,7 +592,7 @@ func (server HTTPServer) getClustersDetailForRule(writer http.ResponseWriter, re
 	activeClusters := make([]types.ClusterName, 0)
 	// Get list of active clusters if AMS client is available
 	if server.amsClient != nil {
-		activeClusters, err = server.amsClient.GetClustersForOrganization(
+		activeClustersInfo, err := server.amsClient.GetClustersForOrganization(
 			orgID,
 			nil,
 			[]string{amsclient.StatusDeprovisioned, amsclient.StatusArchived},
@@ -602,6 +601,8 @@ func (server HTTPServer) getClustersDetailForRule(writer http.ResponseWriter, re
 		if err != nil {
 			log.Error().Err(err).Msg("amsclient was unable to retrieve the list of active clusters")
 			activeClusters = make([]types.ClusterName, 0)
+		} else {
+			activeClusters = stypes.GetClusterNames(activeClustersInfo)
 		}
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -362,7 +362,8 @@ func (server HTTPServer) readClusterIDsForOrgID(orgID types.OrgID) ([]types.Clus
 		)
 		if err == nil {
 			log.Info().Int(orgIDTag, int(orgID)).Msgf("Number of clusters retrieved from the AMS API: %v", len(clusters))
-			return clusters, err
+			clusterNames := proxy_types.GetClusterNames(clusters)
+			return clusterNames, err
 		}
 
 		log.Error().Err(err).Msg("Error accessing amsclient")

--- a/server/utils.go
+++ b/server/utils.go
@@ -1,3 +1,17 @@
+// Copyright 2021 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package server
 
 import (

--- a/tests/helpers/amsclient.go
+++ b/tests/helpers/amsclient.go
@@ -17,18 +17,18 @@ package helpers
 import (
 	"fmt"
 
-	"github.com/RedHatInsights/insights-operator-utils/types"
 	"github.com/RedHatInsights/insights-results-smart-proxy/amsclient"
+	"github.com/RedHatInsights/insights-results-smart-proxy/types"
 )
 
 type mockAMSClient struct {
-	clustersPerOrg map[types.OrgID][]types.ClusterName
+	clustersPerOrg map[types.OrgID][]types.ClusterInfo
 }
 
 func (m *mockAMSClient) GetClustersForOrganization(
 	orgID types.OrgID,
 	unused1, unused2 []string,
-) ([]types.ClusterName, error) {
+) ([]types.ClusterInfo, error) {
 
 	clusters, ok := m.clustersPerOrg[orgID]
 	if !ok {
@@ -40,9 +40,9 @@ func (m *mockAMSClient) GetClustersForOrganization(
 
 // AMSClientWithOrgResults creates a mock of AMSClient interface that returns the results
 // defined by orgID and clusters parameters
-func AMSClientWithOrgResults(orgID types.OrgID, clusters []types.ClusterName) amsclient.AMSClient {
+func AMSClientWithOrgResults(orgID types.OrgID, clusters []types.ClusterInfo) amsclient.AMSClient {
 	return &mockAMSClient{
-		clustersPerOrg: map[types.OrgID][]types.ClusterName{
+		clustersPerOrg: map[types.OrgID][]types.ClusterInfo{
 			orgID: clusters,
 		},
 	}

--- a/tests/testdata/amstestdata.go
+++ b/tests/testdata/amstestdata.go
@@ -77,10 +77,12 @@ var (
 		"total": 2,
 		"items": []map[string]interface{}{
 			{
+				"display_name":        ClusterDisplayName1,
 				"external_cluster_id": ClusterName1,
 				"id":                  "1YfQ9bR7LTDz24YzfFmaCdeB0sS",
 			},
 			{
+				"display_name":        ClusterDisplayName2,
 				"external_cluster_id": ClusterName2,
 				"id":                  "1YfQLCOCZZOEXgOp8uIbqe5i5z2",
 			},

--- a/tests/testdata/testdata.go
+++ b/tests/testdata/testdata.go
@@ -20,13 +20,20 @@ import (
 
 	"github.com/RedHatInsights/insights-operator-utils/types"
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
+
+	stypes "github.com/RedHatInsights/insights-results-smart-proxy/types"
 )
 
 const (
 	ClusterName1 = "00000000-bbbb-cccc-dddd-eeeeeeeeeeee"
 	ClusterName2 = "11111111-bbbb-cccc-dddd-eeeeeeeeeeee"
 	ClusterName3 = "22222222-bbbb-cccc-dddd-eeeeeeeeeeee"
-	GeneratedAt  = "2020-03-06T12:00:00Z"
+
+	ClusterDisplayName1 = "Cluster 1"
+	ClusterDisplayName2 = "Cluster 2"
+	ClusterDisplayName3 = "Cluster 3"
+
+	GeneratedAt = "2020-03-06T12:00:00Z"
 )
 
 var (
@@ -73,7 +80,24 @@ var (
 		GeneratedAt: GeneratedAt,
 		Status:      "ok",
 	}
+
+	ClusterInfoResult = []stypes.ClusterInfo{
+		stypes.ClusterInfo{
+			ID:          testdata.ClusterName,
+			DisplayName: ClusterDisplayName1,
+		},
+	}
 )
+
+// GetRandomClusterInfo function returns a ClusterInfo with random ID
+// and using the same ID as DisplayName
+func GetRandomClusterInfo() stypes.ClusterInfo {
+	clusterID := testdata.GetRandomClusterID()
+	return stypes.ClusterInfo{
+		ID:          clusterID,
+		DisplayName: string(clusterID),
+	}
+}
 
 func whateverToJSONRawMessage(obj interface{}) json.RawMessage {
 	var result json.RawMessage

--- a/types/operations.go
+++ b/types/operations.go
@@ -1,0 +1,26 @@
+// Copyright 2021 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// GetClusterNames extract the ClusterName from an array of ClusterInfo
+func GetClusterNames(clustersInfo []ClusterInfo) []ClusterName {
+	var retval []ClusterName = make([]ClusterName, 0)
+
+	for _, info := range clustersInfo {
+		retval = append(retval, info.ID)
+	}
+
+	return retval
+}

--- a/types/types.go
+++ b/types/types.go
@@ -39,6 +39,12 @@ type RuleContent = types.RuleContent
 // RuleID is a rename for types.RuleID
 type RuleID = types.RuleID
 
+// ClusterName is a rename for types.ClusterName
+type ClusterName = types.ClusterName
+
+// OrgID is a rename for types.OrgID
+type OrgID = types.OrgID
+
 // ImpactingFlag controls the behaviour of 'impacting' param on GET /rule/
 type ImpactingFlag int
 
@@ -252,4 +258,10 @@ type InfoResponse struct {
 	SmartProxy     map[string]string `json:"SmartProxy"`
 	Aggregator     map[string]string `json:"Aggregator"`
 	ContentService map[string]string `json:"ContentService"`
+}
+
+// ClusterInfo is a data structure containing some relevant cluster information
+type ClusterInfo struct {
+	ID          ClusterName
+	DisplayName string
 }


### PR DESCRIPTION
# Description

Adding "display_name" column from AMS API into the results generated by the `amsclient` package.
Adapted `amsclient` unittests
Adapted `server` package code relying on `amsclient` output
New type for `ClusterInfo`, just in case we need more things apart of ID and display name in the future
Adapted `server` unit tests, as they use the mocked `amsclient` version

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps

Tested locally against stage environment and unit tests

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
