### PR TITLE
Omit `last_checked_at` field when no recommedations in report

### DIFF
--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -128,7 +128,7 @@ var (
 	v1Report1RuleNoContent = types.SmartProxyReportV1{
 		Meta: types.ReportResponseMetaV1{
 			Count:         0,
-			LastCheckedAt: types.Timestamp(testdata.LastCheckedAt.UTC().Format(time.RFC3339)),
+			LastCheckedAt: "",
 		},
 		Data: []types.RuleWithContentResponse{},
 	}
@@ -352,6 +352,10 @@ func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
 
 		expectNoRulesDisabledSystemWide(&t)
 
+		expectedJSONBody := helpers.ToJSONString(SmartProxyV1ReportResponse1RuleNoContent)
+		// last_checked_at is omitted from the JSON as it is empty
+		assert.Equal(t, `{"status":"ok","report":{"meta":{"count":0},"data":[]}}`, expectedJSONBody)
+
 		// previously was InternalServerError, but it was changed as an edge-case which will appear as "No issues found"
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
 			Method:       http.MethodGet,
@@ -361,7 +365,7 @@ func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
 			OrgID:        testdata.OrgID,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
-			Body:       helpers.ToJSONString(SmartProxyV1ReportResponse1RuleNoContent),
+			Body:       expectedJSONBody,
 		})
 	}, testTimeout)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -915,15 +915,14 @@ func (server HTTPServer) reportEndpointV1(writer http.ResponseWriter, request *h
 	}
 
 	// Uses SmartProxyReportV1 type for backward compatibility
-	report := types.SmartProxyReportV1{
-		Meta: types.ReportResponseMetaV1{
-			LastCheckedAt: aggregatorResponse.Meta.LastCheckedAt,
-		},
-	}
+	report := types.SmartProxyReportV1{}
 
 	var err error
 	if report.Data, report.Meta.Count, err = server.buildReportEndpointResponse(
 		writer, request, aggregatorResponse, clusterID); err == nil {
+		if report.Meta.Count != 0 {
+			report.Meta.LastCheckedAt = aggregatorResponse.Meta.LastCheckedAt
+		}
 		sendReportReponse(writer, report)
 	}
 }
@@ -935,17 +934,16 @@ func (server HTTPServer) reportEndpointV2(writer http.ResponseWriter, request *h
 		return
 	}
 
-	report := types.SmartProxyReport{
-		Meta: ctypes.ReportResponseMeta{
-			LastCheckedAt: aggregatorResponse.Meta.LastCheckedAt,
-		},
-	}
+	report := types.SmartProxyReport{}
 
 	server.SetClusterDisplayNameInReport(clusterID, &report)
 
 	var err error
 	if report.Data, report.Meta.Count, err = server.buildReportEndpointResponse(
 		writer, request, aggregatorResponse, clusterID); err == nil {
+		if report.Meta.Count != 0 {
+			report.Meta.LastCheckedAt = aggregatorResponse.Meta.LastCheckedAt
+		}
 		sendReportReponse(writer, report)
 	}
 }

--- a/types/types.go
+++ b/types/types.go
@@ -110,7 +110,7 @@ type RecommendationContentUserData struct {
 // ReportResponseMetaV1 contains metadata for /report endpoint in v1
 type ReportResponseMetaV1 struct {
 	Count         int       `json:"count"`
-	LastCheckedAt Timestamp `json:"last_checked_at"`
+	LastCheckedAt Timestamp `json:"last_checked_at,omitempty"`
 }
 
 // SmartProxyReportV1 represents the response of /report (V1) endpoint for smart proxy


### PR DESCRIPTION
# Description

If we agree on fixing [CCXDEV-7218](https://issues.redhat.com/browse/CCXDEV-7218) by showing "Unknown" in the single cluster's view "last seen" timestamp, this fix makes sense. If we decide to fix it by actually showing a timestamp in the cluster list view, this is not a fix, but a way to "hide" the discrepancy.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)
- Bump-up dependent library (no changes in the code)
- Behavioral tests (no changes in the code)
- REST API tests
- Benchmarks (no changes in the code)
- Documentation update

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
