### PR TITLE
Increase coverage for package content

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -81,26 +81,6 @@ func (s *RulesWithContentStorage) GetRuleWithErrorKeyContent(
 	return res, found
 }
 
-// GetRuleContentV1 returns content for rule for api v1
-func (s *RulesWithContentStorage) GetRuleContentV1(ruleID ctypes.RuleID) (*types.RuleContentV1, bool) {
-	res, found := s.getRuleContent(ruleID)
-	resV1 := types.RuleContentV1{}
-	if found {
-		resV1 = RuleContentToV1(res)
-	}
-	return &resV1, found
-}
-
-// GetRuleContentV2 returns content for rule for api v2
-func (s *RulesWithContentStorage) GetRuleContentV2(ruleID ctypes.RuleID) (*types.RuleContentV2, bool) {
-	res, found := s.getRuleContent(ruleID)
-	resV2 := types.RuleContentV2{}
-	if found {
-		resV2 = RuleContentToV2(res)
-	}
-	return &resV2, found
-}
-
 // GetContentForRecommendation returns content for rule with error key
 func (s *RulesWithContentStorage) GetContentForRecommendation(
 	ruleID ctypes.RuleID,

--- a/content/content.go
+++ b/content/content.go
@@ -424,7 +424,7 @@ func RunUpdateContentLoop(servicesConf services.Configuration) {
 		select {
 		case <-ticker.C:
 		case <-stopUpdateContentLoop:
-			break
+			return
 		}
 	}
 }

--- a/content/content_test.go
+++ b/content/content_test.go
@@ -660,6 +660,12 @@ func TestContentLoop(t *testing.T) {
 	content.StopUpdateContentLoop()
 }
 
+func TestRuleContentDirectoryTimeoutErrorError(t *testing.T) {
+	ruleContentDirectoryTimeoutError := content.RuleContentDirectoryTimeoutError{}
+	errString := ruleContentDirectoryTimeoutError.Error()
+	assert.NotEmpty(t, errString)
+}
+
 func fakeRuleAsInternal(ruleContent *ctypes.RuleContent) {
 	modifyPluginPythonModule(ruleContent, internalStr)
 }

--- a/content/content_test.go
+++ b/content/content_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/RedHatInsights/insights-results-smart-proxy/content"
+	"github.com/RedHatInsights/insights-results-smart-proxy/services"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
 	"github.com/RedHatInsights/insights-results-smart-proxy/types"
 )
@@ -648,6 +649,15 @@ func TestGetExternalRuleSeverities2Unique(t *testing.T) {
 	assert.Equal(t, 2, len(recommendationSeverities))
 	// rules have different severity
 	assert.Equal(t, 2, len(uniqueSeverities))
+}
+
+func TestContentLoop(t *testing.T) {
+	go content.RunUpdateContentLoop(services.Configuration{
+		GroupsPollingTime: 1 * time.Second,
+	})
+	content.SetContentDirectoryTimeout(1 * time.Second)
+	time.Sleep(2 * time.Second)
+	content.StopUpdateContentLoop()
 }
 
 func fakeRuleAsInternal(ruleContent *ctypes.RuleContent) {

--- a/content/parsing.go
+++ b/content/parsing.go
@@ -141,11 +141,8 @@ func timeParse(value string) (publishDate time.Time, missing bool, err error) {
 		)
 	}
 
-	if err != nil {
-		log.Error().Msgf("problem parsing publish_date: %v", err)
-	} else {
-		err = errors.New("invalid format of publish_date")
-	}
+	log.Error().Msgf("problem parsing publish_date: %v", err)
+	err = errors.New("invalid format of publish_date")
 
 	return
 }

--- a/content/parsing_test.go
+++ b/content/parsing_test.go
@@ -1,0 +1,31 @@
+// Copyright 2021 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package content
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCommaSeparatedStrToTags(t *testing.T) {
+	t.Run("empty string", func(t *testing.T) {
+		assert.Equal(t, []string{}, commaSeparatedStrToTags(""))
+	})
+
+	t.Run("valid string", func(t *testing.T) {
+		assert.Equal(t, []string{"a", "string"}, commaSeparatedStrToTags("a,string "))
+	})
+}

--- a/content/parsing_test.go
+++ b/content/parsing_test.go
@@ -16,6 +16,7 @@ package content
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -27,5 +28,26 @@ func TestCommaSeparatedStrToTags(t *testing.T) {
 
 	t.Run("valid string", func(t *testing.T) {
 		assert.Equal(t, []string{"a", "string"}, commaSeparatedStrToTags("a,string "))
+	})
+}
+
+func TestTimeParse(t *testing.T) {
+	t.Run("empty input", func(t *testing.T) {
+		_, missing, err := timeParse("")
+		assert.True(t, missing)
+		assert.NoError(t, err)
+	})
+
+	t.Run("valid layout", func(t *testing.T) {
+		date, missing, err := timeParse("2021-02-03 01:02:03")
+		assert.Equal(t, time.Date(2021, time.Month(2), 3, 1, 2, 3, 0, time.UTC), date)
+		assert.False(t, missing)
+		assert.NoError(t, err)
+	})
+
+	t.Run("invalid layout", func(t *testing.T) {
+		_, missing, err := timeParse("2021/02/03 01:02:03")
+		assert.False(t, missing)
+		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
# Description

Increasing coverage of `content` package.

Fixes  #752 #753 #754 #755  #756  #757 #758

## Type of change

- Unit tests (no changes in the code)

## Testing steps

`go test .`

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
