### PR TITLE
Add smart-proxy part for OCP Advisor Milestone 2 (Clusters View)

### DIFF
--- a/amsclient/amsclient_test.go
+++ b/amsclient/amsclient_test.go
@@ -125,9 +125,10 @@ func TestClusterForOrganization(t *testing.T) {
 		Body: helpers.ToJSONString(testdata.SubscriptionEmptyResponse),
 	})
 
-	clusterList, err := c.GetClustersForOrganization(testdata.ExternalOrgID, nil, nil)
+	clusterList, clusterMap, err := c.GetClustersForOrganization(testdata.ExternalOrgID, nil, nil)
 	helpers.FailOnError(t, err)
 	assert.Equal(t, 2, len(clusterList))
+	assert.Equal(t, 2, len(clusterMap))
 }
 
 func TestClusterForOrganizationWithFiltering(t *testing.T) {
@@ -173,7 +174,7 @@ func TestClusterForOrganizationWithFiltering(t *testing.T) {
 		Body: helpers.ToJSONString(testdata.SubscriptionEmptyResponse),
 	})
 
-	clusterList, err := c.GetClustersForOrganization(
+	clusterList, clusterMap, err := c.GetClustersForOrganization(
 		testdata.ExternalOrgID,
 		[]string{amsclient.StatusArchived, amsclient.StatusDeprovisioned},
 		nil,
@@ -181,15 +182,17 @@ func TestClusterForOrganizationWithFiltering(t *testing.T) {
 
 	helpers.FailOnError(t, err)
 	assert.Equal(t, 2, len(clusterList))
+	assert.Equal(t, 2, len(clusterMap))
 }
 
 func TestGetClustersForOrganizationOnError(t *testing.T) {
 	client, err := amsclient.NewAMSClient(defaultConfig)
 	helpers.FailOnError(t, err) // Doesn't fail because ocm-sdk doesn't perform any checks
 
-	clusters, err := client.GetClustersForOrganization(testdata.ExternalOrgID, nil, nil)
+	clusters, clusterMap, err := client.GetClustersForOrganization(testdata.ExternalOrgID, nil, nil)
 	if err == nil {
 		t.Fail()
 	}
 	assert.Equal(t, 0, len(clusters))
+	assert.Equal(t, 0, len(clusterMap))
 }

--- a/content/content.go
+++ b/content/content.go
@@ -216,9 +216,9 @@ func (s *RulesWithContentStorage) GetExternalRuleIDs() []ctypes.RuleID {
 	return s.externalRuleIDs
 }
 
-// GetRuleSeverities returns a map of rule IDs and their severity (total risk)
+// GetExternalRuleSeverities returns a map of external rule IDs and their severity (total risk)
 // along with a list of unique severities
-func (s *RulesWithContentStorage) GetRuleSeverities() (
+func (s *RulesWithContentStorage) GetExternalRuleSeverities() (
 	severityMap map[ctypes.RuleID]int,
 	uniqueSeverities []int,
 ) {
@@ -226,11 +226,12 @@ func (s *RulesWithContentStorage) GetRuleSeverities() (
 	defer s.Unlock()
 
 	severityMap = make(map[ctypes.RuleID]int)
-	uniqueMap := make(map[int]bool)
-	for ruleID := range s.recommendationsWithContent {
+	uniqueMap := make(map[int]interface{})
+
+	for _, ruleID := range s.externalRuleIDs {
 		totalRisk := s.recommendationsWithContent[ruleID].TotalRisk
 		severityMap[ruleID] = totalRisk
-		uniqueMap[totalRisk] = true
+		uniqueMap[totalRisk] = nil
 	}
 
 	for k := range uniqueMap {
@@ -392,9 +393,9 @@ func GetExternalRuleIDs() ([]ctypes.RuleID, error) {
 	return rulesWithContentStorage.GetExternalRuleIDs(), nil
 }
 
-// GetRuleSeverities returns a map of rule IDs and their severity (total risk),
+// GetExternalRuleSeverities returns a map of rule IDs and their severity (total risk),
 // along with a list of unique severities
-func GetRuleSeverities() (
+func GetExternalRuleSeverities() (
 	map[ctypes.RuleID]int,
 	[]int,
 	error,
@@ -405,7 +406,7 @@ func GetRuleSeverities() (
 		return nil, nil, err
 	}
 
-	severityMap, uniqueSeverities := rulesWithContentStorage.GetRuleSeverities()
+	severityMap, uniqueSeverities := rulesWithContentStorage.GetExternalRuleSeverities()
 	return severityMap, uniqueSeverities, nil
 }
 

--- a/content/content_test.go
+++ b/content/content_test.go
@@ -591,6 +591,65 @@ func TestGetExternalRuleIDs(t *testing.T) {
 	assert.Equal(t, 3, len(externalRuleIDs))
 }
 
+// TestGetExternalRuleSeveritiesTwoUnique tests GetExternalRuleSeverities
+func TestGetExternalRuleSeverities1Unique(t *testing.T) {
+	defer content.ResetContent()
+
+	// same total risk
+	externalRule1, externalRule2, internalRule1 := testdata.RuleContent1, testdata.RuleContent1, testdata.RuleContent1
+	fakeRuleAsExternal(&externalRule1)
+	fakeRuleAsExternal(&externalRule2)
+	fakeRuleAsInternal(&internalRule1)
+
+	ruleContentDirectory := ctypes.RuleContentDirectory{
+		Config: ctypes.GlobalRuleConfig{
+			Impact: testdata.ImpactStrToInt,
+		},
+		Rules: map[string]ctypes.RuleContent{
+			"rc1": externalRule1,
+			"rc2": externalRule2,
+			"rc3": internalRule1,
+		},
+	}
+
+	content.LoadRuleContent(&ruleContentDirectory)
+
+	recommendationSeverities, uniqueSeverities, err := content.GetExternalRuleSeverities()
+	helpers.FailOnError(t, err)
+	assert.Equal(t, 2, len(recommendationSeverities))
+	// rules have the same severity
+	assert.Equal(t, 1, len(uniqueSeverities))
+}
+
+// TestGetExternalRuleSeverities2Unique tests GetExternalRuleSeverities
+func TestGetExternalRuleSeverities2Unique(t *testing.T) {
+	defer content.ResetContent()
+
+	externalRule1, externalRule2, internalRule1 := testdata.RuleContent1, testdata.RuleContent2, testdata.RuleContent1
+	fakeRuleAsExternal(&externalRule1)
+	fakeRuleAsExternal(&externalRule2)
+	fakeRuleAsInternal(&internalRule1)
+
+	ruleContentDirectory := ctypes.RuleContentDirectory{
+		Config: ctypes.GlobalRuleConfig{
+			Impact: testdata.ImpactStrToInt,
+		},
+		Rules: map[string]ctypes.RuleContent{
+			"rc1": externalRule1,
+			"rc2": externalRule2,
+			"rc3": internalRule1,
+		},
+	}
+
+	content.LoadRuleContent(&ruleContentDirectory)
+
+	recommendationSeverities, uniqueSeverities, err := content.GetExternalRuleSeverities()
+	helpers.FailOnError(t, err)
+	assert.Equal(t, 2, len(recommendationSeverities))
+	// rules have different severity
+	assert.Equal(t, 2, len(uniqueSeverities))
+}
+
 func fakeRuleAsInternal(ruleContent *ctypes.RuleContent) {
 	modifyPluginPythonModule(ruleContent, internalStr)
 }

--- a/content/parsing.go
+++ b/content/parsing.go
@@ -97,7 +97,8 @@ func LoadRuleContent(contentDir *ctypes.RuleContentDirectory) {
 	}
 }
 
-// TODO: move to utils
+// According to rule content specification, it's explicitly defined as floor((impact + likelihood) / 2), which
+// is the default behaviour in Go
 func calculateTotalRisk(impact, likelihood int) int {
 	return (impact + likelihood) / 2
 }

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20211119142943-71a7a9be7bb8
 	github.com/RedHatInsights/insights-operator-utils v1.22.0
-	github.com/RedHatInsights/insights-results-aggregator v1.2.0
+	github.com/RedHatInsights/insights-results-aggregator v1.2.1
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.4
-	github.com/RedHatInsights/insights-results-types v1.3.1
+	github.com/RedHatInsights/insights-results-types v1.3.3
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/handlers v1.5.1

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20211119142943-71a7a9be7bb8
 	github.com/RedHatInsights/insights-operator-utils v1.22.0
-	github.com/RedHatInsights/insights-results-aggregator v1.1.12
+	github.com/RedHatInsights/insights-results-aggregator v1.2.0
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.4
-	github.com/RedHatInsights/insights-results-types v1.3.0
+	github.com/RedHatInsights/insights-results-types v1.3.1
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/RedHatInsights/insights-operator-utils v1.21.8/go.mod h1:qa1a8NdarIzc
 github.com/RedHatInsights/insights-operator-utils v1.22.0 h1:rXK/n6gJca5u/jmi62QyOeAR0EaUcoBLmGdBwqMBG7s=
 github.com/RedHatInsights/insights-operator-utils v1.22.0/go.mod h1:4G1aWUV3SBc5tRflpAZX2BjoWB8afxXtSutg+5/sLE8=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
-github.com/RedHatInsights/insights-results-aggregator v1.1.12 h1:NuagjDWHnsW2ZLV+3Bf9RnileGln/6bNkkDbUydCZwo=
-github.com/RedHatInsights/insights-results-aggregator v1.1.12/go.mod h1:G0mBu/+u52fecujHpmtJFlDko99bhPba/RSb6sYlOu0=
+github.com/RedHatInsights/insights-results-aggregator v1.2.0 h1:UEb7GkPIBawg5vzf/TCbH8c2XiMqbrgGkWUOmo/FFqc=
+github.com/RedHatInsights/insights-results-aggregator v1.2.0/go.mod h1:y/kNpJ+E1/bbIDEjjtZykfnk11g9mNhlefp3HU4V9Jc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=
@@ -91,14 +91,13 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.0.1-0.202106140729
 github.com/RedHatInsights/insights-results-aggregator-data v1.1.2/go.mod h1:rbiccYJ8whbpLLvNGMiaFzyMPs1A/2/Jh0P2U9DXF+4=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.1/go.mod h1:Ylo2cWFmraBzkwKLew54kZSsUTgeVvFJdIi/oRkdxtc=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.2/go.mod h1:E1UaB+IjJ/muxvMstVoqJrB82zVKNykjTtCiM3tMHoM=
-github.com/RedHatInsights/insights-results-aggregator-data v1.3.3 h1:K6j+Sr+S0iUqFEfevl+MI0dEXn5AxFeJn9FTU5razWA=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.3/go.mod h1:udHNC7lBxYnu9AqMahABqvuclCzWUWSkbacQbUaehfI=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.4 h1:ZE0RM0Rquahb9/MIErlsfMDF/g7KpxgMlBBadS3OVZc=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.4/go.mod h1:iHVNt/wzpjrTvPO+yhCm9jSJljhdwj3o/sehLqch2BU=
-github.com/RedHatInsights/insights-results-types v1.2.0 h1:tFaGQE2h/4OIhf8sI/lRwJ/Fh0soO7a47de9x4irIJs=
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
-github.com/RedHatInsights/insights-results-types v1.3.0 h1:pMxHNTWiAzSluN5UeMoUSz9NVGhkokmO0epzbIiTfuk=
 github.com/RedHatInsights/insights-results-types v1.3.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
+github.com/RedHatInsights/insights-results-types v1.3.1 h1:dctLHdEHsZuK1R0TTFomkYJHIk6je2okbrmMBnHWvAQ=
+github.com/RedHatInsights/insights-results-types v1.3.1/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/RedHatInsights/insights-operator-utils v1.21.8/go.mod h1:qa1a8NdarIzc
 github.com/RedHatInsights/insights-operator-utils v1.22.0 h1:rXK/n6gJca5u/jmi62QyOeAR0EaUcoBLmGdBwqMBG7s=
 github.com/RedHatInsights/insights-operator-utils v1.22.0/go.mod h1:4G1aWUV3SBc5tRflpAZX2BjoWB8afxXtSutg+5/sLE8=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
-github.com/RedHatInsights/insights-results-aggregator v1.2.0 h1:UEb7GkPIBawg5vzf/TCbH8c2XiMqbrgGkWUOmo/FFqc=
-github.com/RedHatInsights/insights-results-aggregator v1.2.0/go.mod h1:y/kNpJ+E1/bbIDEjjtZykfnk11g9mNhlefp3HU4V9Jc=
+github.com/RedHatInsights/insights-results-aggregator v1.2.1 h1:wFATX+MoSoX4c9byhFwCr82KZ9OYX5sUaSZ6Xhzot/U=
+github.com/RedHatInsights/insights-results-aggregator v1.2.1/go.mod h1:5Vb+LT7QDyOj0BheRnejA3xTNa3r+7E8fJYggqtpaCY=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=
@@ -96,8 +96,8 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.3.4 h1:ZE0RM0Rquah
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.4/go.mod h1:iHVNt/wzpjrTvPO+yhCm9jSJljhdwj3o/sehLqch2BU=
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
-github.com/RedHatInsights/insights-results-types v1.3.1 h1:dctLHdEHsZuK1R0TTFomkYJHIk6je2okbrmMBnHWvAQ=
-github.com/RedHatInsights/insights-results-types v1.3.1/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
+github.com/RedHatInsights/insights-results-types v1.3.3 h1:dJAik1xUQoOYCVitPF20M+iWJOi76FPcCR1ylISw/wo=
+github.com/RedHatInsights/insights-results-types v1.3.3/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -416,6 +416,43 @@
         }
       }
     },
+    "/clusters": {
+      "get": {
+        "operationId": "getClusters",
+        "summary": "Returns a list of clusters, total number of hitting rules and a count of impacting rules by total risk.",
+        "description": "Retrieves all clusters for given organization, retrieves the impacting rules for each cluster and calculates the count of impacting rules by total risk (severity == critical, high, moderate, low)",
+        "tags": [
+          "prod"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/clusterListResponse"
+                }
+              }
+            },
+            "description": "If a cluster has 0 total_hit_count and empty last_checked_at timestamp, we have no Insights data for that archive. If total_hit_count = 0 and the timestamp is valid, there are no rule hits for the cluster."
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "status": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "A dependent service such as AMS API or results aggregator is unavailable. Specified in status message."
+          }
+        }
+      }
+    },
     "/rule/{ruleId}/content": {
       "get": {
         "tags": [
@@ -1206,6 +1243,92 @@
           "recommendations": {
             "$ref": "#/components/schemas/recommendationList",
             "description": "List of recommendations and number of impacting clusters"
+          },
+          "status": {
+            "description": "Request response status",
+            "type": "string"
+          }
+        }
+      },
+      "clusterList": {
+        "type": "array",
+        "items": {
+          "type": "object",
+          "properties": {
+            "cluster_id": {
+              "type": "string",
+              "minLength": 36,
+              "maxLength": 36,
+              "format": "uuid"
+            },
+            "cluster_name": {
+              "type": "string",
+              "description": "An human-readable name for the cluster",
+              "example": "Production cluster 1"
+            },
+            "last_checked_at": {
+              "format": "date-time",
+              "type": "string",
+              "description": "Last time of analysis for given cluster."
+            },
+            "total_hit_count": {
+              "type": "int",
+              "description": "Total number of rules hitting for given cluster. 0 combined with an empty last_checked_at means we haven't received any archive from that cluster. 0 hits with a valid timestamp means we have an archive, but there are no rule hits."
+            },
+            "hits_by_total_risk": {
+              "description": "Dictionary with numeric representation of total risk as keys, the number of rule hits by each total risk as values.",
+              "example": {
+                "1": 1,
+                "2": 4,
+                "3": 0,
+                "4": 0
+              }
+            }
+          },
+          "example": [
+            {
+              "cluster_id": "1234ecc5-624a-49a5-bab8-4fdc5e51a266",
+              "cluster_name": "Production cluster 1",
+              "publish_date": "2021-12-06 13:46:28.156726 +0000 UTC",
+              "total_hit_count": 7,
+              "hits_by_total_risk": {
+                "1": 1,
+                "2": 4,
+                "3": 2,
+                "4": 0
+              }
+            },
+            {
+              "cluster_id": "5678ecc5-624a-49a5-bab8-4fdc5e51a266",
+              "cluster_name": "My cluster",
+              "publish_date": "2021-01-01 13:46:28.156726 +0000 UTC",
+              "total_hit_count": 8,
+              "hits_by_total_risk": {
+                "1": 0,
+                "2": 0,
+                "3": 8,
+                "4": 0
+              }
+            }
+          ]
+        }
+      },
+      "clusterListResponse": {
+        "description": "Response data type for GET /clusters endpoint",
+        "type": "object",
+        "properties": {
+          "data": {
+            "$ref": "#/components/schemas/clusterList",
+            "description": "Returns a list of clusters, total number of hitting rules and a count of impacting rules by total risk"
+          },
+          "meta": {
+            "type": "object",
+            "properties": {
+              "count": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
           },
           "status": {
             "description": "Request response status",

--- a/server/endpoints_v2.go
+++ b/server/endpoints_v2.go
@@ -32,7 +32,10 @@ const (
 	ClustersDetail = "rule/{rule_selector}/clusters_detail"
 
 	// RecommendationsListEndpoint lists all recommendations with a number of impacted clusters.
-	RecommendationsListEndpoint = "rule/"
+	RecommendationsListEndpoint = "rule"
+
+	// ClustersRecommendationsEndpoint returns a list of all clusters, number of impacting rules and number of rules by total risk
+	ClustersRecommendationsEndpoint = "clusters"
 
 	// RuleContentV2 https://issues.redhat.com/browse/CCXDEV-5094
 	// additionally group info is added too
@@ -110,6 +113,7 @@ func (server *HTTPServer) addV2ReportsEndpointsToRouter(router *mux.Router, apiP
 	router.HandleFunc(apiPrefix+ReportEndpointV2, server.reportEndpoint).Methods(http.MethodGet, http.MethodOptions)
 
 	router.HandleFunc(apiPrefix+RecommendationsListEndpoint, server.getRecommendations).Methods(http.MethodGet)
+	router.HandleFunc(apiPrefix+ClustersRecommendationsEndpoint, server.getClustersView).Methods(http.MethodGet)
 }
 
 // addV2RuleEndpointsToRouter method registers handlers for endpoints that handle

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -305,7 +305,7 @@ func (server HTTPServer) getClustersView(writer http.ResponseWriter, request *ht
 	// get a list of clusters from AMS API
 	clusterInfoList, clusterNamesMap, err := server.readClustersForOrgID(orgID)
 	if err != nil {
-		log.Error().Err(err).Int(orgIDTag, int(orgID)).Msgf("problem reading cluster list for org")
+		log.Error().Err(err).Int(orgIDTag, int(orgID)).Msg("problem reading cluster list for org")
 		handleServerError(writer, err)
 		return
 	}
@@ -327,7 +327,7 @@ func (server HTTPServer) getClustersView(writer http.ResponseWriter, request *ht
 
 	clusterViewResponse, err := matchClusterInfoRuleSeverity(clusterNamesMap, clusterRecommendationMap)
 	if err != nil {
-		log.Error().Err(err).Msgf("error matching cluster list and rule severities")
+		log.Error().Err(err).Msg("error matching cluster list and rule severities")
 		handleServerError(writer, err)
 	}
 
@@ -566,7 +566,7 @@ func (server HTTPServer) getClustersAndRecommendations(
 
 	jsonMarshalled, err := json.Marshal(clusterList)
 	if err != nil {
-		log.Error().Err(err).Msgf("problem unmarshalling cluster list")
+		log.Error().Err(err).Msg("problem unmarshalling cluster list")
 		handleServerError(writer, err)
 		return nil, err
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -354,14 +354,14 @@ func copyHeader(srcHeaders, dstHeaders http.Header) {
 // organization from aggregator
 func (server HTTPServer) readClusterIDsForOrgID(orgID ctypes.OrgID) ([]ctypes.ClusterName, error) {
 	if server.amsClient != nil {
-		clusters, err := server.amsClient.GetClustersForOrganization(
+		clusterInfoList, _, err := server.amsClient.GetClustersForOrganization(
 			orgID,
 			nil,
 			[]string{amsclient.StatusDeprovisioned, amsclient.StatusArchived},
 		)
 		if err == nil {
-			log.Info().Int(orgIDTag, int(orgID)).Msgf("Number of clusters retrieved from the AMS API: %v", len(clusters))
-			clusterNames := types.GetClusterNames(clusters)
+			log.Info().Int(orgIDTag, int(orgID)).Msgf("Number of cluster IDs retrieved from the AMS API: %v", len(clusterInfoList))
+			clusterNames := types.GetClusterNames(clusterInfoList)
 			return clusterNames, err
 		}
 
@@ -375,6 +375,56 @@ func (server HTTPServer) readClusterIDsForOrgID(orgID ctypes.OrgID) ([]ctypes.Cl
 	}
 
 	log.Info().Msg("amsclient not initialized. Using fallback mechanism")
+	return server.getClusterIDsFromAggregator(orgID)
+}
+
+// readClustersForOrgID returns a list of cluster info types and a map of cluster display names
+func (server HTTPServer) readClustersForOrgID(orgID ctypes.OrgID) (
+	[]types.ClusterInfo,
+	map[types.ClusterName]string,
+	error,
+) {
+	if server.amsClient != nil {
+		clusterInfoList, clusterNamesMap, err := server.amsClient.GetClustersForOrganization(
+			orgID,
+			nil,
+			[]string{amsclient.StatusDeprovisioned, amsclient.StatusArchived},
+		)
+		if err == nil {
+			log.Info().Int(orgIDTag, int(orgID)).Msgf("Number of clusters retrieved from the AMS API: %v", len(clusterInfoList))
+			return clusterInfoList, clusterNamesMap, nil
+		}
+
+		log.Error().Err(err).Msg("Error accessing amsclient")
+	}
+
+	if !server.Config.UseOrgClustersFallback {
+		err := fmt.Errorf("amsclient not initialized")
+		log.Error().Err(err).Msg("")
+		return nil, nil, err
+	}
+
+	log.Info().Msg("amsclient not initialized. Using fallback mechanism")
+	clusterIDs, err := server.getClusterIDsFromAggregator(orgID)
+	if err != nil {
+		log.Error().Err(err).Msg("error retrieving clusters from aggregator")
+		return nil, nil, err
+	}
+
+	// fill in empty display names
+	clusterNamesMap := make(map[types.ClusterName]string)
+	clusterInfo := make([]types.ClusterInfo, len(clusterIDs))
+
+	for i := range clusterIDs {
+		clusterInfo = append(clusterInfo, types.ClusterInfo{ID: clusterIDs[i]})
+		clusterNamesMap[clusterIDs[i]] = ""
+	}
+	return clusterInfo, clusterNamesMap, nil
+}
+
+// readClusterIDsForOrgID reads the list of clusters for a given organization from aggregator
+func (server HTTPServer) getClusterIDsFromAggregator(orgID ctypes.OrgID) ([]ctypes.ClusterName, error) {
+	log.Info().Msg("retrieving cluster IDs from aggregator")
 
 	aggregatorURL := httputils.MakeURLToEndpoint(
 		server.ServicesConfig.AggregatorBaseEndpoint,

--- a/server/server.go
+++ b/server/server.go
@@ -435,6 +435,10 @@ func (server HTTPServer) getClusterIDsFromAggregator(orgID ctypes.OrgID) ([]ctyp
 	// #nosec G107
 	response, err := http.Get(aggregatorURL)
 	if err != nil {
+		log.Error().Err(err).Msgf("problem getting cluster list from aggregator")
+		if _, ok := err.(*url.Error); ok {
+			return nil, &AggregatorServiceUnavailableError{}
+		}
 		return nil, err
 	}
 

--- a/tests/helpers/amsclient.go
+++ b/tests/helpers/amsclient.go
@@ -28,14 +28,23 @@ type mockAMSClient struct {
 func (m *mockAMSClient) GetClustersForOrganization(
 	orgID types.OrgID,
 	unused1, unused2 []string,
-) ([]types.ClusterInfo, error) {
+) (
+	clusterInfoList []types.ClusterInfo,
+	clusterNamesMap map[types.ClusterName]string,
+	err error,
+) {
 
-	clusters, ok := m.clustersPerOrg[orgID]
+	clusterInfoList, ok := m.clustersPerOrg[orgID]
 	if !ok {
-		return nil, fmt.Errorf("No clusters")
+		return nil, nil, fmt.Errorf("No clusters")
 	}
 
-	return clusters, nil
+	clusterNamesMap = make(map[types.ClusterName]string)
+	for i := range clusterInfoList {
+		clusterNamesMap[clusterInfoList[i].ID] = clusterInfoList[i].DisplayName
+	}
+
+	return
 }
 
 // AMSClientWithOrgResults creates a mock of AMSClient interface that returns the results

--- a/types/operations.go
+++ b/types/operations.go
@@ -31,11 +31,11 @@ func GetClusterNames(clustersInfo []ClusterInfo) []ClusterName {
 
 // ClusterInfoArrayToMap convert an array of ClusterInfo elements into a map using
 // ClusterName as key
-func ClusterInfoArrayToMap(clustersInfo []ClusterInfo) map[ctypes.ClusterName]string {
-	var retval map[ctypes.ClusterName]string = make(map[ctypes.ClusterName]string)
+func ClusterInfoArrayToMap(clustersInfo []ClusterInfo) (retval map[ctypes.ClusterName]string) {
+	retval = make(map[ctypes.ClusterName]string)
 	for _, clusterInfo := range clustersInfo {
 		retval[clusterInfo.ID] = clusterInfo.DisplayName
 	}
 
-	return retval
+	return
 }

--- a/types/types.go
+++ b/types/types.go
@@ -183,8 +183,8 @@ type RecommendationListView struct {
 // ClusterListView represents a single item in the response for Clusters List view
 type ClusterListView struct {
 	ClusterID       types.ClusterName `json:"cluster_id"`
-	DisplayName     string            `json:"display_name"`
-	LastCheckedAt   time.Time         `json:"last_checked_at"`
+	ClusterName     string            `json:"cluster_name"`
+	LastCheckedAt   string            `json:"last_checked_at"`
 	TotalHitCount   uint32            `json:"total_hit_count"`
 	HitsByTotalRisk map[int]int       `json:"hits_by_total_risk"`
 }

--- a/types/types.go
+++ b/types/types.go
@@ -180,6 +180,15 @@ type RecommendationListView struct {
 	ImpactedClustersCnt types.ImpactedClustersCnt `json:"impacted_clusters_count"`
 }
 
+// ClusterListView represents a single item in the response for Clusters List view
+type ClusterListView struct {
+	ClusterID       types.ClusterName `json:"cluster_id"`
+	DisplayName     string            `json:"display_name"`
+	LastCheckedAt   time.Time         `json:"last_checked_at"`
+	TotalHitCount   uint32            `json:"total_hit_count"`
+	HitsByTotalRisk map[int]int       `json:"hits_by_total_risk"`
+}
+
 // RuleRating structure with the rule identifier and the rating
 type RuleRating = types.RuleRating
 


### PR DESCRIPTION
# Description
Needed for https://issues.redhat.com/browse/CCXDEV-6487

This endpoints returns a list of all clusters retrieved from AMS API and a "summary" for each cluster:
- `last_checked_at` = the time of last clusters analysis
- `total_hit_count`
- `hits_by_total_risk` = a map of total risk values to be matched on frontend with numbers of hitting rules for each severity

Fixes CCXDEV-6487

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)
- Bump-up dependent library (no changes in the code)
- REST API tests

## Testing steps
alongside aggregator

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
