### PR TITLE
check for zero date

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -976,7 +976,13 @@ func fillImpacted(
 
 	for i, resp := range responses {
 		id := string(resp.ErrorKey) + string(resp.RuleID)
-		if report, ok := idReport[id]; ok {
+		report, ok := idReport[id]
+		CreatedAtTime, err := time.Parse(time.RFC3339, string(report.CreatedAt))
+		if err != nil {
+			log.Warn().Err(err).Msgf("fillImpacted: invalid time format %v", report.CreatedAt)
+			continue
+		}
+		if ok && !CreatedAtTime.IsZero() {
 			resp.Impacted = report.CreatedAt
 			responses[i] = resp
 		}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1442,6 +1442,10 @@ func TestFillImpacted(t *testing.T) {
 		RuleID:   "rid1",
 		ErrorKey: "ek1",
 	}
+	resp2 := types.RuleWithContentResponse{
+		RuleID:   "rid2",
+		ErrorKey: "ek2",
+	}
 	respNa := types.RuleWithContentResponse{
 		RuleID:   "111",
 		ErrorKey: "111",
@@ -1452,19 +1456,29 @@ func TestFillImpacted(t *testing.T) {
 		CreatedAt: types.Timestamp(time.Now().UTC().Format(time.RFC3339)),
 	}
 	report1 := ctypes.RuleOnReport{
-		Module:   "rid1",
-		ErrorKey: "ek1",
+		Module:    "rid1",
+		ErrorKey:  "ek1",
+		CreatedAt: types.Timestamp(time.Time{}.UTC().Format(time.RFC3339)),
+	}
+	report2 := ctypes.RuleOnReport{
+		Module:    "rid2",
+		ErrorKey:  "ek2",
+		CreatedAt: "wrong time format",
 	}
 	reportNa := ctypes.RuleOnReport{
 		Module:   "000",
 		ErrorKey: "000",
 	}
 
-	response = append(response, resp0, resp1, respNa)
-	aggregatorReport = append(aggregatorReport, report0, report1, reportNa)
+	response = append(response, resp0, resp1, resp2, respNa)
+	aggregatorReport = append(aggregatorReport, report0, report1, report2, reportNa)
 
 	server.FillImpacted(response, aggregatorReport)
 	assert.Equal(t, response[0].Impacted, report0.CreatedAt)
 	assert.True(t, len(response[1].Impacted) == 0)
 	assert.True(t, len(response[2].Impacted) == 0)
+
+	jsonResp, err := json.Marshal(response)
+	assert.NoError(t, err)
+	assert.NotContains(t, string(jsonResp), "0001-01-01T00:00:00Z")
 }


### PR DESCRIPTION
# Description

prevent the smart proxy to send the zero date (`0001-01-01T00:00:00Z`) to the front end

Fixes CCXDEV-7859

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
-

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
