### PR TITLE
change timestamp format and fix unit tests for /clusters 

### DIFF
--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -1895,7 +1895,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_ClustersFoundNoInsights(t *t
 		}, &helpers.APIResponse{
 			StatusCode:  http.StatusOK,
 			Body:        helpers.ToJSONString(resp),
-			BodyChecker: recommendationInResponseChecker,
+			BodyChecker: clusterInResponseChecker,
 		})
 	}, testTimeout)
 }
@@ -1954,6 +1954,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_NoRuleHits(t *testing.T) {
 		for i := range clusterInfoList {
 			resp.Clusters[i].ClusterID = clusterInfoList[i].ID
 			resp.Clusters[i].ClusterName = clusterInfoList[i].DisplayName
+			resp.Clusters[i].LastCheckedAt = testTimeStr
 		}
 
 		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, amsClientMock, nil, nil, nil)
@@ -1964,7 +1965,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_NoRuleHits(t *testing.T) {
 		}, &helpers.APIResponse{
 			StatusCode:  http.StatusOK,
 			Body:        helpers.ToJSONString(resp),
-			BodyChecker: recommendationInResponseChecker,
+			BodyChecker: clusterInResponseChecker,
 		})
 	}, testTimeout)
 }
@@ -2009,8 +2010,8 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_2ClustersFilled(t *testing.T
 			}
 		}`
 		respBody = fmt.Sprintf(respBody,
-			clusterInfoList[0].ID, testTimeStr, testdata.Rule1CompositeID,
-			clusterInfoList[1].ID, testTimeStr, testdata.Rule2CompositeID, testdata.Rule3CompositeID,
+			clusterInfoList[0].ID, testTimeStr, testdata.Rule1CompositeID, // total_risk = 1
+			clusterInfoList[1].ID, testTimeStr, testdata.Rule2CompositeID, testdata.Rule3CompositeID, // total_risk = 2, 2
 		)
 
 		// prepare response from amsclient for list of clusters
@@ -2047,7 +2048,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_2ClustersFilled(t *testing.T
 		}, &helpers.APIResponse{
 			StatusCode:  http.StatusOK,
 			Body:        helpers.ToJSONString(resp),
-			BodyChecker: recommendationInResponseChecker,
+			BodyChecker: clusterInResponseChecker,
 		})
 	}, testTimeout)
 }

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -377,7 +377,7 @@ func matchClusterInfoRuleSeverity(
 		}
 
 		if hittingRecommendations, any := clusterRecommendationsMap[clusterViewItem.ClusterID]; any {
-			clusterViewItem.LastCheckedAt = hittingRecommendations.CreatedAt.String()
+			clusterViewItem.LastCheckedAt = hittingRecommendations.CreatedAt.UTC().Format(time.RFC3339)
 
 			for _, ruleID := range hittingRecommendations.Recommendations {
 				if ruleSeverity, found := recommendationSeverities[ruleID]; found {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -860,8 +860,8 @@ var (
 				LastCheckedAt: testTimeStr,
 				TotalHitCount: 2,
 				HitsByTotalRisk: map[int]int{
-					1: 1,
-					2: 1,
+					1: 0,
+					2: 2,
 				},
 			},
 		},


### PR DESCRIPTION
# Description
The timestamp format doesn't match other timestamp formats in our API. This PR fixes it so it is RFC3339 as others.
Also, some of the unit tests weren't working properly :face_with_head_bandage: 

Fixes CCXDEV-6791

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
checked timestamp is RFC3339 + fixed unit tests

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
