### PR TITLE
Look for rule module with '.report' in rule enable/disable tables

### DIFF
--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -900,10 +900,11 @@ func (server *HTTPServer) getListOfDisabledClusters(
 	// rule selector has already been validated
 	splitRuleID := strings.Split(string(ruleSelector), "|")
 
+	// rules disabled using v1 enable/disable endpoints include '.report' in the module
 	aggregatorURL := httputils.MakeURLToEndpoint(
 		server.ServicesConfig.AggregatorBaseEndpoint,
 		ira_server.ListOfDisabledClusters,
-		splitRuleID[0],
+		splitRuleID[0]+dotReport,
 		splitRuleID[1],
 		userID,
 	)

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -32,6 +32,10 @@ import (
 	"github.com/RedHatInsights/insights-results-smart-proxy/types"
 )
 
+const (
+	dotReportRuleModuleSuffix = ".report"
+)
+
 func TestHTTPServer_SetRating(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
 
@@ -134,7 +138,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 		&helpers.APIRequest{
 			Method:       http.MethodGet,
 			Endpoint:     ira_server.ListOfDisabledClusters,
-			EndpointArgs: []interface{}{testdata.Rule1ID, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
+			EndpointArgs: []interface{}{testdata.Rule1ID + dotReportRuleModuleSuffix, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
 		},
 		&helpers.APIResponse{
 			StatusCode: http.StatusOK,
@@ -216,6 +220,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_ImpactedClusterDi
 	}
 	`
 	impactedClustersResponse = fmt.Sprintf(impactedClustersResponse, clusters[0], "")
+
 	helpers.GockExpectAPIRequest(
 		t,
 		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
@@ -252,7 +257,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_ImpactedClusterDi
 		&helpers.APIRequest{
 			Method:       http.MethodGet,
 			Endpoint:     ira_server.ListOfDisabledClusters,
-			EndpointArgs: []interface{}{testdata.Rule1ID, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
+			EndpointArgs: []interface{}{testdata.Rule1ID + dotReportRuleModuleSuffix, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
 		},
 		&helpers.APIResponse{
 			StatusCode: http.StatusOK,
@@ -363,7 +368,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_DisabledClusterNo
 		&helpers.APIRequest{
 			Method:       http.MethodGet,
 			Endpoint:     ira_server.ListOfDisabledClusters,
-			EndpointArgs: []interface{}{testdata.Rule1ID, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
+			EndpointArgs: []interface{}{testdata.Rule1ID + dotReportRuleModuleSuffix, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
 		},
 		&helpers.APIResponse{
 			StatusCode: http.StatusOK,
@@ -452,7 +457,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponse400(t *testing.T) {
 		&helpers.APIRequest{
 			Method:       http.MethodGet,
 			Endpoint:     ira_server.ListOfDisabledClusters,
-			EndpointArgs: []interface{}{testdata.Rule1ID, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
+			EndpointArgs: []interface{}{testdata.Rule1ID + dotReportRuleModuleSuffix, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
 		},
 		&helpers.APIResponse{
 			StatusCode: http.StatusOK,
@@ -511,7 +516,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponse404(t *testing.T) {
 		&helpers.APIRequest{
 			Method:       http.MethodGet,
 			Endpoint:     ira_server.ListOfDisabledClusters,
-			EndpointArgs: []interface{}{testdata.Rule1ID, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
+			EndpointArgs: []interface{}{testdata.Rule1ID + dotReportRuleModuleSuffix, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
 		},
 		&helpers.APIResponse{
 			StatusCode: http.StatusNotFound,
@@ -579,7 +584,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponse500(t *testing.T) {
 		&helpers.APIRequest{
 			Method:       http.MethodGet,
 			Endpoint:     ira_server.ListOfDisabledClusters,
-			EndpointArgs: []interface{}{testdata.Rule1ID, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
+			EndpointArgs: []interface{}{testdata.Rule1ID + dotReportRuleModuleSuffix, testdata.ErrorKey1, userIDOnGoodJWTAuthBearer},
 		},
 		&helpers.APIResponse{
 			StatusCode: http.StatusInternalServerError,

--- a/server/rating.go
+++ b/server/rating.go
@@ -38,7 +38,7 @@ func (server *HTTPServer) postRating(writer http.ResponseWriter, request *http.R
 		return
 	}
 
-	log.Info().Int32("org_id", int32(orgID)).Str("user_id", string(userID)).Msg("Extraced user and org")
+	log.Info().Int32("org_id", int32(orgID)).Str("user_id", string(userID)).Msg("Extracted user and org")
 
 	rating, successful := server.postRatingToAggregator(orgID, userID, request, writer)
 	if !successful {


### PR DESCRIPTION
# Description

Rules disabled using v1 enable/disable endpoints include '.report' in the module, so we need this trick to make advisor's rule-related operations more consistent.

Fixes [CCXDEV-7183](https://issues.redhat.com/browse/CCXDEV-7183)

## Type of change

- Bug fix (breaking-change)

## Testing steps

- tested locally
- updated corresponding UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
