### PR TITLE
Display name in cluster reports

### DIFF
--- a/amsclient/amsclient_test.go
+++ b/amsclient/amsclient_test.go
@@ -16,7 +16,6 @@ package amsclient_test
 
 import (
 	"crypto/rsa"
-	"github.com/RedHatInsights/insights-results-smart-proxy/types"
 	"net/http"
 	"testing"
 	"time"
@@ -29,6 +28,7 @@ import (
 	"github.com/RedHatInsights/insights-results-smart-proxy/amsclient"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/testdata"
+	"github.com/RedHatInsights/insights-results-smart-proxy/types"
 )
 
 const (

--- a/amsclient/amsclient_test.go
+++ b/amsclient/amsclient_test.go
@@ -16,6 +16,7 @@ package amsclient_test
 
 import (
 	"crypto/rsa"
+	"github.com/RedHatInsights/insights-results-smart-proxy/types"
 	"net/http"
 	"testing"
 	"time"
@@ -39,6 +40,8 @@ const (
 		"search=organization_id+is+%%27{orgID}%%27+and+cluster_id+%%21%%3D+%%27%%27+and+status+in+%%28%%27{status1}%%27%%2C%%27{status2}%%27%%29&size={pageSize}")
 	subscriptionsSearchEndpointWithDefaultFilter = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id%%2Cdisplay_name%%2Ccluster_id&page={pageNum}&" +
 		"search=organization_id+is+%%27{orgID}%%27+and+cluster_id+%%21%%3D+%%27%%27+and+status+not+in+%%28%%27{status1}%%27%%2C%%27{status2}%%27%%2C%%27{status3}%%27%%29&size={pageSize}")
+	clusterDetailsSearchEndpoint = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id%%2Cdisplay_name%%2Ccluster_id&page={pageNum}&" +
+		"search=external_cluster_id+%%3D+%%27{clusterID}%%27&size={pageSize}")
 )
 
 var (
@@ -255,4 +258,70 @@ func TestGetClustersForOrganizationOnError(t *testing.T) {
 		t.Fail()
 	}
 	assert.Equal(t, 0, len(clusters))
+}
+
+func TestGetClusterDetailsFromExternalClusterId(t *testing.T) {
+	defer helpers.CleanAfterGock(t)
+	c, err := amsclient.NewAMSClientWithTransport(defaultConfig, gock.DefaultTransport)
+	helpers.FailOnError(t, err)
+
+	// prepare subscription filtered by external_cluster_id response
+	helpers.GockExpectAPIRequest(t, defaultConfig.URL, &helpers.APIRequest{
+		Method:       http.MethodGet,
+		Endpoint:     clusterDetailsSearchEndpoint,
+		EndpointArgs: []interface{}{1, testdata.ClusterName1, defaultConfig.PageSize},
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusOK,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body: helpers.ToJSONString(testdata.SubscriptionsResponse),
+	})
+
+	// second request will get an empty response (0 sized), so no more requests will be made
+	helpers.GockExpectAPIRequest(t, defaultConfig.URL, &helpers.APIRequest{
+		Method:       http.MethodGet,
+		Endpoint:     clusterDetailsSearchEndpoint,
+		EndpointArgs: []interface{}{2, testdata.ClusterName1, defaultConfig.PageSize},
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusOK,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body: helpers.ToJSONString(testdata.SubscriptionEmptyResponse),
+	})
+
+	clusterListInfo := c.GetClusterDetailsFromExternalClusterID(
+		testdata.ClusterName1,
+	)
+
+	assert.Equal(t, clusterListInfo, types.ClusterInfo{
+		ID:          testdata.ClusterName1,
+		DisplayName: testdata.ClusterDisplayName1,
+	})
+}
+
+func TestGetClusterDetailsUnknownExternalClusterId(t *testing.T) {
+	defer helpers.CleanAfterGock(t)
+	c, err := amsclient.NewAMSClientWithTransport(defaultConfig, gock.DefaultTransport)
+	helpers.FailOnError(t, err)
+
+	// prepare subscription filtered by external_cluster_id response
+	helpers.GockExpectAPIRequest(t, defaultConfig.URL, &helpers.APIRequest{
+		Method:       http.MethodGet,
+		Endpoint:     clusterDetailsSearchEndpoint,
+		EndpointArgs: []interface{}{1, testdata.ClusterName1, defaultConfig.PageSize},
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusOK,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body: helpers.ToJSONString(testdata.SubscriptionEmptyResponse),
+	})
+
+	clusterListInfo := c.GetClusterDetailsFromExternalClusterID(
+		testdata.ClusterName1,
+	)
+
+	assert.Equal(t, clusterListInfo, types.ClusterInfo{})
 }

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/RedHatInsights/insights-operator-utils v1.22.0
 	github.com/RedHatInsights/insights-results-aggregator v1.2.3
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.4
-	github.com/RedHatInsights/insights-results-types v1.3.4
+	github.com/RedHatInsights/insights-results-types v1.3.5
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/gorilla/handlers v1.5.1
@@ -20,4 +20,8 @@ require (
 	github.com/spf13/viper v1.9.0
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/h2non/gock.v1 v1.1.2
+)
+
+replace (
+	github.com/RedHatInsights/insights-results-aggregator => ../insights-results-aggregator
 )

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,3 @@ require (
 	github.com/stretchr/testify v1.7.0
 	gopkg.in/h2non/gock.v1 v1.1.2
 )
-
-replace (
-	github.com/RedHatInsights/insights-results-aggregator => ../insights-results-aggregator
-)

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20211119142943-71a7a9be7bb8
 	github.com/RedHatInsights/insights-operator-utils v1.22.0
-	github.com/RedHatInsights/insights-results-aggregator v1.2.3
+	github.com/RedHatInsights/insights-results-aggregator v1.2.4
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.4
 	github.com/RedHatInsights/insights-results-types v1.3.5
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869

--- a/go.sum
+++ b/go.sum
@@ -82,8 +82,8 @@ github.com/RedHatInsights/insights-operator-utils v1.21.8/go.mod h1:qa1a8NdarIzc
 github.com/RedHatInsights/insights-operator-utils v1.22.0 h1:rXK/n6gJca5u/jmi62QyOeAR0EaUcoBLmGdBwqMBG7s=
 github.com/RedHatInsights/insights-operator-utils v1.22.0/go.mod h1:4G1aWUV3SBc5tRflpAZX2BjoWB8afxXtSutg+5/sLE8=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
-github.com/RedHatInsights/insights-results-aggregator v1.2.3 h1:vIfMFl0SpvO0mZn+oI1IkYx13EPyECeVSDxVFSxacHE=
-github.com/RedHatInsights/insights-results-aggregator v1.2.3/go.mod h1:ELn+Mhk0mcmbiliJVOZ3aMkyzOYDpyfM6utPONVxapo=
+github.com/RedHatInsights/insights-results-aggregator v1.2.4 h1:xUDGEKpnAiG540Xtc75LcbGR9FiSjZ5xpsdVkBD2dUI=
+github.com/RedHatInsights/insights-results-aggregator v1.2.4/go.mod h1:fC2oUxyX4U6bM+lb2pk0ads9XglW4KEjUfat80MNpXU=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=
@@ -96,7 +96,6 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.3.4 h1:ZE0RM0Rquah
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.4/go.mod h1:iHVNt/wzpjrTvPO+yhCm9jSJljhdwj3o/sehLqch2BU=
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
-github.com/RedHatInsights/insights-results-types v1.3.4/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.5 h1:Q1awNYeJqIFgst7zQgKfQwbdMieyJTG/eDIau+yIUpo=
 github.com/RedHatInsights/insights-results-types v1.3.5/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,9 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.3.4 h1:ZE0RM0Rquah
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.4/go.mod h1:iHVNt/wzpjrTvPO+yhCm9jSJljhdwj3o/sehLqch2BU=
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
-github.com/RedHatInsights/insights-results-types v1.3.4 h1:3rab3nTKMqLYTnAVrRIdIVhRhjG9bst+cknWO5DX3h0=
 github.com/RedHatInsights/insights-results-types v1.3.4/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
+github.com/RedHatInsights/insights-results-types v1.3.5 h1:Q1awNYeJqIFgst7zQgKfQwbdMieyJTG/eDIau+yIUpo=
+github.com/RedHatInsights/insights-results-types v1.3.5/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=

--- a/server/api/v1/openapi.json
+++ b/server/api/v1/openapi.json
@@ -676,6 +676,11 @@
                           "description": "",
                           "type": "object",
                           "properties": {
+                            "cluster_name": {
+                              "type": "string",
+                              "description": "An human-readable name for the cluster",
+                              "example": "Production cluster 1"
+                            },
                             "count": {
                               "format": "int32",
                               "type": "integer"
@@ -686,7 +691,8 @@
                             }
                           },
                           "example": {
-                            "count": 9,
+                            "cluster_name": "Production cluster 1",
+			    "count": 9,
                             "last_checked_at": "2020-12-08T09:45:23Z"
                           }
                         }

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -1144,6 +1144,11 @@
         "description": "",
         "type": "object",
         "properties": {
+          "cluster_name": {
+            "type": "string",
+            "description": "An human-readable name for the cluster",
+            "example": "Production cluster 1"
+          },
           "count": {
             "format": "int32",
             "type": "integer"
@@ -1154,6 +1159,7 @@
           }
         },
         "example": {
+          "cluster_name": "Production cluster 1",
           "count": 9,
           "last_checked_at": "2020-12-08T09:45:23Z"
         }

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -884,7 +884,11 @@
                                 "type": "string",
                                 "description": "An human-readable name for the cluster",
                                 "example": "Production cluster 1"
-                              }
+                              },
+			      "last_checked_at": {
+				"format": "date-time",
+			       	"type": "string"
+			      }
                             }
                           }
                         },

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -53,13 +53,14 @@ var (
 		},
 	}
 
-	SmartProxyReportRule1 = struct {
+	SmartProxyReportRule1NoAMSClient = struct {
 		Status string                  `json:"status"`
 		Report *types.SmartProxyReport `json:"report"`
 	}{
 		Status: "ok",
 		Report: &types.SmartProxyReport{
 			Meta: types.ReportResponseMeta{
+				DisplayName:   string(testdata.ClusterName),
 				Count:         1,
 				LastCheckedAt: types.Timestamp(testdata.LastCheckedAt.UTC().Format(time.RFC3339)),
 			},
@@ -412,7 +413,7 @@ func TestHTTPServer_ReportEndpoint_WithClusterAndSystemWideDisabledRules(t *test
 			OrgID:        testdata.OrgID,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
-			Body:       helpers.ToJSONString(SmartProxyReportRule1),
+			Body:       helpers.ToJSONString(SmartProxyReportRule1NoAMSClient),
 		})
 
 		// Get report without specifying get_disabled => same result as above
@@ -424,7 +425,7 @@ func TestHTTPServer_ReportEndpoint_WithClusterAndSystemWideDisabledRules(t *test
 			OrgID:        testdata.OrgID,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
-			Body:       helpers.ToJSONString(SmartProxyReportRule1),
+			Body:       helpers.ToJSONString(SmartProxyReportRule1NoAMSClient),
 		})
 
 		// Get report with get_disabled = true

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -91,7 +91,8 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 		"clusters":[
 			{
 				"cluster":"%v",
-				"cluster_name": "%v"
+				"cluster_name": "%v",
+				"last_checked_at":""
 			}
 		],
 		"status":"ok"
@@ -153,7 +154,8 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 			"enabled": [
 				{
 					"cluster": "%v",
-					"cluster_name": "%v"
+					"cluster_name": "%v",
+				    "last_checked_at": ""
 				}
 			],
 			"disabled": [
@@ -381,7 +383,8 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_DisabledClusterNo
 			"enabled": [
 				{
 					"cluster": "%v",
-					"cluster_name": "%v"
+					"cluster_name": "%v",
+					"last_checked_at":""
 				}
 			],
 			"disabled": []

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -155,7 +155,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 				{
 					"cluster": "%v",
 					"cluster_name": "%v",
-				    "last_checked_at": ""
+					"last_checked_at": ""
 				}
 			],
 			"disabled": [

--- a/server/server.go
+++ b/server/server.go
@@ -838,15 +838,15 @@ func (server HTTPServer) fetchAggregatorReportsUsingRequestBodyClusterList(
 	return aggregatorResponse, true
 }
 
-func (server HTTPServer) setClusterDisplayNameInReport(clusterID types.ClusterName, report *types.SmartProxyReport) {
+func (server HTTPServer) SetClusterDisplayNameInReport(clusterID types.ClusterName, report *types.SmartProxyReport) {
 	if server.amsClient != nil {
 		clusterInfo := server.amsClient.GetClusterDetailsFromExternalClusterID(clusterID)
-		if clusterInfo.DisplayName == "" {
-			report.Meta.DisplayName = string(clusterID)
-		} else {
+		if clusterInfo.DisplayName != "" {
 			report.Meta.DisplayName = clusterInfo.DisplayName
+			return
 		}
 	}
+	report.Meta.DisplayName = string(clusterID)
 }
 
 func (server HTTPServer) reportEndpoint(writer http.ResponseWriter, request *http.Request) {
@@ -900,7 +900,7 @@ func (server HTTPServer) reportEndpoint(writer http.ResponseWriter, request *htt
 		}
 	}
 
-	server.setClusterDisplayNameInReport(clusterID, &report)
+	server.SetClusterDisplayNameInReport(clusterID, &report)
 
 	totalRuleCnt := server.getRuleCount(visibleRules, noContentRulesCnt, disabledRulesCnt, clusterID)
 

--- a/server/server.go
+++ b/server/server.go
@@ -838,6 +838,9 @@ func (server HTTPServer) fetchAggregatorReportsUsingRequestBodyClusterList(
 	return aggregatorResponse, true
 }
 
+// SetClusterDisplayNameInReport tries to retrieve the display name of the cluster using
+// the configured AMS client. If no info is retrieved, it sets the cluster's external
+// ID as display name.
 func (server HTTPServer) SetClusterDisplayNameInReport(clusterID types.ClusterName, report *types.SmartProxyReport) {
 	if server.amsClient != nil {
 		clusterInfo := server.amsClient.GetClusterDetailsFromExternalClusterID(clusterID)

--- a/server/server.go
+++ b/server/server.go
@@ -82,15 +82,14 @@ const (
 
 // HTTPServer is an implementation of Server interface
 type HTTPServer struct {
-	Config                   Configuration
-	InfoParams               map[string]string
-	ServicesConfig           services.Configuration
-	amsClient                amsclient.AMSClient
-	GroupsChannel            chan []groups.Group
-	AmsClusterDetailsChannel chan []groups.Group
-	ErrorFoundChannel        chan bool
-	ErrorChannel             chan error
-	Serv                     *http.Server
+	Config            Configuration
+	InfoParams        map[string]string
+	ServicesConfig    services.Configuration
+	amsClient         amsclient.AMSClient
+	GroupsChannel     chan []groups.Group
+	ErrorFoundChannel chan bool
+	ErrorChannel      chan error
+	Serv              *http.Server
 }
 
 // RequestModifier is a type of function which modifies request when proxying

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -125,7 +125,7 @@ var (
 		Report *types.SmartProxyReport `json:"report"`
 	}{
 		Status: "ok",
-		Report: &SmartProxyReport1RuleNoContent,
+		Report: &SmartProxyReport1RuleNoContentNoAMSClient,
 	}
 
 	SmartProxyReportResponse3Rules2NoContent = struct {
@@ -133,7 +133,7 @@ var (
 		Report *types.SmartProxyReport `json:"report"`
 	}{
 		Status: "ok",
-		Report: &SmartProxyReport3Rules2NoContent,
+		Report: &SmartProxyReport3Rules2NoContentNoAMSClient,
 	}
 
 	SmartProxyReportResponse3Rules = struct {
@@ -141,19 +141,21 @@ var (
 		Report *types.SmartProxyReport `json:"report"`
 	}{
 		Status: "ok",
-		Report: &SmartProxyReport3Rules,
+		Report: &SmartProxyReport3RulesNoAMSClient,
 	}
 
-	SmartProxyReport1RuleNoContent = types.SmartProxyReport{
+	SmartProxyReport1RuleNoContentNoAMSClient = types.SmartProxyReport{
 		Meta: types.ReportResponseMeta{
+			DisplayName:   string(testdata.ClusterName),
 			Count:         0,
 			LastCheckedAt: types.Timestamp(testdata.LastCheckedAt.UTC().Format(time.RFC3339)),
 		},
 		Data: []types.RuleWithContentResponse{},
 	}
 
-	SmartProxyReport3Rules = types.SmartProxyReport{
+	SmartProxyReport3RulesNoAMSClient = types.SmartProxyReport{
 		Meta: types.ReportResponseMeta{
+			DisplayName:   string(testdata.ClusterName),
 			Count:         3,
 			LastCheckedAt: types.Timestamp(testdata.LastCheckedAt.UTC().Format(time.RFC3339)),
 		},
@@ -209,8 +211,9 @@ var (
 		},
 	}
 
-	SmartProxyReport3Rules2NoContent = types.SmartProxyReport{
+	SmartProxyReport3Rules2NoContentNoAMSClient = types.SmartProxyReport{
 		Meta: types.ReportResponseMeta{
+			DisplayName:   string(testdata.ClusterName),
 			Count:         3,
 			LastCheckedAt: types.Timestamp(testdata.LastCheckedAt.UTC().Format(time.RFC3339)),
 		},
@@ -239,7 +242,7 @@ var (
 		Report *types.SmartProxyReport `json:"report"`
 	}{
 		Status: "ok",
-		Report: &SmartProxyReport3RulesWithOnlyOSD,
+		Report: &SmartProxyReport3RulesWithOnlyOSDNoAMSClient,
 	}
 
 	SmartProxyReportResponse3RulesOnlyEnabled = struct {
@@ -247,7 +250,7 @@ var (
 		Report *types.SmartProxyReport `json:"report"`
 	}{
 		Status: "ok",
-		Report: &SmartProxyReport3RulesOnlyEnabled,
+		Report: &SmartProxyReport3RulesOnlyEnabledNoAMSClient,
 	}
 
 	SmartProxyEmptyResponse = struct {
@@ -255,7 +258,7 @@ var (
 		Report *types.SmartProxyReport `json:"report"`
 	}{
 		Status: "ok",
-		Report: &SmartProxyReportEmptyCount2,
+		Report: &SmartProxyReportEmptyCount2NoAMSClient,
 	}
 
 	SmartProxyReportResponse3RulesAll = struct {
@@ -263,11 +266,12 @@ var (
 		Report *types.SmartProxyReport `json:"report"`
 	}{
 		Status: "ok",
-		Report: &SmartProxyReport3RulesWithDisabled,
+		Report: &SmartProxyReport3RulesWithDisabledNoAMSClient,
 	}
 
-	SmartProxyReport3RulesWithOnlyOSD = types.SmartProxyReport{
+	SmartProxyReport3RulesWithOnlyOSDNoAMSClient = types.SmartProxyReport{
 		Meta: types.ReportResponseMeta{
+			DisplayName:   string(testdata.ClusterName),
 			Count:         1,
 			LastCheckedAt: types.Timestamp(testdata.LastCheckedAt.UTC().Format(time.RFC3339)),
 		},
@@ -291,8 +295,9 @@ var (
 		},
 	}
 
-	SmartProxyReport3RulesOnlyEnabled = types.SmartProxyReport{
+	SmartProxyReport3RulesOnlyEnabledNoAMSClient = types.SmartProxyReport{
 		Meta: types.ReportResponseMeta{
+			DisplayName:   string(testdata.ClusterName),
 			Count:         2,
 			LastCheckedAt: types.Timestamp(testdata.LastCheckedAt.UTC().Format(time.RFC3339)),
 		},
@@ -332,16 +337,18 @@ var (
 		},
 	}
 
-	SmartProxyReportEmptyCount2 = types.SmartProxyReport{
+	SmartProxyReportEmptyCount2NoAMSClient = types.SmartProxyReport{
 		Meta: types.ReportResponseMeta{
+			DisplayName:   string(testdata.ClusterName),
 			Count:         2,
 			LastCheckedAt: types.Timestamp(testdata.LastCheckedAt.UTC().Format(time.RFC3339)),
 		},
 		Data: []types.RuleWithContentResponse{},
 	}
 
-	SmartProxyReport3RulesWithDisabled = types.SmartProxyReport{
+	SmartProxyReport3RulesWithDisabledNoAMSClient = types.SmartProxyReport{
 		Meta: types.ReportResponseMeta{
+			DisplayName:   string(testdata.ClusterName),
 			Count:         3,
 			LastCheckedAt: types.Timestamp(testdata.LastCheckedAt.UTC().Format(time.RFC3339)),
 		},

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -19,6 +19,7 @@ package server_test
 import (
 	"encoding/json"
 	"fmt"
+	data "github.com/RedHatInsights/insights-results-smart-proxy/tests/testdata"
 	"net/http"
 	"testing"
 	"time"
@@ -1054,7 +1055,6 @@ func TestAddCORSHeaders(t *testing.T) {
 	})
 }
 
-//
 // TestHTTPServer_OverviewEndpointWithFallback
 func TestHTTPServer_OverviewEndpointWithFallback(t *testing.T) {
 	defer content.ResetContent()
@@ -1101,6 +1101,27 @@ func TestHTTPServer_OverviewEndpointWithFallback(t *testing.T) {
 				Body:       helpers.ToJSONString(OverviewResponse),
 			})
 	}, testTimeout)
+}
+
+func TestHTTPServer_setClusterDisplayNameInReportNoAMSClient(t *testing.T) {
+	report := types.SmartProxyReport{}
+	config := helpers.DefaultServerConfig
+	testServer := helpers.CreateHTTPServer(&config, nil, nil, nil, nil, nil)
+	testServer.SetClusterDisplayNameInReport(testdata.ClusterName, &report)
+	assert.Equal(t, string(testdata.ClusterName), report.Meta.DisplayName)
+}
+
+func TestHTTPServer_setClusterDisplayNameInReportAMSClientClusterIDFound(t *testing.T) {
+	report := types.SmartProxyReport{}
+	config := helpers.DefaultServerConfig
+	// prepare list of organizations response
+	amsClientMock := helpers.AMSClientWithOrgResults(
+		testdata.OrgID,
+		data.ClusterInfoResult,
+	)
+	testServer := helpers.CreateHTTPServer(&config, nil, amsClientMock, nil, nil, nil)
+	testServer.SetClusterDisplayNameInReport(testdata.ClusterName, &report)
+	assert.Equal(t, data.ClusterDisplayName1, report.Meta.DisplayName)
 }
 
 func ruleIDsChecker(t testing.TB, expected, got []byte) {

--- a/tests/helpers/amsclient.go
+++ b/tests/helpers/amsclient.go
@@ -16,6 +16,7 @@ package helpers
 
 import (
 	"fmt"
+	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
 
 	"github.com/RedHatInsights/insights-results-smart-proxy/amsclient"
 	"github.com/RedHatInsights/insights-results-smart-proxy/types"
@@ -38,6 +39,21 @@ func (m *mockAMSClient) GetClustersForOrganization(
 		return nil, fmt.Errorf("No clusters")
 	}
 
+	return
+}
+
+//Returns cluster info is given ID is found in clusterInfoList for testdata.orgID
+func (m *mockAMSClient) GetClusterDetailsFromExternalClusterID(
+	id types.ClusterName,
+) (
+	clusterInfo types.ClusterInfo,
+) {
+
+	for _, info := range m.clustersPerOrg[testdata.OrgID] {
+		if info.ID == id {
+			return info
+		}
+	}
 	return
 }
 


### PR DESCRIPTION
# Description

Include display_name in the cluster_details endpoint's JSON to avoid doing the query to AMS client from the UI.

Fixes CCXDEV-6552

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Updated/added UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
