### PR TITLE
Using latest version of data types to export the version to the v2 API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,7 @@ require (
 	github.com/RedHatInsights/insights-operator-utils v1.23.3
 	github.com/RedHatInsights/insights-results-aggregator v1.2.5
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.5
-	github.com/RedHatInsights/insights-results-types v1.3.7
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
+	github.com/RedHatInsights/insights-results-types v1.3.9
 	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/RedHatInsights/insights-content-service v0.0.0-20211119142943-71a7a9be7bb8
 	github.com/RedHatInsights/insights-operator-utils v1.23.3
 	github.com/RedHatInsights/insights-results-aggregator v1.2.5
-	github.com/RedHatInsights/insights-results-aggregator-data v1.3.5
+	github.com/RedHatInsights/insights-results-aggregator-data v1.3.6
 	github.com/RedHatInsights/insights-results-types v1.3.9
 	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -97,8 +97,9 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.3.5 h1:6N0W03ccV2e
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.5/go.mod h1:tOwmlIB5irSv1mTLgONuLrsbTp4vokl4ClJFClrrXX0=
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.6/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
-github.com/RedHatInsights/insights-results-types v1.3.7 h1:rvzW6LI6O3yNZzmGNUA92y/unuHa7Kb9n5NOdQS+kTc=
 github.com/RedHatInsights/insights-results-types v1.3.7/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
+github.com/RedHatInsights/insights-results-types v1.3.9 h1:jXg/tyd5+ndl+Wq8eteng/+6THI9zKrLTwVZSfrx/os=
+github.com/RedHatInsights/insights-results-types v1.3.9/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec h1:/msFfckx6EIj0rZncrMUfNixFvsLbOiRIe4J0AurhDo=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=

--- a/go.sum
+++ b/go.sum
@@ -93,8 +93,8 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.1.2/go.mod h1:rbic
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.1/go.mod h1:Ylo2cWFmraBzkwKLew54kZSsUTgeVvFJdIi/oRkdxtc=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.2/go.mod h1:E1UaB+IjJ/muxvMstVoqJrB82zVKNykjTtCiM3tMHoM=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.3/go.mod h1:udHNC7lBxYnu9AqMahABqvuclCzWUWSkbacQbUaehfI=
-github.com/RedHatInsights/insights-results-aggregator-data v1.3.5 h1:6N0W03ccV2eNviMAJP2mO8Evj7kxeu1AymLbgZWZgSQ=
-github.com/RedHatInsights/insights-results-aggregator-data v1.3.5/go.mod h1:tOwmlIB5irSv1mTLgONuLrsbTp4vokl4ClJFClrrXX0=
+github.com/RedHatInsights/insights-results-aggregator-data v1.3.6 h1:RcZsn25t+km9/VBAcbks5oLx21HI0aQvLFldgEja5NY=
+github.com/RedHatInsights/insights-results-aggregator-data v1.3.6/go.mod h1:tOwmlIB5irSv1mTLgONuLrsbTp4vokl4ClJFClrrXX0=
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.6/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.7/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -859,6 +859,11 @@
                               "last_checked_at": {
                                 "format": "date-time",
                                 "type": "string"
+                              },
+                              "cluster_version": {
+                                "type": "string",
+                                "description": "Version of OpenShift in the cluster",
+                                "example": "4.7"
                               }
                             }
                           }

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -96,7 +96,10 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 			{
 				"cluster":"%v",
 				"cluster_name": "%v",
-				"last_checked_at":""
+				"last_checked_at":"",
+				"meta": {
+					"cluster_version": "4.7"
+				}
 			}
 		],
 		"status":"ok"
@@ -159,7 +162,10 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 				{
 					"cluster": "%v",
 					"cluster_name": "%v",
-					"last_checked_at": ""
+					"last_checked_at": "",
+					"meta": {
+						"cluster_version": "4.7"
+					}
 				}
 			],
 			"disabled": [
@@ -389,7 +395,10 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_DisabledClusterNo
 				{
 					"cluster": "%v",
 					"cluster_name": "%v",
-					"last_checked_at":""
+					"last_checked_at":"",
+					"meta": {
+						"cluster_version": ""
+					}
 				}
 			],
 			"disabled": []

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -98,14 +98,16 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 				"cluster_name": "%v",
 				"last_checked_at":"",
 				"meta": {
-					"cluster_version": "4.7"
+					"cluster_version": "%v"
 				}
 			}
 		],
 		"status":"ok"
 	}
 	`
-	impactedClustersResponse = fmt.Sprintf(impactedClustersResponse, clusters[0], "")
+	impactedClustersResponse = fmt.Sprintf(
+		impactedClustersResponse, clusters[0], "", testdata.ClusterVersion,
+	)
 	helpers.GockExpectAPIRequest(
 		t,
 		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
@@ -164,7 +166,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 					"cluster_name": "%v",
 					"last_checked_at": "",
 					"meta": {
-						"cluster_version": "4.7"
+						"cluster_version": "%v"
 					}
 				}
 			],
@@ -181,7 +183,8 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 	}
 	`
 
-	expectedResponse = fmt.Sprintf(expectedResponse, clusters[0], data.ClusterDisplayName1,
+	expectedResponse = fmt.Sprintf(
+		expectedResponse, clusters[0], data.ClusterDisplayName1, testdata.ClusterVersion,
 		clusters[1], data.ClusterDisplayName2, disabledAt, justificationNote,
 	)
 


### PR DESCRIPTION
# Description

Using latest version of insights-result-types in order to automatially include the cluster metadata into the clusters_detail responses

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Locally tested

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
