### PR TITLE
[CCXDEV-6474] Update go image version to 1.16

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.14.1'
+          go-version: '^1.16.7'
       - name: Generate docgo
         run: make godoc
       - name: Store the Gitleaks file

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,6 @@ go:
 
 jobs:
   include:
-    - name: "Build 1.15"
-      stage: build
-      go: "1.15"
-      script:
-        - make
     - name: "Build 1.16"
       stage: build
       script:

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/rhel8/go-toolset:1.16.7 AS builder
+FROM registry.redhat.io/rhel8/go-toolset:1.16 AS builder
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.redhat.io/rhel8/go-toolset:1.15 AS builder
+FROM registry.redhat.io/rhel8/go-toolset:1.16.7 AS builder
 
 COPY . .
 


### PR DESCRIPTION
# Description

Use [RHEL image](https://catalog.redhat.com/software/containers/rhel8/go-toolset/5b9c810add19c70b45cbd666?container-tabs=overview) with `go 1.16` version.

Fixes [CCXDEV-6474](https://issues.redhat.com/browse/CCXDEV-6474).

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
