### PR TITLE
v2/rule takes user disabled clusters into account for impacted clusters count

### DIFF
--- a/abcgo.sh
+++ b/abcgo.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-threshold=62
+threshold=63
 
 BLUE=$(tput setaf 4)
 RED_BG=$(tput setab 1)

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -1,5 +1,5 @@
 [amsclient]
-url = "https://api.openshift.com"
+url = ""
 client_id = ""
 client_secret = ""
 page_size = 100
@@ -19,7 +19,7 @@ enable_cors = true
 enable_internal_rules_organizations = false
 internal_rules_organizations = []
 log_auth_token = true
-org_clusters_fallback = false
+org_clusters_fallback = true
 
 [services]
 aggregator = "http://localhost:8080/api/insights-results-aggregator/v1/"

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,9 @@ require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20211119142943-71a7a9be7bb8
 	github.com/RedHatInsights/insights-operator-utils v1.23.3
-	github.com/RedHatInsights/insights-results-aggregator v1.2.4
+	github.com/RedHatInsights/insights-results-aggregator v1.2.5
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.4
-	github.com/RedHatInsights/insights-results-types v1.3.5
+	github.com/RedHatInsights/insights-results-types v1.3.6
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -83,8 +83,8 @@ github.com/RedHatInsights/insights-operator-utils v1.22.0/go.mod h1:4G1aWUV3SBc5
 github.com/RedHatInsights/insights-operator-utils v1.23.3 h1:4w6Yzj8cUpZuGAduO5tMeyoAx47DBQTfyMh3dOnJ5D4=
 github.com/RedHatInsights/insights-operator-utils v1.23.3/go.mod h1:vInEzg0d/rJQiINGtbOomA038N2uC/qlm1Bqt649yXY=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
-github.com/RedHatInsights/insights-results-aggregator v1.2.4 h1:xUDGEKpnAiG540Xtc75LcbGR9FiSjZ5xpsdVkBD2dUI=
-github.com/RedHatInsights/insights-results-aggregator v1.2.4/go.mod h1:fC2oUxyX4U6bM+lb2pk0ads9XglW4KEjUfat80MNpXU=
+github.com/RedHatInsights/insights-results-aggregator v1.2.5 h1:j2d+vIE4TV2U5AsiM9a3331lO22sm9UsO7GA4wMkslo=
+github.com/RedHatInsights/insights-results-aggregator v1.2.5/go.mod h1:Wv5oV/fpwUz9eiAxY31tUhNm+OMTDeMYX8ZXHiV8QJ8=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=
@@ -97,8 +97,8 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.3.4 h1:ZE0RM0Rquah
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.4/go.mod h1:iHVNt/wzpjrTvPO+yhCm9jSJljhdwj3o/sehLqch2BU=
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
-github.com/RedHatInsights/insights-results-types v1.3.5 h1:Q1awNYeJqIFgst7zQgKfQwbdMieyJTG/eDIau+yIUpo=
-github.com/RedHatInsights/insights-results-types v1.3.5/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
+github.com/RedHatInsights/insights-results-types v1.3.6 h1:mC5vZn4hK4f6L/Y4MSv0EsN/Z1avAh5qWB2Z2m11PWk=
+github.com/RedHatInsights/insights-results-types v1.3.6/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -1259,7 +1259,7 @@
             },
             "impacted_clusters_count": {
               "type": "int",
-              "description": "The number of clusters impacted by this rule.",
+              "description": "The number of clusters impacted by this rule. When the user disables a rule for a specific cluster, this cluster is no longer considered to be impacted.",
               "example": 42
             }
           },

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -1523,6 +1523,21 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing(t *testin
 			},
 		)
 
+		ruleDisablesBody := `{"rules":[],"status":"ok"}`
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+			&helpers.APIRequest{
+				Method: http.MethodPost,
+				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
+				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
+				Body:         reqBody,
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       ruleDisablesBody,
+			},
+		)
+
 		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, amsClientMock, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigJWT.APIv2Prefix, &helpers.APIRequest{
 			Method:             http.MethodGet,
@@ -1536,8 +1551,8 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing(t *testin
 	}, testTimeout)
 }
 
-// TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisabled
-func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisabled(t *testing.T) {
+// TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisabled1Acked
+func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisabled1Acked(t *testing.T) {
 	defer content.ResetContent()
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
@@ -1559,8 +1574,8 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisab
 
 		respBody := `{"recommendations":{"%v":%v,"%v":%v},"status":"ok"}`
 		respBody = fmt.Sprintf(respBody,
-			testdata.Rule1CompositeID, 0,
-			testdata.Rule2CompositeID, 0,
+			testdata.Rule1CompositeID, 2,
+			testdata.Rule2CompositeID, 2,
 		)
 
 		// prepare response from amsclient for list of clusters
@@ -1606,6 +1621,33 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisab
 			},
 		)
 
+		// rule 2 is disabled for one cluster
+		ruleDisablesBody := `{
+			"rules":[
+				{
+					"ClusterID": "%v",
+					"RuleID": "%v",
+					"ErrorKey": "%v"
+				}
+			],
+			"status":"ok"
+		}`
+		ruleDisablesBody = fmt.Sprintf(ruleDisablesBody, clusterInfoList[0].ID, testdata.Rule2ID, testdata.ErrorKey2)
+
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+			&helpers.APIRequest{
+				Method: http.MethodPost,
+				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
+				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
+				Body:         reqBody,
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       ruleDisablesBody,
+			},
+		)
+
 		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, amsClientMock, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigJWT.APIv2Prefix, &helpers.APIRequest{
 			Method:             http.MethodGet,
@@ -1613,7 +1655,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisab
 			AuthorizationToken: goodJWTAuthBearer,
 		}, &helpers.APIResponse{
 			StatusCode:  http.StatusOK,
-			Body:        helpers.ToJSONString(GetRecommendationsResponse2Rules1Disabled0Clusters),
+			Body:        helpers.ToJSONString(GetRecommendationsResponse2Rules1Disabled1Acked),
 			BodyChecker: recommendationInResponseChecker,
 		})
 	}, testTimeout)
@@ -1680,6 +1722,21 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1MissingContent(t *testing.
 			},
 		)
 
+		ruleDisablesBody := `{"rules":[],"status":"ok"}`
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+			&helpers.APIRequest{
+				Method: http.MethodPost,
+				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
+				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
+				Body:         reqBody,
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       ruleDisablesBody,
+			},
+		)
+
 		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, amsClientMock, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigJWT.APIv2Prefix, &helpers.APIRequest{
 			Method:             http.MethodGet,
@@ -1743,6 +1800,21 @@ func TestHTTPServer_RecommendationsListEndpoint_NoRuleContent(t *testing.T) {
 			&helpers.APIResponse{
 				StatusCode: http.StatusOK,
 				Body:       ruleAcksBody,
+			},
+		)
+
+		ruleDisablesBody := `{"rules":[],"status":"ok"}`
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+			&helpers.APIRequest{
+				Method: http.MethodPost,
+				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
+				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
+				Body:         reqBody,
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       ruleDisablesBody,
 			},
 		)
 
@@ -1815,6 +1887,21 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 			},
 		)
 
+		ruleDisablesBody := `{"rules":[],"status":"ok"}`
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+			&helpers.APIRequest{
+				Method: http.MethodPost,
+				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
+				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
+				Body:         reqBody,
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       ruleDisablesBody,
+			},
+		)
+
 		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, amsClientMock, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigJWT.APIv2Prefix, &helpers.APIRequest{
 			Method:             http.MethodGet,
@@ -1881,6 +1968,21 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 			&helpers.APIResponse{
 				StatusCode: http.StatusOK,
 				Body:       ruleAcksBody,
+			},
+		)
+
+		ruleDisablesBody := `{"rules":[],"status":"ok"}`
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+			&helpers.APIRequest{
+				Method: http.MethodPost,
+				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
+				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
+				Body:         reqBody,
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       ruleDisablesBody,
 			},
 		)
 
@@ -1954,6 +2056,21 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_Impactin
 			&helpers.APIResponse{
 				StatusCode: http.StatusOK,
 				Body:       ruleAcksBody,
+			},
+		)
+
+		ruleDisablesBody := `{"rules":[],"status":"ok"}`
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+			&helpers.APIRequest{
+				Method: http.MethodPost,
+				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
+				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
+				Body:         reqBody,
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       ruleDisablesBody,
 			},
 		)
 
@@ -2032,6 +2149,21 @@ func TestHTTPServer_RecommendationsListEndpoint4Rules1Internal2Clusters_Impactin
 			&helpers.APIResponse{
 				StatusCode: http.StatusOK,
 				Body:       ruleAcksBody,
+			},
+		)
+
+		ruleDisablesBody := `{"rules":[],"status":"ok"}`
+		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+			&helpers.APIRequest{
+				Method: http.MethodPost,
+				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
+				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
+				Body:         reqBody,
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       ruleDisablesBody,
 			},
 		)
 

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -1483,10 +1483,10 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing(t *testin
 		clusterList := types.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
-		respBody := `{"recommendations":{"%v":%v,"%v":%v},"status":"ok"}`
+		respBody := `{"recommendations":{"%v":["%v","%v"],"%v":["%v"]},"status":"ok"}`
 		respBody = fmt.Sprintf(respBody,
-			testdata.Rule1CompositeID, 2,
-			testdata.Rule2CompositeID, 1,
+			testdata.Rule1CompositeID, clusterList[0], clusterList[1],
+			testdata.Rule2CompositeID, clusterList[0],
 		)
 
 		// prepare response from amsclient for list of clusters
@@ -1526,9 +1526,8 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing(t *testin
 		ruleDisablesBody := `{"rules":[],"status":"ok"}`
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method: http.MethodPost,
-				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
-				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				Method:       http.MethodPost,
+				Endpoint:     ira_server.ListOfDisabledRulesForClusters,
 				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
 				Body:         reqBody,
 			},
@@ -1572,10 +1571,10 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisab
 		clusterList := types.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
-		respBody := `{"recommendations":{"%v":%v,"%v":%v},"status":"ok"}`
+		respBody := `{"recommendations":{"%v":["%v","%v"],"%v":["%v","%v"]},"status":"ok"}`
 		respBody = fmt.Sprintf(respBody,
-			testdata.Rule1CompositeID, 2,
-			testdata.Rule2CompositeID, 2,
+			testdata.Rule1CompositeID, clusterList[0], clusterList[1],
+			testdata.Rule2CompositeID, clusterList[0], clusterList[1],
 		)
 
 		// prepare response from amsclient for list of clusters
@@ -1636,9 +1635,8 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisab
 
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method: http.MethodPost,
-				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
-				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				Method:       http.MethodPost,
+				Endpoint:     ira_server.ListOfDisabledRulesForClusters,
 				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
 				Body:         reqBody,
 			},
@@ -1648,6 +1646,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisab
 			},
 		)
 
+		// one rule acked; one rule user disabled (not counted as impacting)
 		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, amsClientMock, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigJWT.APIv2Prefix, &helpers.APIRequest{
 			Method:             http.MethodGet,
@@ -1682,10 +1681,10 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1MissingContent(t *testing.
 		clusterList := types.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
-		respBody := `{"recommendations":{"%v":%v,"%v":%v},"status":"ok"}`
+		respBody := `{"recommendations":{"%v":["%v","%v"],"%v":["%v","%v"]},"status":"ok"}`
 		respBody = fmt.Sprintf(respBody,
-			testdata.Rule1CompositeID, 2,
-			testdata.Rule2CompositeID, 1,
+			testdata.Rule1CompositeID, clusterList[0], clusterList[1],
+			testdata.Rule2CompositeID, clusterList[0], clusterList[1],
 		)
 
 		// prepare response from amsclient for list of clusters
@@ -1725,9 +1724,8 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1MissingContent(t *testing.
 		ruleDisablesBody := `{"rules":[],"status":"ok"}`
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method: http.MethodPost,
-				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
-				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				Method:       http.MethodPost,
+				Endpoint:     ira_server.ListOfDisabledRulesForClusters,
 				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
 				Body:         reqBody,
 			},
@@ -1762,11 +1760,10 @@ func TestHTTPServer_RecommendationsListEndpoint_NoRuleContent(t *testing.T) {
 		clusterList := types.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
-		respBody := `{"recommendations":{"%v":%v,"%v":%v,"%v":%v},"status":"ok"}`
+		respBody := `{"recommendations":{"%v":["%v","%v"],"%v":["%v","%v"]},"status":"ok"}`
 		respBody = fmt.Sprintf(respBody,
-			testdata.Rule1CompositeID, 2,
-			testdata.Rule2CompositeID, 2,
-			testdata.Rule3CompositeID, 1,
+			testdata.Rule1CompositeID, clusterList[0], clusterList[1],
+			testdata.Rule2CompositeID, clusterList[0], clusterList[1],
 		)
 
 		// prepare response from amsclient for list of clusters
@@ -1806,9 +1803,8 @@ func TestHTTPServer_RecommendationsListEndpoint_NoRuleContent(t *testing.T) {
 		ruleDisablesBody := `{"rules":[],"status":"ok"}`
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method: http.MethodPost,
-				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
-				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				Method:       http.MethodPost,
+				Endpoint:     ira_server.ListOfDisabledRulesForClusters,
 				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
 				Body:         reqBody,
 			},
@@ -1890,9 +1886,8 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 		ruleDisablesBody := `{"rules":[],"status":"ok"}`
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method: http.MethodPost,
-				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
-				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				Method:       http.MethodPost,
+				Endpoint:     ira_server.ListOfDisabledRulesForClusters,
 				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
 				Body:         reqBody,
 			},
@@ -1974,9 +1969,8 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 		ruleDisablesBody := `{"rules":[],"status":"ok"}`
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method: http.MethodPost,
-				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
-				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				Method:       http.MethodPost,
+				Endpoint:     ira_server.ListOfDisabledRulesForClusters,
 				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
 				Body:         reqBody,
 			},
@@ -2020,9 +2014,9 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_Impactin
 		clusterList := types.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
-		respBody := `{"recommendations":{"%v":%v},"status":"ok"}`
+		respBody := `{"recommendations":{"%v":["%v","%v"]},"status":"ok"}`
 		respBody = fmt.Sprintf(respBody,
-			testdata.Rule1CompositeID, 2,
+			testdata.Rule1CompositeID, clusterList[0], clusterList[1],
 		)
 
 		// prepare response from amsclient for list of clusters
@@ -2062,9 +2056,8 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_Impactin
 		ruleDisablesBody := `{"rules":[],"status":"ok"}`
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method: http.MethodPost,
-				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
-				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				Method:       http.MethodPost,
+				Endpoint:     ira_server.ListOfDisabledRulesForClusters,
 				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
 				Body:         reqBody,
 			},
@@ -2113,9 +2106,9 @@ func TestHTTPServer_RecommendationsListEndpoint4Rules1Internal2Clusters_Impactin
 		clusterList := types.GetClusterNames(clusterInfoList)
 		reqBody, _ := json.Marshal(clusterList)
 
-		respBody := `{"recommendations":{"%v":%v},"status":"ok"}`
+		respBody := `{"recommendations":{"%v":["%v"]},"status":"ok"}`
 		respBody = fmt.Sprintf(respBody,
-			testdata.Rule1CompositeID, 1,
+			testdata.Rule1CompositeID, clusterList[0],
 		)
 
 		// prepare response from amsclient for list of clusters
@@ -2155,9 +2148,8 @@ func TestHTTPServer_RecommendationsListEndpoint4Rules1Internal2Clusters_Impactin
 		ruleDisablesBody := `{"rules":[],"status":"ok"}`
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method: http.MethodPost,
-				//Endpoint:     ira_server.ListOfDisabledRulesForClusters,
-				Endpoint:     "rules/users/{user_id}/disabled_for_clusters",
+				Method:       http.MethodPost,
+				Endpoint:     ira_server.ListOfDisabledRulesForClusters,
 				EndpointArgs: []interface{}{userIDOnGoodJWTAuthBearer},
 				Body:         reqBody,
 			},

--- a/server/server.go
+++ b/server/server.go
@@ -1344,3 +1344,56 @@ func (server *HTTPServer) readListOfClusterDisabledRules(userID types.UserID) ([
 
 	return response.DisabledRules, nil
 }
+
+// Method readListOfClusterDisabledRules returns user disabled rules for given cluster list
+func (server *HTTPServer) readListOfDisabledRulesForClusters(
+	writer http.ResponseWriter,
+	userID ctypes.UserID,
+	clusterList []ctypes.ClusterName,
+) ([]ctypes.DisabledRule, error) {
+
+	// wont be used anywhere else
+	var response struct {
+		Status        string                `json:"status"`
+		DisabledRules []ctypes.DisabledRule `json:"rules"`
+	}
+
+	aggregatorURL := httputils.MakeURLToEndpoint(
+		server.ServicesConfig.AggregatorBaseEndpoint,
+		// ira_server.ListOfDisabledRulesForClusters, FIXME
+		"rules/users/{user_id}/disabled_for_clusters",
+		userID,
+	)
+
+	jsonMarshalled, err := json.Marshal(clusterList)
+	if err != nil {
+		log.Error().Err(err).Msg("readListOfDisabledRulesForClusters problem unmarshalling cluster list")
+		handleServerError(writer, err)
+		return nil, err
+	}
+
+	// #nosec G107
+	resp, err := http.Post(aggregatorURL, JSONContentType, bytes.NewBuffer(jsonMarshalled))
+	if err != nil {
+		log.Error().Err(err).Msgf("readListOfDisabledRulesForClusters problem getting response from aggregator")
+		if _, ok := err.(*url.Error); ok {
+			handleServerError(writer, &AggregatorServiceUnavailableError{})
+		} else {
+			handleServerError(writer, err)
+		}
+		return nil, err
+	}
+
+	// check the aggregator response
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusNotFound {
+		err := fmt.Errorf("error reading disabled rules from aggregator: %v", resp.StatusCode)
+		return nil, err
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(&response)
+	if err != nil {
+		return nil, err
+	}
+
+	return response.DisabledRules, nil
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -19,10 +19,11 @@ package server_test
 import (
 	"encoding/json"
 	"fmt"
-	data "github.com/RedHatInsights/insights-results-smart-proxy/tests/testdata"
 	"net/http"
 	"testing"
 	"time"
+
+	data "github.com/RedHatInsights/insights-results-smart-proxy/tests/testdata"
 
 	"github.com/RedHatInsights/insights-content-service/groups"
 	"github.com/RedHatInsights/insights-operator-utils/responses"
@@ -667,7 +668,7 @@ var (
 		},
 	}
 
-	GetRecommendationsResponse2Rules1Disabled0Clusters = struct {
+	GetRecommendationsResponse2Rules1Disabled1Acked = struct {
 		Status          string                         `json:"status"`
 		Recommendations []types.RecommendationListView `json:"recommendations"`
 	}{
@@ -682,9 +683,9 @@ var (
 				Impact:              uint8(testdata.RuleErrorKey1.Impact),
 				Likelihood:          uint8(testdata.RuleErrorKey1.Likelihood),
 				Tags:                testdata.RuleErrorKey1.Tags,
-				Disabled:            true,
+				Disabled:            true, // acked flag
 				RiskOfChange:        0,
-				ImpactedClustersCnt: 0,
+				ImpactedClustersCnt: 2,
 			},
 			{
 				RuleID:              testdata.Rule2CompositeID,
@@ -697,7 +698,7 @@ var (
 				Tags:                testdata.RuleErrorKey2.Tags,
 				Disabled:            false,
 				RiskOfChange:        0,
-				ImpactedClustersCnt: 0,
+				ImpactedClustersCnt: 1, // one cluster is disabled
 			},
 		},
 	}

--- a/types/types.go
+++ b/types/types.go
@@ -180,17 +180,17 @@ type RuleWithContent struct {
 // RiskOfChange == resolution risk, currently missing from rule content
 type RecommendationListView struct {
 	// RuleID is in "|" format
-	RuleID              types.RuleID              `json:"rule_id"`
-	Description         string                    `json:"description"`
-	Generic             string                    `json:"generic"`
-	PublishDate         time.Time                 `json:"publish_date"`
-	TotalRisk           uint8                     `json:"total_risk"`
-	Impact              uint8                     `json:"impact"`
-	Likelihood          uint8                     `json:"likelihood"`
-	Tags                []string                  `json:"tags"`
-	Disabled            bool                      `json:"disabled"`
-	RiskOfChange        uint8                     `json:"risk_of_change"`
-	ImpactedClustersCnt types.ImpactedClustersCnt `json:"impacted_clusters_count"`
+	RuleID              types.RuleID `json:"rule_id"`
+	Description         string       `json:"description"`
+	Generic             string       `json:"generic"`
+	PublishDate         time.Time    `json:"publish_date"`
+	TotalRisk           uint8        `json:"total_risk"`
+	Impact              uint8        `json:"impact"`
+	Likelihood          uint8        `json:"likelihood"`
+	Tags                []string     `json:"tags"`
+	Disabled            bool         `json:"disabled"`
+	RiskOfChange        uint8        `json:"risk_of_change"`
+	ImpactedClustersCnt uint32       `json:"impacted_clusters_count"`
 }
 
 // ClusterListView represents a single item in the response for Clusters List view


### PR DESCRIPTION
# Description

Modifies /rule endpoint so that it accounts for user disabled clusters for single rules
- sends list of active clusters to aggregator to retrieve the list of disabled rules for them.
- takes disabled clusters into account when calculating the total impacted count

Also modifies config-devel, so it uses the aggregator cluster list fallback.

Fixes CCXDEV-7096

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- Bump-up dependent library (no changes in the code)

## Testing steps
`make before_commit` + alongside aggregator

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
