### PR TITLE
dedicated secret for internal_rules_organizations.csv

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -168,7 +168,14 @@ objects:
             limits:
               cpu: 250m
               memory: 600Mi
-
+          volumeMounts:
+          - mountPath: /internal-rules-organizations
+            name: internal-rules-organizations
+            readOnly: true
+          volumes:
+          - name: internal-rules-organizations
+            secret:
+              secretName: internal-rules-organizations
 - kind: Service
   apiVersion: v1
   metadata:
@@ -217,7 +224,7 @@ parameters:
 - name: IRSP_ENABLE_INTERNAL_ORGANIZATIONS
   value: "false"
 - name: IRSP_INTERNAL_RULES_ORGANIZATIONS_CSV_FILE
-  value: "/etc/ccx-smart-proxy-secrets/internal_rules_organizations.csv"
+  value: "/internal-rules-organizations/internal_rules_organizations.csv"
 - name: INSIGHTS_RESULTS_AGGREGATOR_SERVICE_URL
   value: "http://ccx-insights-results-aggregator:10000/api/v1/"
 - name: INSIGHTS_CONTENT_SERVICE_URL


### PR DESCRIPTION
# Description

We currently read internal_rules_organizations.csv from the same secret than the clowdapp config. This means there is a secret configuration conflict between clowder and app-interface resulting in constant secret patching.

This change allows to use a dedicated secret for internal_rules_organizations.csv

Part of https://issues.redhat.com/browse/CCXDEV-6464

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes (local docker issue)
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
