### PR TITLE
fix /rule and /clusters behaviour regarding single disabled rules/clusters

### DIFF
--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -1625,7 +1625,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisab
 			"rules":[
 				{
 					"ClusterID": "%v",
-					"RuleID": "%v",
+					"RuleID": "%v.report",
 					"ErrorKey": "%v"
 				}
 			],
@@ -2973,7 +2973,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_DisabledRuleSingleCluster(t 
 			"rules":[
 				{
 					"ClusterID": "%v",
-					"RuleID": "%v",
+					"RuleID": "%v.report",
 					"ErrorKey": "%v"
 				}
 			],
@@ -3105,7 +3105,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_DisabledAndAcked(t *testing.
 			"rules":[
 				{
 					"ClusterID": "%v",
-					"RuleID": "%v",
+					"RuleID": "%v.report",
 					"ErrorKey": "%v"
 				}
 			],

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -29,7 +29,6 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/RedHatInsights/insights-content-service/groups"
-	"github.com/RedHatInsights/insights-operator-utils/generators"
 	httputils "github.com/RedHatInsights/insights-operator-utils/http"
 	"github.com/RedHatInsights/insights-operator-utils/responses"
 	utypes "github.com/RedHatInsights/insights-operator-utils/types"
@@ -348,7 +347,8 @@ func (server HTTPServer) getRuleDisabledClusters(
 	}
 
 	for _, disabledRule := range listOfDisabledRules {
-		compositeRuleID, err := generators.GenerateCompositeRuleID(ctypes.RuleFQDN(disabledRule.RuleID), disabledRule.ErrorKey)
+		compositeRuleID, err := generateCompositeRuleIDFromDisabled(disabledRule)
+
 		if err != nil {
 			log.Error().Err(err).Msg("error generating composite rule ID")
 			continue
@@ -535,7 +535,7 @@ func (server *HTTPServer) getUserDisabledRulesPerCluster(userID types.UserID) (
 	for i := range listOfDisabledRules {
 		disabledRule := &listOfDisabledRules[i]
 
-		compositeRuleID, err := generators.GenerateCompositeRuleID(ctypes.RuleFQDN(disabledRule.RuleID), disabledRule.ErrorKey)
+		compositeRuleID, err := generateCompositeRuleIDFromDisabled(*disabledRule)
 		if err != nil {
 			log.Error().Err(err).Msgf(compositeRuleIDError, disabledRule.RuleID, disabledRule.ErrorKey)
 			continue

--- a/server/server.go
+++ b/server/server.go
@@ -1359,8 +1359,7 @@ func (server *HTTPServer) readListOfDisabledRulesForClusters(
 
 	aggregatorURL := httputils.MakeURLToEndpoint(
 		server.ServicesConfig.AggregatorBaseEndpoint,
-		// ira_server.ListOfDisabledRulesForClusters, FIXME
-		"rules/users/{user_id}/disabled_for_clusters",
+		ira_server.ListOfDisabledRulesForClusters,
 		userID,
 	)
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -17,7 +17,10 @@ package server
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 
+	"github.com/RedHatInsights/insights-operator-utils/generators"
+	ctypes "github.com/RedHatInsights/insights-results-types"
 	types "github.com/RedHatInsights/insights-results-types"
 	"github.com/rs/zerolog/log"
 )
@@ -44,4 +47,19 @@ func logClustersReport(orgID types.OrgID, reports map[types.ClusterName]json.Raw
 		}
 		logClusterInfos(orgID, clusterName, report)
 	}
+}
+
+// generateCompositeRuleIDFromDisabled trims ".report" from given disabled rule module and generates composite rule ID
+func generateCompositeRuleIDFromDisabled(disabledRule ctypes.DisabledRule) (
+	compositeRuleID types.RuleID, err error,
+) {
+	// the records in v1-related enable/disable DB tables contain ".report" suffix which needs to be
+	// (hopefully) temporarily trimmed for v2-related functionality
+	trimmedRuleModule := strings.TrimSuffix(string(disabledRule.RuleID), dotReport)
+
+	compositeRuleID, err = generators.GenerateCompositeRuleID(
+		ctypes.RuleFQDN(trimmedRuleModule),
+		disabledRule.ErrorKey,
+	)
+	return
 }


### PR DESCRIPTION
# Description
- recently, it was decided that OCP Advisor would use the v1 enable/disable endpoints the same way OCM does (sending g `.
report` as a suffix to the rule module name)
- this was partially taken into account by [pull/866](https://github.com/RedHatInsights/insights-results-smart-proxy/pull/866), but wasn't taken into account on the other v2 endpoints that deal with v1-related rule disables.

This explains why it was working before, because if you tested the enable/disable functionality via Advisor UI prior to this change, the UI sent the request with rule module without the `.report` suffix, therefore it was taken into account in Recommendations and Clusters lists.

This also explains why it was working on prod, but not in stage, even though the backend version was the same. It's because the UI wasn't updated on prod yet, therefore it was still sending rule module without the suffix, whereas on stage, it was already sending the suffix, effectively breaking the functionality on 2/3 endpoints.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

## Testing steps
hard to test and debug because of special hardcoded values 1) from frontend 2) from aggregator, both of which we're unable to test in smart-proxy

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
