### PR TITLE
change AMS API query to match query OCM makes

### DIFF
--- a/amsclient/amsclient_test.go
+++ b/amsclient/amsclient_test.go
@@ -34,9 +34,9 @@ const (
 	organizationsSearchEndpoint = "api/accounts_mgmt/v1/organizations?fields=id%%2Cexternal_id&search=external_id+%%3D+{orgID}"
 
 	subscriptionsSearchEndpoint = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id%%2Cdisplay_name&page={pageNum}&" +
-		"search=organization_id+is+%%27{orgID}%%27&size={pageSize}")
+		"search=organization_id+is+%%27{orgID}%%27+and+cluster_id+%%21%%3D+%%27%%27&size={pageSize}")
 	subscriptionsSearchEndpointWithFilter = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id%%2Cdisplay_name&page={pageNum}&" +
-		"search=organization_id+is+%%27{orgID}%%27+and+status+in+%%28%%27{status1}%%27%%2C%%27{status2}%%27%%29&size={pageSize}")
+		"search=organization_id+is+%%27{orgID}%%27+and+cluster_id+%%21%%3D+%%27%%27+and+status+in+%%28%%27{status1}%%27%%2C%%27{status2}%%27%%29&size={pageSize}")
 )
 
 var (

--- a/amsclient/utils.go
+++ b/amsclient/utils.go
@@ -21,7 +21,7 @@ import (
 
 // generateSearchParameter generates a search string for given org_id and desired statuses
 func generateSearchParameter(orgID string, allowedStatuses, disallowedStatuses []string) string {
-	searchQuery := fmt.Sprintf("organization_id is '%s'", orgID)
+	searchQuery := fmt.Sprintf("organization_id is '%s' and cluster_id != ''", orgID)
 
 	if len(allowedStatuses) > 0 {
 		clusterIDQuery := " and status in ('" + strings.Join(allowedStatuses, "','") + "')"


### PR DESCRIPTION
# Description
This PR changes the AMS client to make the same query to get the list of clusters as OCM.
We were missing an extra filter `cluster_id != ''` which meant we were showing a few more clusters than OCM does.

Fixes CCXDEV-6797

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps
`make test`

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
