### PR TITLE
fix AMS API not enforcing unique or filled in cluster UUIDs

### DIFF
--- a/amsclient/amsclient.go
+++ b/amsclient/amsclient.go
@@ -44,7 +44,6 @@ const (
 type AMSClient interface {
 	GetClustersForOrganization(types.OrgID, []string, []string) (
 		clusterInfoList []types.ClusterInfo,
-		clusterNamesMap map[types.ClusterName]string,
 		err error,
 	)
 }
@@ -100,12 +99,10 @@ func NewAMSClientWithTransport(conf Configuration, transport http.RoundTripper) 
 // it allows to filter the clusters by their status (statusNegativeFilter will exclude the clusters with status in that list)
 func (c *amsClientImpl) GetClustersForOrganization(orgID types.OrgID, statusFilter, statusNegativeFilter []string) (
 	clusterInfoList []types.ClusterInfo,
-	clusterNamesMap map[types.ClusterName]string,
 	err error,
 ) {
 	log.Debug().Uint32(orgIDTag, uint32(orgID)).Msg("Looking cluster for the organization")
 	log.Info().Uint32(orgIDTag, uint32(orgID)).Msgf("GetClustersForOrganization start. AMS client page size %v", c.pageSize)
-	clusterNamesMap = make(map[types.ClusterName]string)
 
 	tStart := time.Now()
 
@@ -129,7 +126,7 @@ func (c *amsClientImpl) GetClustersForOrganization(orgID types.OrgID, statusFilt
 		response, err := subscriptionListRequest.Send()
 
 		if err != nil {
-			return clusterInfoList, clusterNamesMap, err
+			return clusterInfoList, err
 		}
 
 		// When an empty page is returned, then exit the loop
@@ -159,11 +156,6 @@ func (c *amsClientImpl) GetClustersForOrganization(orgID types.OrgID, statusFilt
 				ID:          clusterID,
 				DisplayName: displayName,
 			})
-			if existingDisplayName, exists := clusterNamesMap[clusterID]; exists {
-				log.Error().Uint32(orgIDTag, uint32(orgID)).Msgf("duplicate cluster ID %v with display names %v, %v", clusterID, displayName, existingDisplayName)
-			} else {
-				clusterNamesMap[clusterID] = displayName
-			}
 		}
 	}
 

--- a/amsclient/amsclient_test.go
+++ b/amsclient/amsclient_test.go
@@ -125,10 +125,9 @@ func TestClusterForOrganization(t *testing.T) {
 		Body: helpers.ToJSONString(testdata.SubscriptionEmptyResponse),
 	})
 
-	clusterList, clusterMap, err := c.GetClustersForOrganization(testdata.ExternalOrgID, nil, nil)
+	clusterList, err := c.GetClustersForOrganization(testdata.ExternalOrgID, nil, nil)
 	helpers.FailOnError(t, err)
 	assert.Equal(t, 2, len(clusterList))
-	assert.Equal(t, 2, len(clusterMap))
 }
 
 func TestClusterForOrganizationWithFiltering(t *testing.T) {
@@ -174,7 +173,7 @@ func TestClusterForOrganizationWithFiltering(t *testing.T) {
 		Body: helpers.ToJSONString(testdata.SubscriptionEmptyResponse),
 	})
 
-	clusterList, clusterMap, err := c.GetClustersForOrganization(
+	clusterList, err := c.GetClustersForOrganization(
 		testdata.ExternalOrgID,
 		[]string{amsclient.StatusArchived, amsclient.StatusDeprovisioned},
 		nil,
@@ -182,17 +181,15 @@ func TestClusterForOrganizationWithFiltering(t *testing.T) {
 
 	helpers.FailOnError(t, err)
 	assert.Equal(t, 2, len(clusterList))
-	assert.Equal(t, 2, len(clusterMap))
 }
 
 func TestGetClustersForOrganizationOnError(t *testing.T) {
 	client, err := amsclient.NewAMSClient(defaultConfig)
 	helpers.FailOnError(t, err) // Doesn't fail because ocm-sdk doesn't perform any checks
 
-	clusters, clusterMap, err := client.GetClustersForOrganization(testdata.ExternalOrgID, nil, nil)
+	clusters, err := client.GetClustersForOrganization(testdata.ExternalOrgID, nil, nil)
 	if err == nil {
 		t.Fail()
 	}
 	assert.Equal(t, 0, len(clusters))
-	assert.Equal(t, 0, len(clusterMap))
 }

--- a/server/server.go
+++ b/server/server.go
@@ -412,10 +412,13 @@ func (server HTTPServer) readClustersForOrgID(orgID ctypes.OrgID) (
 	}
 
 	// fill in empty display names
-	clusterInfo := make([]types.ClusterInfo, len(clusterIDs))
+	clusterInfo := make([]types.ClusterInfo, 0)
 
-	for i := range clusterIDs {
-		clusterInfo = append(clusterInfo, types.ClusterInfo{ID: clusterIDs[i]})
+	for _, clusterID := range clusterIDs {
+		clusterInfo = append(clusterInfo, types.ClusterInfo{
+			ID:          clusterID,
+			DisplayName: string(clusterID),
+		})
 	}
 	return clusterInfo, nil
 }

--- a/tests/helpers/amsclient.go
+++ b/tests/helpers/amsclient.go
@@ -30,18 +30,12 @@ func (m *mockAMSClient) GetClustersForOrganization(
 	unused1, unused2 []string,
 ) (
 	clusterInfoList []types.ClusterInfo,
-	clusterNamesMap map[types.ClusterName]string,
 	err error,
 ) {
 
 	clusterInfoList, ok := m.clustersPerOrg[orgID]
 	if !ok {
-		return nil, nil, fmt.Errorf("No clusters")
-	}
-
-	clusterNamesMap = make(map[types.ClusterName]string)
-	for i := range clusterInfoList {
-		clusterNamesMap[clusterInfoList[i].ID] = clusterInfoList[i].DisplayName
+		return nil, fmt.Errorf("No clusters")
 	}
 
 	return


### PR DESCRIPTION
# Description
Apparently, AMS API is not enforcing unique cluster UUIDs. We were storing the cluster display names in a map with cluster UUIDs as keys, but the map had fewer elements than the list. After some investigation, the AMS API is not only not enforcing uniqueness, but they allow totally EMPTY UUIDs.

Fixes CCXDEV-6650

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
make test

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
