### PR TITLE
Exlude clusters with empty `external_cluster_id` from AMS API response

### DIFF
--- a/abcgo.sh
+++ b/abcgo.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-threshold=63
+threshold=64
 
 BLUE=$(tput setaf 4)
 RED_BG=$(tput setab 1)

--- a/amsclient/amsclient.go
+++ b/amsclient/amsclient.go
@@ -228,11 +228,12 @@ func (c *amsClientImpl) executeSubscriptionListRequest(
 
 		for _, item := range response.Items().Slice() {
 			clusterIDstr, ok := item.GetExternalClusterID()
-			if !ok {
+			// we could exclude empty external_cluster_id in the query, but we want to log these special clusters
+			if !ok || clusterIDstr == "" {
 				if id, ok := item.GetID(); ok {
-					log.Info().Str("IntClusterID", id).Msg("Not external cluster ID")
+					log.Warn().Str("InternalClusterID", id).Msg("cluster has no external ID")
 				} else {
-					log.Info().Msg("Not external cluster ID")
+					log.Error().Msgf("No external or internal cluster ID. Cluster [%v]", item)
 				}
 
 				continue

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -261,6 +261,7 @@ func (server HTTPServer) getRecommendations(writer http.ResponseWriter, request 
 	tStartImpacting := time.Now()
 	impactingRecommendations, err := server.getImpactingRecommendations(writer, orgID, userID, clusterList)
 	if err != nil {
+		// log cluster list in case of error even though message might be too large for Kibana/zerolog
 		log.Error().
 			Err(err).
 			Int(orgIDTag, int(orgID)).
@@ -381,7 +382,8 @@ func (server HTTPServer) getClustersView(writer http.ResponseWriter, request *ht
 		return
 	}
 	log.Info().Uint32(orgIDTag, uint32(orgID)).Msgf(
-		"getClustersView list of clusters %s", clusterInfoList)
+		"getClustersView number of clusters before processing %d", len(clusterInfoList),
+	)
 
 	tStartImpacting := time.Now()
 	clusterRecommendationMap, err := server.getClustersAndRecommendations(writer, orgID, userID, types.GetClusterNames(clusterInfoList))

--- a/server/server.go
+++ b/server/server.go
@@ -885,7 +885,7 @@ func (server HTTPServer) buildReportEndpointResponse(
 	systemWideRuleDisables := generateRuleAckMap(acks)
 
 	visibleRules, noContentRulesCnt, disabledRulesCnt, err := filterRulesInResponse(aggregatorResponse.Report, osdFlag, includeDisabled, systemWideRuleDisables)
-	log.Info().Msgf("Cluster ID: %v; visible rules %v, no content rules %d, disabled rules %d", clusterID, visibleRules, noContentRulesCnt, disabledRulesCnt)
+	log.Info().Msgf("Cluster ID: %v; visible rules %d, no content rules %d, disabled rules %d", clusterID, len(visibleRules), noContentRulesCnt, disabledRulesCnt)
 
 	if err != nil {
 		if _, ok := err.(*content.RuleContentDirectoryTimeoutError); ok {
@@ -1309,7 +1309,6 @@ func filterRulesInResponse(aggregatorReport []ctypes.RuleOnReport, filterOSD, ge
 		okRules = append(okRules, *rule)
 	}
 
-	log.Info().Msgf("ok rules [%v]", okRules)
 	return
 }
 

--- a/tests/testdata/amstestdata.go
+++ b/tests/testdata/amstestdata.go
@@ -89,6 +89,33 @@ var (
 		},
 	}
 
+	// SubscriptionsResponseEmptyClusterIDs contains a valid response for subscription from AMS, 3 clusters,
+	// but 2 of them are expected to be filtered out, even if they have display name and internal ID,
+	// as they don't have the external_cluster_id
+	SubscriptionsResponseEmptyClusterIDs map[string]interface{} = map[string]interface{}{
+		"kind":  "SubscriptionList",
+		"page":  1,
+		"size":  2,
+		"total": 2,
+		"items": []map[string]interface{}{
+			{
+				"display_name":        ClusterDisplayName1,
+				"external_cluster_id": ClusterName1,
+				"id":                  "1YfQ9bR7LTDz24YzfFmaCdeB0sS",
+			},
+			{
+				"display_name":        ClusterDisplayName2,
+				"external_cluster_id": "",
+				"id":                  "1QfQ9bR7LTDz24YzfFmaCdeBf86",
+			},
+			{
+				"display_name":        "",
+				"external_cluster_id": "",
+				"id":                  "", // cover edge case condition
+			},
+		},
+	}
+
 	// SubscriptionEmptyResponse contains a valid response for subscription from AMS, 0 clusters
 	SubscriptionEmptyResponse map[string]interface{} = map[string]interface{}{
 		"kind":  "SubscriptionList",


### PR DESCRIPTION
# Description
We cannot (and should not) store Insights results for clusters with invalid cluster UUIDs.

We could exclude by simply filtering out `external_cluster_id != ''`, but we want to log these clusters' internal IDs if we'd like to investigate, because we were told that it shouldn't be possible at all.

Also removes some log lines which could be too large/have little value outside of debugging problems.

Fixes https://issues.redhat.com/browse/CCXDEV-7408
Hopefully fixes https://issues.redhat.com/browse/CCXDEV-7264

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps
tested with valid credentials against prod AMS API locally and checked response of the affected endpoints

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
