### PR TITLE
Adding more_info into reportData schema

### DIFF
--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -1118,6 +1118,10 @@
             "description": "Resolution steps of the issue, possibly linking to a resolution article in the knowledge base.",
             "type": "string"
           },
+          "more_info": {
+            "description": "Non essential information.",
+            "type": "string"
+          },
           "total_risk": {
             "description": "Total risk - calculated from rule impact and likelihood.",
             "enum": [


### PR DESCRIPTION
# Description

Adding "more_info" into the report data schema, as it is the only field missing in the OpenAPI spec.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Refactor (refactoring code, removing useless files)

## Testing steps

`make openapi_check`

## Checklist
* [ ] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
