### PR TITLE
add AMS Cluster Info endpoint 

### DIFF
--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -104,6 +104,76 @@
         }
       }
     },
+    "/cluster/{clusterId}/info": {
+      "get": {
+        "tags": [
+          "prod"
+        ],
+        "summary": "Returns relevant information about the cluster available in AMS API.",
+        "description": "Cluster ID is given in URL. Organization ID in token must match the one under which the cluster is registered in AMS.",
+        "operationId": "getInfoForCluster",
+        "parameters": [
+          {
+            "example": "34c3ecc5-624a-49a5-bab8-4fdc5e51a266",
+            "name": "clusterId",
+            "description": "ID of the cluster which must conform to UUID format.",
+            "schema": {
+              "type": "string"
+            },
+            "in": "path",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Information about the given cluster retrieved from AMS API.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "description": "Response data type for GET /clusters/{clusterId}/report endpoint",
+                  "type": "object",
+                  "properties": {
+                    "cluster": {
+                      "cluster_id": {
+                        "type": "string",
+                        "minLength": 36,
+                        "maxLength": 36,
+                        "format": "uuid"
+                      },
+                      "display_name": {
+                        "type": "string",
+                        "description": "An human-readable name for the cluster",
+                        "example": "Production cluster 1"
+                      },
+                      "managed": {
+                        "type": "bool",
+                        "description": "Indicates whether cluster is managed or not (has 'managed' flag in AMS)",
+                        "example": true
+                      },
+                      "status": {
+                        "type": "string",
+                        "description": "Status of the cluster, such as Active, Deprovisioned, etc",
+                        "example": "Active"
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request, usually caused when some cluster belongs to different organization."
+          },
+          "404": {
+            "description": "Cluster info was not returned from AMS API for given organization."
+          }
+        }
+      }
+    },
     "/content": {
       "get": {
         "tags": [

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -130,30 +130,32 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "description": "Response data type for GET /clusters/{clusterId}/report endpoint",
-                  "type": "object",
+                  "description": "Response data type for GET /clusters/{clusterId}/info endpoint",
                   "properties": {
                     "cluster": {
-                      "cluster_id": {
-                        "type": "string",
-                        "minLength": 36,
-                        "maxLength": 36,
-                        "format": "uuid"
-                      },
-                      "display_name": {
-                        "type": "string",
-                        "description": "An human-readable name for the cluster",
-                        "example": "Production cluster 1"
-                      },
-                      "managed": {
-                        "type": "bool",
-                        "description": "Indicates whether cluster is managed or not (has 'managed' flag in AMS)",
-                        "example": true
-                      },
-                      "status": {
-                        "type": "string",
-                        "description": "Status of the cluster, such as Active, Deprovisioned, etc",
-                        "example": "Active"
+                      "type": "object",
+                      "properties":{
+                        "cluster_id": {
+                          "type": "string",
+                          "minLength": 36,
+                          "maxLength": 36,
+                          "format": "uuid"
+                        },
+                        "display_name": {
+                          "type": "string",
+                          "description": "An human-readable name for the cluster",
+                          "example": "Production cluster 1"
+                        },
+                        "managed": {
+                          "type": "bool",
+                          "description": "Indicates whether cluster is managed or not (has 'managed' flag in AMS)",
+                          "example": true
+                        },
+                        "status": {
+                          "type": "string",
+                          "description": "Status of the cluster, such as Active, Deprovisioned, etc",
+                          "example": "Active"
+                        }
                       }
                     },
                     "status": {

--- a/server/endpoints_v2.go
+++ b/server/endpoints_v2.go
@@ -28,6 +28,9 @@ const (
 	// ReportEndpointV2 https://issues.redhat.com/browse/CCXDEV-5097
 	ReportEndpointV2 = "cluster/{cluster}/reports"
 
+	// ClusterInfoEndpoint provides information about given cluster retrieved from AMS API
+	ClusterInfoEndpoint = "cluster/{cluster}/info"
+
 	// ClustersDetail https://issues.redhat.com/browse/CCXDEV-5088
 	ClustersDetail = "rule/{rule_selector}/clusters_detail"
 
@@ -111,7 +114,7 @@ func (server *HTTPServer) addV2EndpointsToRouter(router *mux.Router) {
 // return cluster report or reports to client
 func (server *HTTPServer) addV2ReportsEndpointsToRouter(router *mux.Router, apiPrefix, aggregatorBaseURL string) {
 	router.HandleFunc(apiPrefix+ReportEndpointV2, server.reportEndpointV2).Methods(http.MethodGet, http.MethodOptions)
-
+	router.HandleFunc(apiPrefix+ClusterInfoEndpoint, server.getSingleClusterInfo).Methods(http.MethodGet)
 	router.HandleFunc(apiPrefix+RecommendationsListEndpoint, server.getRecommendations).Methods(http.MethodGet)
 	router.HandleFunc(apiPrefix+ClustersRecommendationsEndpoint, server.getClustersView).Methods(http.MethodGet)
 }

--- a/server/errors.go
+++ b/server/errors.go
@@ -94,6 +94,13 @@ func (*AggregatorServiceUnavailableError) Error() string {
 	return "Aggregator service is unreachable"
 }
 
+// AMSAPIUnavailableError error is used when AMS API is not available and is the only source of data
+type AMSAPIUnavailableError struct{}
+
+func (*AMSAPIUnavailableError) Error() string {
+	return "AMS API is unreachable"
+}
+
 // ParamsParsingError error meaning that the cluster name cannot be handled
 type ParamsParsingError struct{}
 
@@ -116,7 +123,8 @@ func handleServerError(writer http.ResponseWriter, err error) {
 		respErr = responses.SendNotFound(writer, err.Error())
 	case *AuthenticationError:
 		respErr = responses.SendForbidden(writer, err.Error())
-	case *ContentServiceUnavailableError, *AggregatorServiceUnavailableError, *content.RuleContentDirectoryTimeoutError:
+	case *ContentServiceUnavailableError, *AggregatorServiceUnavailableError,
+		*AMSAPIUnavailableError, *content.RuleContentDirectoryTimeoutError:
 		respErr = responses.SendServiceUnavailable(writer, err.Error())
 	default:
 		respErr = responses.SendInternalServerError(writer, "Internal Server Error")

--- a/tests/helpers/amsclient.go
+++ b/tests/helpers/amsclient.go
@@ -16,6 +16,7 @@ package helpers
 
 import (
 	"fmt"
+
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
 
 	"github.com/RedHatInsights/insights-results-smart-proxy/amsclient"
@@ -53,6 +54,20 @@ func (m *mockAMSClient) GetClusterDetailsFromExternalClusterID(
 	for _, info := range m.clustersPerOrg[testdata.OrgID] {
 		if info.ID == id {
 			return info
+		}
+	}
+	return
+}
+
+func (m *mockAMSClient) GetSingleClusterInfoForOrganization(
+	orgID types.OrgID, clusterID types.ClusterName,
+) (
+	clusterInfo types.ClusterInfo, err error,
+) {
+
+	for _, info := range m.clustersPerOrg[testdata.OrgID] {
+		if info.ID == clusterID {
+			return info, nil
 		}
 	}
 	return

--- a/tests/testdata/amstestdata.go
+++ b/tests/testdata/amstestdata.go
@@ -34,6 +34,9 @@ const (
 	InternalClusterName1 string = "1ABCD2abEFcdefGhijkH3lmnopI"
 	// InternalClusterName2 represents the AMS internal name for ClusterName2
 	InternalClusterName2 string = "9ZYXW8zyVUxwvuTtsrqS7ponmlR"
+
+	// ActiveStatus default status for testing AMS clusters
+	ActiveStatus = "Active"
 )
 
 var (
@@ -82,12 +85,14 @@ var (
 				"external_cluster_id": ClusterName1,
 				"id":                  "1YfQ9bR7LTDz24YzfFmaCdeB0sS",
 				"managed":             true,
+				"status":              ActiveStatus,
 			},
 			{
 				"display_name":        ClusterDisplayName2,
 				"external_cluster_id": ClusterName2,
 				"id":                  "1YfQLCOCZZOEXgOp8uIbqe5i5z2",
 				"managed":             false,
+				"status":              ActiveStatus,
 			},
 		},
 	}
@@ -106,18 +111,21 @@ var (
 				"external_cluster_id": ClusterName1,
 				"id":                  "1YfQ9bR7LTDz24YzfFmaCdeB0sS",
 				"managed":             true,
+				"status":              ActiveStatus,
 			},
 			{
 				"display_name":        ClusterDisplayName2,
 				"external_cluster_id": "",
 				"id":                  "1QfQ9bR7LTDz24YzfFmaCdeBf86",
 				"managed":             false,
+				"status":              ActiveStatus,
 			},
 			{
 				"display_name":        "",
 				"external_cluster_id": "",
 				"id":                  "", // cover edge case condition
 				"managed":             false,
+				"status":              ActiveStatus,
 			},
 		},
 	}
@@ -137,11 +145,13 @@ var (
 			ID:          ClusterName1,
 			DisplayName: ClusterDisplayName1,
 			Managed:     true,
+			Status:      ActiveStatus,
 		},
 		{
 			ID:          ClusterName2,
 			DisplayName: ClusterDisplayName2,
 			Managed:     false,
+			Status:      ActiveStatus,
 		},
 	}
 )

--- a/tests/testdata/testdata.go
+++ b/tests/testdata/testdata.go
@@ -107,6 +107,7 @@ func GetRandomClusterInfo() types.ClusterInfo {
 	return types.ClusterInfo{
 		ID:          clusterID,
 		DisplayName: string(clusterID),
+		Status:      ActiveStatus,
 	}
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -253,6 +253,7 @@ type ClusterInfo struct {
 	ID          ClusterName `json:"cluster_id"`
 	DisplayName string      `json:"display_name"`
 	Managed     bool        `json:"managed"`
+	Status      string      `json:"status"`
 }
 
 // ClustersDetailData is the inner data structure for /clusters_detail


### PR DESCRIPTION
# Description
The new endpoint only communicates with AMSAPI, it will be used whenever frontend is unable to retrieve the data from the API otherwise. Some seemingly unnecessary conditions were added because of unexpected behaviour of the API...

Fixes CCXDEV-7682

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- Documentation update

## Testing steps
final version tested against production API

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
