### PR TITLE
Add "Reserved" cluster status filter to amsclient

### DIFF
--- a/config-devel.toml
+++ b/config-devel.toml
@@ -1,3 +1,9 @@
+[amsclient]
+url = "https://api.openshift.com"
+client_id = ""
+client_secret = ""
+page_size = 100
+
 [server]
 address = ":8081"
 api_dbg_prefix = "/api/dbg/"
@@ -13,6 +19,7 @@ enable_cors = true
 enable_internal_rules_organizations = false
 internal_rules_organizations = []
 log_auth_token = true
+org_clusters_fallback = false
 
 [services]
 aggregator = "http://localhost:8080/api/insights-results-aggregator/v1/"

--- a/config.toml
+++ b/config.toml
@@ -13,6 +13,7 @@ enable_cors = false
 enable_internal_rules_organizations = false
 internal_rules_organizations = []
 log_auth_token = true
+org_clusters_fallback = false
 
 [services]
 aggregator = "http://localhost:8080/api/v1/"
@@ -25,8 +26,8 @@ internal_rules_organizations_csv_file = ""
 
 [amsclient]
 url = "https://api.openshift.com"
-client_id = "theclient"
-client_secret = "thesecret"
+client_id = ""
+client_secret = ""
 page_size = 100
 
 [metrics]

--- a/gocyclo.sh
+++ b/gocyclo.sh
@@ -20,4 +20,4 @@ then
     GO111MODULE=off go get github.com/fzipp/gocyclo/cmd/gocyclo
 fi
 
-gocyclo -over 10 -avg .
+gocyclo -over 9 -avg .


### PR DESCRIPTION
# Description
- add default cluster status filters to amsclient, which are applied to AMS API subscription list requests if `nil` filters are passed.
- add 3rd cluster status filter (Reserved) to the default filters, which are always applied for OCP Advisor-related request. Reserved clusters don't have cluster ID assigned yet, or are not ready to start sending Insights for other reasons

slight DRY refactor

note: based on [discussion on SD channel](https://coreos.slack.com/archives/CB53T9ZHQ/p1639474846188100)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps
`make test`

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
