### PR TITLE
userID is empty most of the times on prod, try to decode userID on to…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/RedHatInsights/insights-operator-utils v1.23.8
 	github.com/RedHatInsights/insights-results-aggregator v1.2.7
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.6
-	github.com/RedHatInsights/insights-results-types v1.3.18
+	github.com/RedHatInsights/insights-results-types v1.3.19
 	github.com/golang-jwt/jwt/v4 v4.2.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,8 @@ github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2c
 github.com/RedHatInsights/insights-results-types v1.3.7/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.12/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.16/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
-github.com/RedHatInsights/insights-results-types v1.3.18 h1:V8wngjEc1j8r99P7e0EsCbh2FcsLXQkvDoWN3LJdfIY=
-github.com/RedHatInsights/insights-results-types v1.3.18/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
+github.com/RedHatInsights/insights-results-types v1.3.19 h1:uqulNvjEhz6la6/0uSRwxw4/BzXYapi9nEz084bytsk=
+github.com/RedHatInsights/insights-results-types v1.3.19/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/RedHatInsights/kafka-zerolog v1.0.0 h1:4zPrLcwnfFl07qv9/ximlm1E/rWs93TkYnHrgNiU73A=
 github.com/RedHatInsights/kafka-zerolog v1.0.0/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=

--- a/gocyclo.sh
+++ b/gocyclo.sh
@@ -20,4 +20,4 @@ then
     GO111MODULE=off go get github.com/fzipp/gocyclo/cmd/gocyclo
 fi
 
-gocyclo -over 14 -avg .
+gocyclo -over 15 -avg .

--- a/server/auth.go
+++ b/server/auth.go
@@ -124,6 +124,13 @@ func (server *HTTPServer) Authentication(next http.Handler, noAuthURLs []string)
 			log.Error().Msg("org_id not found on top level in token structure (old format)")
 		}
 
+		log.Info().Msgf("userID on top level [%v], userID nested [%v]", tkV2.IdentityV2.UserID, tkV2.IdentityV2.User.UserID)
+		log.Info().Msgf("username [%v], email [%v]", tkV2.IdentityV2.UserID, tkV2.IdentityV2.User.UserID)
+		if tkV2.IdentityV2.UserID != "" {
+			tkV2.IdentityV2.User.UserID = tkV2.IdentityV2.UserID
+			tk.Identity.User.UserID = tkV2.IdentityV2.UserID
+		}
+
 		if tk.Identity.AccountNumber == "" || tk.Identity.AccountNumber == "0" {
 			log.Info().Msgf("anemic tenant found! org_id %v, user data [%+v]",
 				tk.Identity.Internal.OrgID, tk.Identity.User,


### PR DESCRIPTION
…p level, all tokens/cookies on crc have userID on top level, so just checking if we're doing everything correctly and we should expect userID to be empty a lot

this is probably the cause of the 404s because of invalid URLs

Fixes # (issue)

## Type of change

## Testing steps
run

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
