### PR TITLE
increase AMS page size to avoid duplicate/missing clusters when retrieving the full list

### DIFF
--- a/amsclient/amsclient.go
+++ b/amsclient/amsclient.go
@@ -137,7 +137,7 @@ func (c *amsClientImpl) GetClustersForOrganization(orgID types.OrgID, statusFilt
 		return
 	}
 
-	log.Info().Uint32(orgIDTag, uint32(orgID)).Msgf("GetClustersForOrganization took %s", time.Since(tStart))
+	log.Info().Uint32(orgIDTag, uint32(orgID)).Msgf("GetClustersForOrganization from AMS API took %s", time.Since(tStart))
 	return
 }
 
@@ -179,8 +179,6 @@ func (c *amsClientImpl) executeSubscriptionListRequest(
 	clusterInfoList []types.ClusterInfo,
 	err error,
 ) {
-	uniqueClusterIDs := make(map[types.ClusterName]string)
-
 	for pageNum := 1; ; pageNum++ {
 		var err error
 		subscriptionListRequest = subscriptionListRequest.
@@ -222,25 +220,8 @@ func (c *amsClientImpl) executeSubscriptionListRequest(
 				ID:          clusterID,
 				DisplayName: displayName,
 			})
-
-			amsID, _ := item.GetClusterID()
-			uniqueClusterIDs[clusterID] = amsID
 		}
 	}
 
-	log.Info().Uint32(orgIDTag, uint32(orgID)).Msgf(
-		"clusterInfoList length: %v; uniqueClusterIDs length: %v", len(clusterInfoList), len(uniqueClusterIDs),
-	)
-	cIDmap := make(map[types.ClusterName]interface{})
-	for i := range clusterInfoList {
-		cID := clusterInfoList[i].ID
-		if _, exists := cIDmap[cID]; exists {
-			log.Error().Uint32(orgIDTag, uint32(orgID)).Msgf(
-				"duplicate cluster UUID in clusterInfoList %v", cID,
-			)
-		} else {
-			cIDmap[cID] = nil
-		}
-	}
 	return
 }

--- a/config.toml
+++ b/config.toml
@@ -28,7 +28,7 @@ internal_rules_organizations_csv_file = ""
 url = "https://api.openshift.com"
 client_id = ""
 client_secret = ""
-page_size = 100
+page_size = 6000
 
 [metrics]
 namespace = "smart_proxy"

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -261,4 +261,4 @@ parameters:
 - name: AMS_API_URL
   value: "https://api.stage.openshift.com"
 - name: AMS_API_PAGESIZE
-  value: "1500"
+  value: "6000"

--- a/gocyclo.sh
+++ b/gocyclo.sh
@@ -20,4 +20,4 @@ then
     GO111MODULE=off go get github.com/fzipp/gocyclo/cmd/gocyclo
 fi
 
-gocyclo -over 9 -avg .
+gocyclo -over 10 -avg .

--- a/gocyclo.sh
+++ b/gocyclo.sh
@@ -20,4 +20,4 @@ then
     GO111MODULE=off go get github.com/fzipp/gocyclo/cmd/gocyclo
 fi
 
-gocyclo -over 10 -avg .
+gocyclo -over 9 -avg .


### PR DESCRIPTION
# Description
Some organizations have several clusters come and go every second. Retrieving the complete cluster list by making paginated requests is obviously inconsistent. Largest organizations had <5000 clusters, so I'm increasing the limit to 6000. AMS API is handling it fine and it even speeds up the whole function by a lot.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
queried prod AMS from local and tested various scenarios
`make before_commit`

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
