### PR TITLE
fix last_checked_at behaviour in v2/cluster/{clusterId}/reports and v2/clusters endpoints

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,3 +1,17 @@
+# Copyright 2022 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: golangci-lint
 on:
   push:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,17 @@
+# Copyright 2022 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 run:
     skip-files:
         - export_test.go

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -465,7 +465,9 @@ func matchClusterInfoAndUserData(
 
 		// check if there are any hitting recommendations
 		if hittingRecommendations, any := clusterRecommendationsMap[clusterViewItem.ClusterID]; any {
-			clusterViewItem.LastCheckedAt = hittingRecommendations.CreatedAt.UTC().Format(time.RFC3339)
+			clusterViewItem.LastCheckedAt = types.Timestamp(
+				hittingRecommendations.CreatedAt.UTC().Format(time.RFC3339),
+			)
 
 			// filter out acked and disabled rules
 			enabledOnlyRecommendations := filterOutDisabledRules(

--- a/server/server.go
+++ b/server/server.go
@@ -938,12 +938,13 @@ func (server HTTPServer) reportEndpointV2(writer http.ResponseWriter, request *h
 	server.SetClusterDisplayNameInReport(clusterID, &report)
 
 	var err error
+
 	if report.Data, report.Meta.Count, err = server.buildReportEndpointResponse(
 		writer, request, aggregatorResponse, clusterID); err == nil {
-		if report.Meta.Count != 0 {
-			report.Meta.LastCheckedAt = aggregatorResponse.Meta.LastCheckedAt
-			report.Meta.GatheredAt = aggregatorResponse.Meta.GatheredAt
-		}
+
+		// fill in timestamps
+		report.Meta.LastCheckedAt = aggregatorResponse.Meta.LastCheckedAt
+		report.Meta.GatheredAt = aggregatorResponse.Meta.GatheredAt
 		sendReportReponse(writer, report)
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -72,6 +72,7 @@ var (
 	invalidJWTAuthBearer      = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NvdW50X251bWJlciI6IjUyMTM0NzYiLCJvcmdfaWQiOjEsImp0aSI6IjA1NDQzYjk5LWQ4MjQtNDgwYi1hNGJlLTM3OTc3NDA1ZjA5MyIsImlhdCI6MTU5NDEyNjM0MCwiZXhwIjoxNTk0MTQxODQ3fQ.GndJUWNaG4IWm8OkKBs_1uvD1-vaJqL2Xvf9QiGvlRw"
 	userIDOnGoodJWTAuthBearer = 5213476
 	testTimeStr               = "2021-01-02T15:04:05Z"
+	testTimestamp             = types.Timestamp(testTimeStr)
 
 	serverConfigJWT = server.Configuration{
 		Address:                          ":8081",
@@ -920,14 +921,40 @@ var (
 			{
 				ClusterID:       "",
 				ClusterName:     "",
-				LastCheckedAt:   testTimeStr,
+				LastCheckedAt:   testTimestamp,
 				TotalHitCount:   0,
 				HitsByTotalRisk: map[int]int{},
 			},
 			{
 				ClusterID:       "",
 				ClusterName:     "",
-				LastCheckedAt:   testTimeStr,
+				LastCheckedAt:   testTimestamp,
+				TotalHitCount:   0,
+				HitsByTotalRisk: map[int]int{},
+			},
+		},
+	}
+
+	// cluster data filled in in test cases, last_checked_at is empty and thus ommitted
+	GetClustersResponse2ClusterNoArchiveInDB = struct {
+		Meta     map[string]interface{}  `json:"meta"`
+		Status   string                  `json:"status"`
+		Clusters []types.ClusterListView `json:"data"`
+	}{
+		Meta: map[string]interface{}{
+			"count": 2,
+		},
+		Status: "ok",
+		Clusters: []types.ClusterListView{
+			{
+				ClusterID:       "",
+				ClusterName:     "",
+				TotalHitCount:   0,
+				HitsByTotalRisk: map[int]int{},
+			},
+			{
+				ClusterID:       "",
+				ClusterName:     "",
 				TotalHitCount:   0,
 				HitsByTotalRisk: map[int]int{},
 			},
@@ -948,7 +975,7 @@ var (
 			{
 				ClusterID:     "",
 				ClusterName:   "",
-				LastCheckedAt: testTimeStr,
+				LastCheckedAt: testTimestamp,
 				TotalHitCount: 1,
 				// HitsByTotalRisk always has all unique total risks to have consistent response
 				HitsByTotalRisk: map[int]int{
@@ -959,7 +986,7 @@ var (
 			{
 				ClusterID:     "",
 				ClusterName:   "",
-				LastCheckedAt: testTimeStr,
+				LastCheckedAt: testTimestamp,
 				TotalHitCount: 2,
 				HitsByTotalRisk: map[int]int{
 					1: 0,
@@ -983,7 +1010,7 @@ var (
 			{
 				ClusterID:     "",
 				ClusterName:   "",
-				LastCheckedAt: testTimeStr,
+				LastCheckedAt: testTimestamp,
 				TotalHitCount: 0,
 				// HitsByTotalRisk always has all unique total risks to have consistent response
 				HitsByTotalRisk: map[int]int{
@@ -994,7 +1021,7 @@ var (
 			{
 				ClusterID:     "",
 				ClusterName:   "",
-				LastCheckedAt: testTimeStr,
+				LastCheckedAt: testTimestamp,
 				TotalHitCount: 1,
 				HitsByTotalRisk: map[int]int{
 					1: 0,
@@ -1018,7 +1045,7 @@ var (
 			{
 				ClusterID:     "",
 				ClusterName:   "",
-				LastCheckedAt: testTimeStr,
+				LastCheckedAt: testTimestamp,
 				TotalHitCount: 1,
 				// HitsByTotalRisk always has all unique total risks to have consistent response
 				HitsByTotalRisk: map[int]int{
@@ -1029,7 +1056,7 @@ var (
 			{
 				ClusterID:     "",
 				ClusterName:   "",
-				LastCheckedAt: testTimeStr,
+				LastCheckedAt: testTimestamp,
 				TotalHitCount: 1,
 				HitsByTotalRisk: map[int]int{
 					1: 0,

--- a/types/types.go
+++ b/types/types.go
@@ -212,7 +212,7 @@ type RecommendationListView struct {
 type ClusterListView struct {
 	ClusterID       types.ClusterName `json:"cluster_id"`
 	ClusterName     string            `json:"cluster_name"`
-	LastCheckedAt   string            `json:"last_checked_at"`
+	LastCheckedAt   Timestamp         `json:"last_checked_at,omitempty"`
 	TotalHitCount   uint32            `json:"total_hit_count"`
 	HitsByTotalRisk map[int]int       `json:"hits_by_total_risk"`
 }


### PR DESCRIPTION
# Description
- `v2/cluster/{clusterId}/reports` is no longer ommitting `last_checked_at` when it shouldn't
- `v2/clusters` is now ommitting `last_checked_at` when it should

Fixes CCXDEV-7218, CCXDEV-7761

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
tested behaviour with archives with and without rule hits

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
