### PR TITLE
 retrieve information about managed clusters from AMS API 

### DIFF
--- a/amsclient/amsclient.go
+++ b/amsclient/amsclient.go
@@ -212,7 +212,7 @@ func (c *amsClientImpl) executeSubscriptionListRequest(
 		subscriptionListRequest = subscriptionListRequest.
 			Size(c.pageSize).
 			Page(pageNum).
-			Fields("external_cluster_id,display_name,cluster_id").
+			Fields("external_cluster_id,display_name,cluster_id,managed").
 			Search(searchQuery)
 
 		response, err := subscriptionListRequest.Send()
@@ -244,10 +244,16 @@ func (c *amsClientImpl) executeSubscriptionListRequest(
 				displayName = string(clusterIDstr)
 			}
 
+			managed, ok := item.GetManaged()
+			if !ok {
+				log.Warn().Str(clusterIDTag, clusterIDstr).Msg("cluster has no managed attribute")
+			}
+
 			clusterID := types.ClusterName(clusterIDstr)
 			clusterInfoList = append(clusterInfoList, types.ClusterInfo{
 				ID:          clusterID,
 				DisplayName: displayName,
+				Managed:     managed,
 			})
 		}
 	}

--- a/gocyclo.sh
+++ b/gocyclo.sh
@@ -20,4 +20,4 @@ then
     GO111MODULE=off go get github.com/fzipp/gocyclo/cmd/gocyclo
 fi
 
-gocyclo -over 9 -avg .
+gocyclo -over 10 -avg .

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -455,6 +455,7 @@ func matchClusterInfoAndUserData(
 		clusterViewItem := types.ClusterListView{
 			ClusterID:       clusterInfoList[i].ID,
 			ClusterName:     clusterInfoList[i].DisplayName,
+			Managed:         clusterInfoList[i].Managed,
 			HitsByTotalRisk: make(map[int]int),
 		}
 

--- a/server/server.go
+++ b/server/server.go
@@ -835,12 +835,13 @@ func (server HTTPServer) fetchAggregatorReportsUsingRequestBodyClusterList(
 	return aggregatorResponse, true
 }
 
-// SetClusterDisplayNameInReport tries to retrieve the display name of the cluster using
+// SetAMSInfoInReport tries to retrieve the display name and managed status of the cluster using
 // the configured AMS client. If no info is retrieved, it sets the cluster's external
 // ID as display name.
-func (server HTTPServer) SetClusterDisplayNameInReport(clusterID types.ClusterName, report *types.SmartProxyReportV2) {
+func (server HTTPServer) SetAMSInfoInReport(clusterID types.ClusterName, report *types.SmartProxyReportV2) {
 	if server.amsClient != nil {
 		clusterInfo := server.amsClient.GetClusterDetailsFromExternalClusterID(clusterID)
+		report.Meta.Managed = clusterInfo.Managed
 		if clusterInfo.DisplayName != "" {
 			report.Meta.DisplayName = clusterInfo.DisplayName
 			return
@@ -935,7 +936,7 @@ func (server HTTPServer) reportEndpointV2(writer http.ResponseWriter, request *h
 
 	report := types.SmartProxyReportV2{}
 
-	server.SetClusterDisplayNameInReport(clusterID, &report)
+	server.SetAMSInfoInReport(clusterID, &report)
 
 	var err error
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1233,15 +1233,15 @@ func TestHTTPServer_OverviewEndpointWithFallback(t *testing.T) {
 	}, testTimeout)
 }
 
-func TestHTTPServer_setClusterDisplayNameInReportNoAMSClient(t *testing.T) {
+func TestHTTPServer_SetAMSInfoInReportNoAMSClient(t *testing.T) {
 	report := types.SmartProxyReportV2{}
 	config := helpers.DefaultServerConfig
 	testServer := helpers.CreateHTTPServer(&config, nil, nil, nil, nil, nil)
-	testServer.SetClusterDisplayNameInReport(testdata.ClusterName, &report)
+	testServer.SetAMSInfoInReport(testdata.ClusterName, &report)
 	assert.Equal(t, string(testdata.ClusterName), report.Meta.DisplayName)
 }
 
-func TestHTTPServer_setClusterDisplayNameInReportAMSClientClusterIDFound(t *testing.T) {
+func TestHTTPServer_SetAMSInfoInReportAMSClientClusterIDFound(t *testing.T) {
 	report := types.SmartProxyReportV2{}
 	config := helpers.DefaultServerConfig
 	// prepare list of organizations response
@@ -1250,7 +1250,7 @@ func TestHTTPServer_setClusterDisplayNameInReportAMSClientClusterIDFound(t *test
 		data.ClusterInfoResult,
 	)
 	testServer := helpers.CreateHTTPServer(&config, nil, amsClientMock, nil, nil, nil)
-	testServer.SetClusterDisplayNameInReport(testdata.ClusterName, &report)
+	testServer.SetAMSInfoInReport(testdata.ClusterName, &report)
 	assert.Equal(t, data.ClusterDisplayName1, report.Meta.DisplayName)
 }
 

--- a/smart_proxy_test.go
+++ b/smart_proxy_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/RedHatInsights/insights-operator-utils/tests/helpers"
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	testify "github.com/stretchr/testify/assert"
 
 	main "github.com/RedHatInsights/insights-results-smart-proxy"

--- a/tests/testdata/amstestdata.go
+++ b/tests/testdata/amstestdata.go
@@ -17,6 +17,7 @@ package testdata
 import (
 	"fmt"
 
+	sptypes "github.com/RedHatInsights/insights-results-smart-proxy/types"
 	types "github.com/RedHatInsights/insights-results-types"
 )
 
@@ -80,11 +81,13 @@ var (
 				"display_name":        ClusterDisplayName1,
 				"external_cluster_id": ClusterName1,
 				"id":                  "1YfQ9bR7LTDz24YzfFmaCdeB0sS",
+				"managed":             true,
 			},
 			{
 				"display_name":        ClusterDisplayName2,
 				"external_cluster_id": ClusterName2,
 				"id":                  "1YfQLCOCZZOEXgOp8uIbqe5i5z2",
+				"managed":             false,
 			},
 		},
 	}
@@ -102,16 +105,19 @@ var (
 				"display_name":        ClusterDisplayName1,
 				"external_cluster_id": ClusterName1,
 				"id":                  "1YfQ9bR7LTDz24YzfFmaCdeB0sS",
+				"managed":             true,
 			},
 			{
 				"display_name":        ClusterDisplayName2,
 				"external_cluster_id": "",
 				"id":                  "1QfQ9bR7LTDz24YzfFmaCdeBf86",
+				"managed":             false,
 			},
 			{
 				"display_name":        "",
 				"external_cluster_id": "",
 				"id":                  "", // cover edge case condition
+				"managed":             false,
 			},
 		},
 	}
@@ -123,5 +129,19 @@ var (
 		"size":  0,
 		"total": 2,
 		"items": []map[string]interface{}{},
+	}
+
+	// OKClustersForOrganization is the expected OK result of GetClustersForOrganization
+	OKClustersForOrganization []sptypes.ClusterInfo = []sptypes.ClusterInfo{
+		{
+			ID:          ClusterName1,
+			DisplayName: ClusterDisplayName1,
+			Managed:     true,
+		},
+		{
+			ID:          ClusterName2,
+			DisplayName: ClusterDisplayName2,
+			Managed:     false,
+		},
 	}
 )

--- a/tests/testdata/testdata.go
+++ b/tests/testdata/testdata.go
@@ -110,6 +110,16 @@ func GetRandomClusterInfo() types.ClusterInfo {
 	}
 }
 
+// GetRandomClusterInfoList generates a slice of given length with random clusterInfo. Every other cluster has managed=true
+func GetRandomClusterInfoList(length int) []types.ClusterInfo {
+	clusterInfoList := make([]types.ClusterInfo, length)
+	for i := range clusterInfoList {
+		clusterInfoList[i] = GetRandomClusterInfo()
+		clusterInfoList[i].Managed = i%2 == 0
+	}
+	return clusterInfoList
+}
+
 func whateverToJSONRawMessage(obj interface{}) json.RawMessage {
 	var result json.RawMessage
 

--- a/types/types.go
+++ b/types/types.go
@@ -247,8 +247,9 @@ type InfoResponse struct {
 
 // ClusterInfo is a data structure containing some relevant cluster information
 type ClusterInfo struct {
-	ID          ClusterName
-	DisplayName string
+	ID          ClusterName `json:"cluster_id"`
+	DisplayName string      `json:"display_name"`
+	Managed     bool        `json:"managed"`
 }
 
 // ClustersDetailData is the inner data structure for /clusters_detail

--- a/types/types.go
+++ b/types/types.go
@@ -116,6 +116,7 @@ type ReportResponseMetaV1 struct {
 // ReportResponseMetaV2 contains metadata for /report endpoint in v2
 type ReportResponseMetaV2 struct {
 	DisplayName   string    `json:"cluster_name"`
+	Managed       bool      `json:"managed"`
 	Count         int       `json:"count"`
 	LastCheckedAt Timestamp `json:"last_checked_at,omitempty"`
 	GatheredAt    Timestamp `json:"gathered_at,omitempty"`
@@ -212,6 +213,7 @@ type RecommendationListView struct {
 type ClusterListView struct {
 	ClusterID       types.ClusterName `json:"cluster_id"`
 	ClusterName     string            `json:"cluster_name"`
+	Managed         bool              `json:"managed"`
 	LastCheckedAt   Timestamp         `json:"last_checked_at,omitempty"`
 	TotalHitCount   uint32            `json:"total_hit_count"`
 	HitsByTotalRisk map[int]int       `json:"hits_by_total_risk"`


### PR DESCRIPTION
# Description
- retrieves information whether cluster is managed or not from AMS
- unifies `assert` libraries to avoid unnecessary time wasted hunting weird issue.... wink wink
- adds information whether cluster is managed to `v2/clusters` and `v2/cluster/{clusterId}/reports` endpoints

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps
`make before_commit` + AMS prod credentials 

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
