### PR TITLE
Fix last seen v2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,7 +27,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          # args: --issues-exit-code=0
+          args: --timeout=3m
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -128,7 +128,7 @@ var (
 	v1Report1RuleNoContent = types.SmartProxyReportV1{
 		Meta: types.ReportResponseMetaV1{
 			Count:         0,
-			LastCheckedAt: types.Timestamp(testdata.LastCheckedAt.UTC().Format(time.RFC3339)),
+			LastCheckedAt: "",
 		},
 		Data: []types.RuleWithContentResponse{},
 	}
@@ -352,6 +352,10 @@ func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
 
 		expectNoRulesDisabledSystemWide(&t)
 
+		expectedJSONBody := helpers.ToJSONString(SmartProxyV1ReportResponse1RuleNoContent)
+		// last_checked_at is omitted from the JSON as it is empty
+		assert.Equal(t, `{"status":"ok","report":{"meta":{"count":0},"data":[]}}`, expectedJSONBody)
+
 		// previously was InternalServerError, but it was changed as an edge-case which will appear as "No issues found"
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
 			Method:       http.MethodGet,
@@ -361,7 +365,7 @@ func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
 			OrgID:        testdata.OrgID,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
-			Body:       helpers.ToJSONString(SmartProxyV1ReportResponse1RuleNoContent),
+			Body:       expectedJSONBody,
 		})
 	}, testTimeout)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -838,7 +838,7 @@ func (server HTTPServer) fetchAggregatorReportsUsingRequestBodyClusterList(
 // SetClusterDisplayNameInReport tries to retrieve the display name of the cluster using
 // the configured AMS client. If no info is retrieved, it sets the cluster's external
 // ID as display name.
-func (server HTTPServer) SetClusterDisplayNameInReport(clusterID types.ClusterName, report *types.SmartProxyReport) {
+func (server HTTPServer) SetClusterDisplayNameInReport(clusterID types.ClusterName, report *types.SmartProxyReportV2) {
 	if server.amsClient != nil {
 		clusterInfo := server.amsClient.GetClusterDetailsFromExternalClusterID(clusterID)
 		if clusterInfo.DisplayName != "" {
@@ -913,14 +913,15 @@ func (server HTTPServer) reportEndpointV1(writer http.ResponseWriter, request *h
 	}
 
 	// Uses SmartProxyReportV1 type for backward compatibility
-	report := types.SmartProxyReportV1{}
+	report := types.SmartProxyReportV1{
+		Meta: types.ReportResponseMetaV1{
+			LastCheckedAt: aggregatorResponse.Meta.LastCheckedAt,
+		},
+	}
 
 	var err error
 	if report.Data, report.Meta.Count, err = server.buildReportEndpointResponse(
 		writer, request, aggregatorResponse, clusterID); err == nil {
-		if report.Meta.Count != 0 {
-			report.Meta.LastCheckedAt = aggregatorResponse.Meta.LastCheckedAt
-		}
 		sendReportReponse(writer, report)
 	}
 }
@@ -932,7 +933,7 @@ func (server HTTPServer) reportEndpointV2(writer http.ResponseWriter, request *h
 		return
 	}
 
-	report := types.SmartProxyReport{}
+	report := types.SmartProxyReportV2{}
 
 	server.SetClusterDisplayNameInReport(clusterID, &report)
 

--- a/server/server.go
+++ b/server/server.go
@@ -915,15 +915,14 @@ func (server HTTPServer) reportEndpointV1(writer http.ResponseWriter, request *h
 	}
 
 	// Uses SmartProxyReportV1 type for backward compatibility
-	report := types.SmartProxyReportV1{
-		Meta: types.ReportResponseMetaV1{
-			LastCheckedAt: aggregatorResponse.Meta.LastCheckedAt,
-		},
-	}
+	report := types.SmartProxyReportV1{}
 
 	var err error
 	if report.Data, report.Meta.Count, err = server.buildReportEndpointResponse(
 		writer, request, aggregatorResponse, clusterID); err == nil {
+		if report.Meta.Count != 0 {
+			report.Meta.LastCheckedAt = aggregatorResponse.Meta.LastCheckedAt
+		}
 		sendReportReponse(writer, report)
 	}
 }
@@ -935,17 +934,16 @@ func (server HTTPServer) reportEndpointV2(writer http.ResponseWriter, request *h
 		return
 	}
 
-	report := types.SmartProxyReport{
-		Meta: ctypes.ReportResponseMeta{
-			LastCheckedAt: aggregatorResponse.Meta.LastCheckedAt,
-		},
-	}
+	report := types.SmartProxyReport{}
 
 	server.SetClusterDisplayNameInReport(clusterID, &report)
 
 	var err error
 	if report.Data, report.Meta.Count, err = server.buildReportEndpointResponse(
 		writer, request, aggregatorResponse, clusterID); err == nil {
+		if report.Meta.Count != 0 {
+			report.Meta.LastCheckedAt = aggregatorResponse.Meta.LastCheckedAt
+		}
 		sendReportReponse(writer, report)
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1207,7 +1207,7 @@ func TestHTTPServer_OverviewEndpointWithFallback(t *testing.T) {
 }
 
 func TestHTTPServer_setClusterDisplayNameInReportNoAMSClient(t *testing.T) {
-	report := types.SmartProxyReport{}
+	report := types.SmartProxyReportV2{}
 	config := helpers.DefaultServerConfig
 	testServer := helpers.CreateHTTPServer(&config, nil, nil, nil, nil, nil)
 	testServer.SetClusterDisplayNameInReport(testdata.ClusterName, &report)
@@ -1215,7 +1215,7 @@ func TestHTTPServer_setClusterDisplayNameInReportNoAMSClient(t *testing.T) {
 }
 
 func TestHTTPServer_setClusterDisplayNameInReportAMSClientClusterIDFound(t *testing.T) {
-	report := types.SmartProxyReport{}
+	report := types.SmartProxyReportV2{}
 	config := helpers.DefaultServerConfig
 	// prepare list of organizations response
 	amsClientMock := helpers.AMSClientWithOrgResults(

--- a/types/types.go
+++ b/types/types.go
@@ -110,6 +110,13 @@ type RecommendationContentUserData struct {
 // ReportResponseMetaV1 contains metadata for /report endpoint in v1
 type ReportResponseMetaV1 struct {
 	Count         int       `json:"count"`
+	LastCheckedAt Timestamp `json:"last_checked_at"`
+}
+
+// ReportResponseMetaV2 contains metadata for /report endpoint in v2
+type ReportResponseMetaV2 struct {
+	DisplayName   string    `json:"cluster_name"`
+	Count         int       `json:"count"`
 	LastCheckedAt Timestamp `json:"last_checked_at,omitempty"`
 }
 
@@ -117,6 +124,13 @@ type ReportResponseMetaV1 struct {
 // This structure exists to make sure we comply with the previous API used by some clients
 type SmartProxyReportV1 struct {
 	Meta ReportResponseMetaV1      `json:"meta"`
+	Data []RuleWithContentResponse `json:"data"`
+}
+
+// SmartProxyReportV2 represents the response of /report (V2) endpoint for smart proxy
+// This structure exists to make sure we comply with the previous API used by some clients
+type SmartProxyReportV2 struct {
+	Meta ReportResponseMetaV2      `json:"meta"`
 	Data []RuleWithContentResponse `json:"data"`
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -110,7 +110,7 @@ type RecommendationContentUserData struct {
 // ReportResponseMetaV1 contains metadata for /report endpoint in v1
 type ReportResponseMetaV1 struct {
 	Count         int       `json:"count"`
-	LastCheckedAt Timestamp `json:"last_checked_at"`
+	LastCheckedAt Timestamp `json:"last_checked_at,omitempty"`
 }
 
 // SmartProxyReportV1 represents the response of /report (V1) endpoint for smart proxy


### PR DESCRIPTION
# Description
creating a new PR instead of requesting permissions to push to https://github.com/RedHatInsights/insights-results-smart-proxy/pull/872/files

fixes `last_checked_at` functionality for v2/report endpoint, but keeps the functionality in v1

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
`make before_commit` + locally

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
