### PR TITLE
Fix getImpactedClustersFromAggregator bug

### DIFF
--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -778,7 +778,7 @@ func getImpactedClustersFromAggregator(
 	url string,
 	activeClusters []ctypes.ClusterName,
 ) (resp *http.Response, err error) {
-	if len(activeClusters) < 0 {
+	if len(activeClusters) < 1 { //empty array
 		// #nosec G107
 		resp, err = http.Get(url)
 		return

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -390,7 +390,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_DisabledClusterNo
 	}
 	`
 
-	// 2nd clussster is there
+	// 2nd cluster is there
 	expectedResponse = fmt.Sprintf(expectedResponse, clusters[1], data.ClusterDisplayName2)
 
 	testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, amsClientMock, nil, nil, nil)

--- a/server/server.go
+++ b/server/server.go
@@ -391,7 +391,7 @@ func (server HTTPServer) readClusterIDsForOrgID(orgID ctypes.OrgID) ([]ctypes.Cl
 	}
 
 	log.Info().Msg("amsclient not initialized. Using fallback mechanism")
-	return server.getClusterIDsFromAggregator(orgID)
+	return server.getClusterDetailsFromAggregator(orgID)
 }
 
 // readClusterInfoForOrgID returns a list of cluster info types and a map of cluster display names
@@ -416,7 +416,7 @@ func (server HTTPServer) readClusterInfoForOrgID(orgID ctypes.OrgID) (
 	}
 
 	log.Info().Msg("amsclient not initialized. Using fallback mechanism")
-	clusterIDs, err := server.getClusterIDsFromAggregator(orgID)
+	clusterIDs, err := server.getClusterDetailsFromAggregator(orgID)
 	if err != nil {
 		log.Error().Err(err).Msg("error retrieving clusters from aggregator")
 		return nil, err
@@ -434,8 +434,8 @@ func (server HTTPServer) readClusterInfoForOrgID(orgID ctypes.OrgID) (
 	return clusterInfo, nil
 }
 
-// readClusterIDsForOrgID reads the list of clusters for a given organization from aggregator
-func (server HTTPServer) getClusterIDsFromAggregator(orgID ctypes.OrgID) ([]ctypes.ClusterName, error) {
+// getClusterDetailsFromAggregator reads the list of clusters for a given organization from aggregator
+func (server HTTPServer) getClusterDetailsFromAggregator(orgID ctypes.OrgID) ([]ctypes.ClusterName, error) {
 	log.Info().Msg("retrieving cluster IDs from aggregator")
 
 	aggregatorURL := httputils.MakeURLToEndpoint(


### PR DESCRIPTION
# Description

`getImpactedClustersFromAggregator` always received a slice of activeClusters, since it is initialised in the `GetClusterNames` function. The comparison being done is therefore always false, resulting in code that is not behaving as expected.

Fixes #849 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
