### PR TITLE
Return cluster names in clusters details

### DIFF
--- a/types/operations.go
+++ b/types/operations.go
@@ -14,12 +14,27 @@
 
 package types
 
+import (
+	ctypes "github.com/RedHatInsights/insights-results-types"
+)
+
 // GetClusterNames extract the ClusterName from an array of ClusterInfo
 func GetClusterNames(clustersInfo []ClusterInfo) []ClusterName {
 	var retval []ClusterName = make([]ClusterName, 0)
 
 	for _, info := range clustersInfo {
 		retval = append(retval, info.ID)
+	}
+
+	return retval
+}
+
+// ClusterInfoArrayToMap convert an array of ClusterInfo elements into a map using
+// ClusterName as key
+func ClusterInfoArrayToMap(clustersInfo []ClusterInfo) map[ctypes.ClusterName]string {
+	var retval map[ctypes.ClusterName]string = make(map[ctypes.ClusterName]string)
+	for _, clusterInfo := range clustersInfo {
+		retval[clusterInfo.ID] = clusterInfo.DisplayName
 	}
 
 	return retval


### PR DESCRIPTION
# Description

Adding the "cluster_name" in the response of the cluster_details endpoint, added to the existing cluster_id.

## Type of change
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Testing steps

Testes though local environment and unit tests

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
