### PR TITLE
Revert "Remove .report substring from rule_selector used in v2 content endpoints"

### DIFF
--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -83,8 +83,7 @@ func readCompositeRuleID(request *http.Request) (
 		return
 	}
 
-	// trim the .report from module part if present
-	ruleID = ctypes.RuleID(trimDotReportFromRuleID(ruleIDParam))
+	ruleID = ctypes.RuleID(ruleIDParam)
 	return
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -76,9 +76,8 @@ const (
 
 	compositeRuleIDError = "Error generating composite rule ID for [%v] and [%v]"
 
-	// dotReportModuleSuffix ".report|" substring present at the end of the rule
-	// selector's module part
-	dotReportModuleSuffix = ".report|"
+	// dotReport ".report" string present in the ruleID in most tables
+	dotReport = ".report"
 )
 
 // HTTPServer is an implementation of Server interface
@@ -1250,7 +1249,7 @@ func isDisabledForOrgRule(aggregatorRule ctypes.RuleOnReport, systemWideDisabled
 	if len(systemWideDisabledRules) > 0 {
 		selector := types.RuleID(
 			fmt.Sprintf("%v|%v",
-				trimDotReportFromRuleID(string(aggregatorRule.Module)),
+				strings.TrimSuffix(string(aggregatorRule.Module), dotReport),
 				aggregatorRule.ErrorKey,
 			),
 		)

--- a/server/utils.go
+++ b/server/utils.go
@@ -17,7 +17,6 @@ package server
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	types "github.com/RedHatInsights/insights-results-types"
 	"github.com/rs/zerolog/log"
@@ -45,8 +44,4 @@ func logClustersReport(orgID types.OrgID, reports map[types.ClusterName]json.Raw
 		}
 		logClusterInfos(orgID, clusterName, report)
 	}
-}
-
-func trimDotReportFromRuleID(ruleID string) string {
-	return strings.ReplaceAll(ruleID, dotReportModuleSuffix, "|")
 }


### PR DESCRIPTION
Reverts RedHatInsights/insights-results-smart-proxy#865

Not needed in the end