### PR TITLE
Remove .report substring from rule_selector used in v2 content endpoints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.16
 require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20211119142943-71a7a9be7bb8
-	github.com/RedHatInsights/insights-operator-utils v1.22.0
+	github.com/RedHatInsights/insights-operator-utils v1.23.3
 	github.com/RedHatInsights/insights-results-aggregator v1.2.4
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.4
 	github.com/RedHatInsights/insights-results-types v1.3.5

--- a/go.sum
+++ b/go.sum
@@ -79,8 +79,9 @@ github.com/RedHatInsights/insights-operator-utils v1.12.0/go.mod h1:mN5jURLpSG+j
 github.com/RedHatInsights/insights-operator-utils v1.21.0/go.mod h1:B2hizFGwXCc8MT34QqVJ1A8ANTyGQZQWXQw/gSCEsaU=
 github.com/RedHatInsights/insights-operator-utils v1.21.2/go.mod h1:3Pfsgsi7GCu2wgIqQlt1llpyQyyxsDWEGdgnPvadM40=
 github.com/RedHatInsights/insights-operator-utils v1.21.8/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
-github.com/RedHatInsights/insights-operator-utils v1.22.0 h1:rXK/n6gJca5u/jmi62QyOeAR0EaUcoBLmGdBwqMBG7s=
 github.com/RedHatInsights/insights-operator-utils v1.22.0/go.mod h1:4G1aWUV3SBc5tRflpAZX2BjoWB8afxXtSutg+5/sLE8=
+github.com/RedHatInsights/insights-operator-utils v1.23.3 h1:4w6Yzj8cUpZuGAduO5tMeyoAx47DBQTfyMh3dOnJ5D4=
+github.com/RedHatInsights/insights-operator-utils v1.23.3/go.mod h1:vInEzg0d/rJQiINGtbOomA038N2uC/qlm1Bqt649yXY=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator v1.2.4 h1:xUDGEKpnAiG540Xtc75LcbGR9FiSjZ5xpsdVkBD2dUI=
 github.com/RedHatInsights/insights-results-aggregator v1.2.4/go.mod h1:fC2oUxyX4U6bM+lb2pk0ads9XglW4KEjUfat80MNpXU=
@@ -375,8 +376,9 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -104,7 +104,7 @@ func (server HTTPServer) getRuleWithGroups(
 // getRecommendationContent retrieves the static content for the given ruleID tied
 // with groups info. rule ID is expected to be the composite rule ID (rule.module|ERROR_KEY)
 func (server HTTPServer) getRecommendationContent(writer http.ResponseWriter, request *http.Request) {
-	ruleID, err := readCompositeRuleID(writer, request)
+	ruleID, err := readCompositeRuleID(request)
 	if err != nil {
 		log.Error().Err(err).Msgf("error retrieving rule ID from request")
 		handleServerError(writer, err)
@@ -157,7 +157,7 @@ func (server HTTPServer) getRecommendationContentWithUserData(writer http.Respon
 		return
 	}
 
-	ruleID, err := readCompositeRuleID(writer, request)
+	ruleID, err := readCompositeRuleID(request)
 	if err != nil {
 		log.Error().Err(err).Msgf("error retrieving rule ID from request")
 		handleServerError(writer, err)

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -237,8 +237,8 @@ func (server HTTPServer) getRecommendationContentWithUserData(writer http.Respon
 }
 
 // getRecommendations retrieves all recommendations with a count of impacted clusters
-// By default returns only those recommendations that currently hit atleast one cluster, but it's
-// possible to show all recommendations by passing a URL parameter `impacting`
+// By default returns only those recommendations that currently hit at least one cluster,
+// but it's possible to show all recommendations by passing a URL parameter `impacting`
 func (server HTTPServer) getRecommendations(writer http.ResponseWriter, request *http.Request) {
 	var recommendationList []types.RecommendationListView
 	tStart := time.Now()

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -83,7 +83,8 @@ func readCompositeRuleID(writer http.ResponseWriter, request *http.Request) (
 		return
 	}
 
-	ruleID = ctypes.RuleID(ruleIDParam)
+	//trim the .report from module part if present
+	ruleID = ctypes.RuleID(trimDotReportFromRuleID(ruleIDParam))
 	return
 }
 

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -58,7 +58,7 @@ func readRuleIDWithErrorKey(writer http.ResponseWriter, request *http.Request) (
 	return ruleID, errorKey, nil
 }
 
-func readCompositeRuleID(writer http.ResponseWriter, request *http.Request) (
+func readCompositeRuleID(request *http.Request) (
 	ruleID ctypes.RuleID,
 	err error,
 ) {
@@ -83,7 +83,7 @@ func readCompositeRuleID(writer http.ResponseWriter, request *http.Request) (
 		return
 	}
 
-	//trim the .report from module part if present
+	// trim the .report from module part if present
 	ruleID = ctypes.RuleID(trimDotReportFromRuleID(ruleIDParam))
 	return
 }

--- a/server/server.go
+++ b/server/server.go
@@ -76,8 +76,9 @@ const (
 
 	compositeRuleIDError = "Error generating composite rule ID for [%v] and [%v]"
 
-	// dotReport ".report" string present in the ruleID in most tables
-	dotReport = ".report"
+	// dotReportModuleSuffix ".report|" substring present at the end of the rule
+	// selector's module part
+	dotReportModuleSuffix = ".report|"
 )
 
 // HTTPServer is an implementation of Server interface
@@ -1249,7 +1250,7 @@ func isDisabledForOrgRule(aggregatorRule ctypes.RuleOnReport, systemWideDisabled
 	if len(systemWideDisabledRules) > 0 {
 		selector := types.RuleID(
 			fmt.Sprintf("%v|%v",
-				strings.TrimSuffix(string(aggregatorRule.Module), dotReport),
+				trimDotReportFromRuleID(string(aggregatorRule.Module)),
 				aggregatorRule.ErrorKey,
 			),
 		)

--- a/server/utils.go
+++ b/server/utils.go
@@ -17,6 +17,7 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	types "github.com/RedHatInsights/insights-results-types"
 	"github.com/rs/zerolog/log"
@@ -44,4 +45,8 @@ func logClustersReport(orgID types.OrgID, reports map[types.ClusterName]json.Raw
 		}
 		logClusterInfos(orgID, clusterName, report)
 	}
+}
+
+func trimDotReportFromRuleID(ruleID string) string {
+	return strings.ReplaceAll(ruleID, dotReportModuleSuffix, "|")
 }


### PR DESCRIPTION
# Description

UI will start sending the rule_selector as it comes in the reports. Therefore, the module part will contain ".report", which our v2-related tables do not expect. Additional considerations:
- This is a quick fix. We have a readAndTrimRuleSelector method in insights-operator-utils that we can't use here because the parameter expected in the URL is `rule_id` instead of `rule_selector`. Once the fix is tested and approved, we should refactor the URLs and use only one method (and update openAPI spec in this repo and for integration tests)
- This change is not breaking, since if there is no `.report|` in the recommendation, nothing is done.

Fixes [CCXDEV-7183](https://issues.redhat.com/browse/CCXDEV-7183)

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
