### PR TITLE
Include disabled clusters in /clusters_detail

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20211119142943-71a7a9be7bb8
 	github.com/RedHatInsights/insights-operator-utils v1.22.0
-	github.com/RedHatInsights/insights-results-aggregator v1.2.2
+	github.com/RedHatInsights/insights-results-aggregator v1.2.3
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.4
-	github.com/RedHatInsights/insights-results-types v1.3.3
+	github.com/RedHatInsights/insights-results-types v1.3.4
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -82,10 +82,8 @@ github.com/RedHatInsights/insights-operator-utils v1.21.8/go.mod h1:qa1a8NdarIzc
 github.com/RedHatInsights/insights-operator-utils v1.22.0 h1:rXK/n6gJca5u/jmi62QyOeAR0EaUcoBLmGdBwqMBG7s=
 github.com/RedHatInsights/insights-operator-utils v1.22.0/go.mod h1:4G1aWUV3SBc5tRflpAZX2BjoWB8afxXtSutg+5/sLE8=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
-github.com/RedHatInsights/insights-results-aggregator v1.2.1 h1:wFATX+MoSoX4c9byhFwCr82KZ9OYX5sUaSZ6Xhzot/U=
-github.com/RedHatInsights/insights-results-aggregator v1.2.1/go.mod h1:5Vb+LT7QDyOj0BheRnejA3xTNa3r+7E8fJYggqtpaCY=
-github.com/RedHatInsights/insights-results-aggregator v1.2.2 h1:WiEfGdbNg7bs3RIuoWWiW4A2Os2e1mlPOoHRkyhIN8g=
-github.com/RedHatInsights/insights-results-aggregator v1.2.2/go.mod h1:5Vb+LT7QDyOj0BheRnejA3xTNa3r+7E8fJYggqtpaCY=
+github.com/RedHatInsights/insights-results-aggregator v1.2.3 h1:vIfMFl0SpvO0mZn+oI1IkYx13EPyECeVSDxVFSxacHE=
+github.com/RedHatInsights/insights-results-aggregator v1.2.3/go.mod h1:ELn+Mhk0mcmbiliJVOZ3aMkyzOYDpyfM6utPONVxapo=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=
@@ -98,8 +96,8 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.3.4 h1:ZE0RM0Rquah
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.4/go.mod h1:iHVNt/wzpjrTvPO+yhCm9jSJljhdwj3o/sehLqch2BU=
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
-github.com/RedHatInsights/insights-results-types v1.3.3 h1:dJAik1xUQoOYCVitPF20M+iWJOi76FPcCR1ylISw/wo=
-github.com/RedHatInsights/insights-results-types v1.3.3/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
+github.com/RedHatInsights/insights-results-types v1.3.4 h1:3rab3nTKMqLYTnAVrRIdIVhRhjG9bst+cknWO5DX3h0=
+github.com/RedHatInsights/insights-results-types v1.3.4/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -843,7 +843,7 @@
     },
     "/rule/{rule_selector}/clusters_detail": {
       "get": {
-        "summary": "Returns a list of cluster where the given rule is active.",
+        "summary": "Returns a list of cluster where the given rule is active. Also returns a list of clusters, for which the rule has been disabled.",
         "description": "Provided a correct rule selector and a valid organization ID, this method will query the DB for all the organization's clusters being currently affected by the rule, if any.",
         "operationId": "getClustersForRecommendation",
         "parameters": [
@@ -866,25 +866,11 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "report": {
+                    "data": {
                       "type": "object",
                       "properties": {
-                        "meta": {
-                          "type": "object",
-                          "properties": {
-                            "count": {
-                              "type": "integer",
-                              "description": "Number of clusters affected by the received rule.",
-                              "example": "1"
-                            },
-                            "rule_selector": {
-                              "type": "string",
-                              "description": "The rule selector retrieved in the URL.",
-                              "example": "some.python.module|SOME_ERROR_KEY"
-                            }
-                          }
-                        },
-                        "data": {
+                        "enabled": {
+                          "description": "A list of clusters, which are hitting this rule and are enabled.",
                           "type": "array",
                           "items": {
                             "type": "object",
@@ -899,6 +885,35 @@
                                 "type": "string",
                                 "description": "An human-readable name for the cluster",
                                 "example": "Production cluster 1"
+                              }
+                            }
+                          }
+                        },
+                        "disabled": {
+                          "description": "A list of clusters, which the user has disabled from hitting this rule.",
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "cluster": {
+                                "type": "string",
+                                "minLength": 36,
+                                "maxLength": 36,
+                                "format": "uuid"
+                              },
+                              "cluster_name": {
+                                "type": "string",
+                                "description": "An human-readable name for the cluster",
+                                "example": "Production cluster 1"
+                              },
+                              "disabled_at": {
+                                  "format": "date-time",
+                                  "type": "string"
+                              },
+                              "justification": {
+                                "type": "string",
+                                "description": "User given justification why rule was disabled.",
+                                "example": "Not useful for us."
                               }
                             }
                           }

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -890,7 +890,7 @@
                           }
                         },
                         "disabled": {
-                          "description": "A list of clusters, which the user has disabled from hitting this rule.",
+                          "description": "A list of clusters for which the user has disabled this rule",
                           "type": "array",
                           "items": {
                             "type": "object",

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -799,8 +799,7 @@ func (server *HTTPServer) getListOfDisabledClusters(
 
 	aggregatorURL := httputils.MakeURLToEndpoint(
 		server.ServicesConfig.AggregatorBaseEndpoint,
-		//FIXME
-		"clusters/rules/{rule_id}/error_key/{error_key}/users/{user_id}/disabled",
+		ira_server.ListOfDisabledClusters,
 		splitRuleID[0],
 		splitRuleID[1],
 		userID,

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -19,9 +19,11 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -46,6 +48,9 @@ const (
 	IncludingImpacting
 	// ExcludingImpacting flag to return all recommendations excluding impacting ones on GET /rule/
 	ExcludingImpacting
+	// OkMsg is in status field with HTTP 200 response
+	OkMsg       = "ok"
+	selectorStr = "selector"
 )
 
 // getContentCheckInternal retrieves static content for the given ruleID and if the rule is internal,
@@ -131,7 +136,7 @@ func (server HTTPServer) getRecommendationContent(writer http.ResponseWriter, re
 
 	// prepare data structure for building response
 	responseContent := make(map[string]interface{})
-	responseContent["status"] = "ok"
+	responseContent["status"] = OkMsg
 	responseContent["groups"] = ruleGroups
 	responseContent["content"] = contentResponse
 
@@ -203,7 +208,7 @@ func (server HTTPServer) getRecommendationContentWithUserData(writer http.Respon
 
 	// prepare data structure for building response
 	responseContent := make(map[string]interface{})
-	responseContent["status"] = "ok"
+	responseContent["status"] = OkMsg
 	responseContent["groups"] = ruleGroups
 	responseContent["content"] = contentResponse
 
@@ -274,7 +279,7 @@ func (server HTTPServer) getRecommendations(writer http.ResponseWriter, request 
 		Msgf("number of final recommendations: %d", len(recommendationList))
 
 	resp := make(map[string]interface{})
-	resp["status"] = "ok"
+	resp["status"] = OkMsg
 	resp["recommendations"] = recommendationList
 
 	log.Info().Uint32(orgIDTag, uint32(orgID)).Msgf(
@@ -335,7 +340,7 @@ func (server HTTPServer) getClustersView(writer http.ResponseWriter, request *ht
 	metaCount := map[string]int{
 		"count": len(clusterViewResponse),
 	}
-	resp["status"] = "ok"
+	resp["status"] = OkMsg
 	resp["meta"] = metaCount
 	resp["data"] = clusterViewResponse
 
@@ -638,7 +643,7 @@ func (server HTTPServer) getContentWithGroups(writer http.ResponseWriter, reques
 	}
 	// prepare data structure for building response
 	responseContent := make(map[string]interface{})
-	responseContent["status"] = "ok"
+	responseContent["status"] = OkMsg
 	responseContent["groups"] = ruleGroups
 	responseContent["content"] = rules
 
@@ -684,51 +689,6 @@ func getImpactedClustersFromAggregator(
 	return
 }
 
-// proxyImpactedClusters sends the list of clusters impacted by the
-// recommendation to the client, if any.
-func proxyImpactedClusters(
-	writer http.ResponseWriter,
-	selector ctypes.RuleSelector,
-	aggregatorResp *http.Response,
-	namesMap map[ctypes.ClusterName]string,
-) error {
-	// If we received a 404 - no entries found for given orgID+selector in DB
-	// We return an empty list and a 200 OK
-	if aggregatorResp.StatusCode == http.StatusNotFound {
-		resp := responses.BuildOkResponse()
-		resp["meta"] = ctypes.HittingClustersMetadata{
-			Count:    0,
-			Selector: selector,
-		}
-		resp["data"] = []ctypes.HittingClustersData{}
-		return responses.SendOK(writer, resp)
-	}
-
-	if aggregatorResp.StatusCode == http.StatusOK {
-		// unmarshall the response to add cluster names to it
-		var response ctypes.HittingClusters
-
-		err := json.NewDecoder(aggregatorResp.Body).Decode(&response)
-		if err != nil {
-			return err
-		}
-
-		for index := range response.ClusterList {
-			clusterID := response.ClusterList[index].Cluster
-			response.ClusterList[index].Name = namesMap[clusterID]
-		}
-
-		return responses.Send(aggregatorResp.StatusCode, writer, response)
-	}
-
-	//Proxy the other responses as they came
-	responseBytes, e := ioutil.ReadAll(aggregatorResp.Body)
-	if e != nil {
-		return e
-	}
-	return responses.Send(aggregatorResp.StatusCode, writer, responseBytes)
-}
-
 // getImpactedClusters retrieves a list of clusters affected by the given recommendation from aggregator
 func (server HTTPServer) getImpactedClusters(
 	writer http.ResponseWriter,
@@ -736,8 +696,10 @@ func (server HTTPServer) getImpactedClusters(
 	userID ctypes.UserID,
 	selector ctypes.RuleSelector,
 	activeClustersInfo []types.ClusterInfo,
-) error {
-
+) (
+	[]ctypes.HittingClustersData,
+	error,
+) {
 	aggregatorURL := httputils.MakeURLToEndpoint(
 		server.ServicesConfig.AggregatorBaseEndpoint,
 		ira_server.RuleClusterDetailEndpoint,
@@ -751,16 +713,24 @@ func (server HTTPServer) getImpactedClusters(
 	// if http.Get fails for whatever reason
 	if err != nil {
 		handleServerError(writer, err)
-		return err
+		return []ctypes.HittingClustersData{}, err
 	}
 
-	namesMap := types.ClusterInfoArrayToMap(activeClustersInfo)
-	if err = proxyImpactedClusters(writer, selector, aggregatorResp, namesMap); err != nil {
-		log.Error().Err(err).Msgf(problemSendingResponseError)
-		handleServerError(writer, err)
-		return err
+	if aggregatorResp.StatusCode == http.StatusOK {
+		var response struct {
+			Clusters []ctypes.HittingClustersData `json:"clusters"`
+			Status   string                       `json:"status"`
+		}
+
+		err := json.NewDecoder(aggregatorResp.Body).Decode(&response)
+		if err != nil {
+			return []ctypes.HittingClustersData{}, err
+		}
+
+		return response.Clusters, nil
 	}
-	return nil
+
+	return []ctypes.HittingClustersData{}, nil
 }
 
 // getClustersDetailForRule retrieves all the clusters affected by the recommendation
@@ -789,15 +759,111 @@ func (server HTTPServer) getClustersDetailForRule(writer http.ResponseWriter, re
 		log.Error().Err(err).Int(orgIDTag, int(orgID)).Msg("Error retrieving cluster IDs from AMS API. Using empty list.")
 	}
 
-	// get the list of clusters affected by given rule from aggregator and send to client
-	err = server.getImpactedClusters(writer, orgID, userID, selector, activeClustersInfo)
+	// get the list of clusters affected by given rule from aggregator and
+	impactedClusters, err := server.getImpactedClusters(writer, orgID, userID, selector, activeClustersInfo)
 	if err != nil {
-		log.Error().
-			Err(err).
-			Int("orgID", int(orgID)).
-			Str(userIDTag, string(userID)).
-			Str("selector", string(selector)).
+		log.Error().Err(err).Int(orgIDTag, int(orgID)).Str(userIDTag, string(userID)).Str(selectorStr, string(selector)).
 			Msg("Couldn't get impacted clusters for given rule selector")
+		handleServerError(writer, err)
 		return
 	}
+
+	disabledClusters, err := server.getListOfDisabledClusters(orgID, userID, selector)
+	if err != nil {
+		log.Error().Err(err).Int(orgIDTag, int(orgID)).Str(userIDTag, string(userID)).Str(selectorStr, string(selector)).
+			Msg("Couldn't retrieve disabled clusters for given rule selector")
+		handleServerError(writer, err)
+		return
+	}
+
+	err = server.processClustersDetailResponse(impactedClusters, disabledClusters, activeClustersInfo, writer)
+	if err != nil {
+		log.Error().Err(err).Int(orgIDTag, int(orgID)).Str(userIDTag, string(userID)).Str(selectorStr, string(selector)).
+			Msg("Couldn't process response for clusters detail")
+		handleServerError(writer, err)
+		return
+	}
+}
+
+// getListOfDisabledClusters reads list of disabled clusters from aggregator
+func (server *HTTPServer) getListOfDisabledClusters(
+	orgID types.OrgID, userID types.UserID, ruleSelector ctypes.RuleSelector,
+) ([]ctypes.DisabledClusterInfo, error) {
+	var response struct {
+		Status           string                       `json:"status"`
+		DisabledClusters []ctypes.DisabledClusterInfo `json:"clusters"`
+	}
+
+	// rule selector has already been validated
+	splitRuleID := strings.Split(string(ruleSelector), "|")
+
+	aggregatorURL := httputils.MakeURLToEndpoint(
+		server.ServicesConfig.AggregatorBaseEndpoint,
+		//FIXME
+		"clusters/rules/{rule_id}/error_key/{error_key}/users/{user_id}/disabled",
+		splitRuleID[0],
+		splitRuleID[1],
+		userID,
+	)
+
+	// #nosec G107
+	resp, err := http.Get(aggregatorURL)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		err := fmt.Errorf("error reading disabled clusters from aggregator: %v", resp.StatusCode)
+		return nil, err
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.DisabledClusters, nil
+}
+
+// processClustersDetailResponse processes responses from aggregator and AMS API and sends a response
+func (server *HTTPServer) processClustersDetailResponse(
+	impactedClusters []ctypes.HittingClustersData,
+	disabledClusters []ctypes.DisabledClusterInfo,
+	clusterInfo []types.ClusterInfo,
+	writer http.ResponseWriter,
+) error {
+
+	data := types.ClustersDetailData{
+		EnabledClusters:  make([]ctypes.HittingClustersData, 0),
+		DisabledClusters: make([]ctypes.DisabledClusterInfo, 0),
+	}
+	// disabledMap is used to filter out the impacted clusters
+	disabledMap := make(map[types.ClusterName]ctypes.DisabledClusterInfo)
+	clusterNamesMap := types.ClusterInfoArrayToMap(clusterInfo)
+
+	// filter out inactive clusters from disabled; fill in display names
+	for _, disabledC := range disabledClusters {
+		// omit clusters that weren't retrieved from AMS API
+		if displayName, found := clusterNamesMap[disabledC.ClusterID]; found {
+			disabledC.ClusterName = displayName
+			disabledMap[disabledC.ClusterID] = disabledC
+			data.DisabledClusters = append(data.DisabledClusters, disabledC)
+		}
+	}
+
+	for _, impactedC := range impactedClusters {
+		// omit disabled clusters
+		if _, disabled := disabledMap[impactedC.Cluster]; disabled {
+			continue
+		}
+		impactedC.Name = clusterNamesMap[impactedC.Cluster]
+		data.EnabledClusters = append(data.EnabledClusters, impactedC)
+	}
+
+	response := types.ClustersDetailResponse{
+		Status: OkMsg,
+		Data:   data,
+	}
+
+	return responses.Send(http.StatusOK, writer, response)
 }

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -131,9 +131,8 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 		t,
 		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 		&helpers.APIRequest{
-			Method: http.MethodGet,
-			//Endpoint:     ira_server.ListOfDisabledClusters,
-			Endpoint:     "clusters/rules/{rule_id}/error_key/{error_key}/users/{user_id}/disabled", //FIXME
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ListOfDisabledClusters,
 			EndpointArgs: []interface{}{testdata.Rule1ID, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
 		},
 		&helpers.APIResponse{
@@ -249,9 +248,8 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_ImpactedClusterDi
 		t,
 		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 		&helpers.APIRequest{
-			Method: http.MethodGet,
-			//Endpoint:     ira_server.ListOfDisabledClusters,
-			Endpoint:     "clusters/rules/{rule_id}/error_key/{error_key}/users/{user_id}/disabled", //FIXME
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ListOfDisabledClusters,
 			EndpointArgs: []interface{}{testdata.Rule1ID, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
 		},
 		&helpers.APIResponse{
@@ -361,9 +359,8 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_DisabledClusterNo
 		t,
 		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 		&helpers.APIRequest{
-			Method: http.MethodGet,
-			//Endpoint:     ira_server.ListOfDisabledClusters,
-			Endpoint:     "clusters/rules/{rule_id}/error_key/{error_key}/users/{user_id}/disabled", //FIXME
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ListOfDisabledClusters,
 			EndpointArgs: []interface{}{testdata.Rule1ID, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
 		},
 		&helpers.APIResponse{
@@ -450,9 +447,8 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponse400(t *testing.T) {
 		t,
 		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 		&helpers.APIRequest{
-			Method: http.MethodGet,
-			//Endpoint:     ira_server.ListOfDisabledClusters,
-			Endpoint:     "clusters/rules/{rule_id}/error_key/{error_key}/users/{user_id}/disabled", //FIXME
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ListOfDisabledClusters,
 			EndpointArgs: []interface{}{testdata.Rule1ID, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
 		},
 		&helpers.APIResponse{
@@ -510,9 +506,8 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponse404(t *testing.T) {
 		t,
 		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 		&helpers.APIRequest{
-			Method: http.MethodGet,
-			//Endpoint:     ira_server.ListOfDisabledClusters,
-			Endpoint:     "clusters/rules/{rule_id}/error_key/{error_key}/users/{user_id}/disabled", //FIXME
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ListOfDisabledClusters,
 			EndpointArgs: []interface{}{testdata.Rule1ID, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
 		},
 		&helpers.APIResponse{
@@ -579,9 +574,8 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponse500(t *testing.T) {
 		t,
 		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 		&helpers.APIRequest{
-			Method: http.MethodGet,
-			//Endpoint:     ira_server.ListOfDisabledClusters,
-			Endpoint:     "clusters/rules/{rule_id}/error_key/{error_key}/users/{user_id}/disabled", //FIXME
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ListOfDisabledClusters,
 			EndpointArgs: []interface{}{testdata.Rule1ID, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
 		},
 		&helpers.APIResponse{

--- a/tests/testdata/testdata.go
+++ b/tests/testdata/testdata.go
@@ -82,9 +82,20 @@ var (
 	}
 
 	ClusterInfoResult = []types.ClusterInfo{
-		types.ClusterInfo{
+		{
 			ID:          testdata.ClusterName,
 			DisplayName: ClusterDisplayName1,
+		},
+	}
+
+	ClusterInfoResult2Clusters = []types.ClusterInfo{
+		{
+			ID:          testdata.GetRandomClusterID(),
+			DisplayName: ClusterDisplayName1,
+		},
+		{
+			ID:          testdata.GetRandomClusterID(),
+			DisplayName: ClusterDisplayName2,
 		},
 	}
 )

--- a/types/types.go
+++ b/types/types.go
@@ -222,3 +222,15 @@ type ClusterInfo struct {
 	ID          ClusterName
 	DisplayName string
 }
+
+// ClustersDetailData is the inner data structure for /clusters_detail
+type ClustersDetailData struct {
+	EnabledClusters  []types.HittingClustersData `json:"enabled"`
+	DisabledClusters []types.DisabledClusterInfo `json:"disabled"`
+}
+
+// ClustersDetailResponse is a data structure used as the response for /clusters_detail
+type ClustersDetailResponse struct {
+	Data   ClustersDetailData `json:"data"`
+	Status string             `json:"status"`
+}


### PR DESCRIPTION
# Description
- Modifies clusters_detail to include disabled rules, returning two lists of clusters (enabled/disabled).
- After discussing with frontend guys, returning `meta.count` for unpaginated requests isn't needed. (especially since `.length` is just an attribute of an array in JS, so it's an inexpensive operation to "count" on frontend)

Fixes CCXDEV-6598

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)
- Bump-up dependent library (no changes in the code)

## Testing steps
alongside aggregator; `make test`

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
