### PR TITLE
attempt to hotfix 404 issue (user id is only used for rule feedbacks)

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -124,13 +124,6 @@ func (server *HTTPServer) Authentication(next http.Handler, noAuthURLs []string)
 			log.Error().Msg("org_id not found on top level in token structure (old format)")
 		}
 
-		log.Info().Msgf("userID on top level [%v], userID nested [%v]", tkV2.IdentityV2.UserID, tkV2.IdentityV2.User.UserID)
-		log.Info().Msgf("username [%v], email [%v]", tkV2.IdentityV2.UserID, tkV2.IdentityV2.User.UserID)
-		if tkV2.IdentityV2.UserID != "" {
-			tkV2.IdentityV2.User.UserID = tkV2.IdentityV2.UserID
-			tk.Identity.User.UserID = tkV2.IdentityV2.UserID
-		}
-
 		if tk.Identity.AccountNumber == "" || tk.Identity.AccountNumber == "0" {
 			log.Info().Msgf("anemic tenant found! org_id %v, user data [%+v]",
 				tk.Identity.Internal.OrgID, tk.Identity.User,
@@ -161,6 +154,11 @@ func (server *HTTPServer) GetCurrentUserID(request *http.Request) (types.UserID,
 	identity, err := server.GetAuthToken(request)
 	if err != nil {
 		return types.UserID(""), err
+	}
+
+	if identity.User.UserID == "" {
+		log.Info().Msgf("empty userID for username [%v] email [%v]", identity.User.Username, identity.User.Email)
+		return types.UserID("0"), nil
 	}
 
 	return identity.User.UserID, nil


### PR DESCRIPTION
# Description
For some reason, most users don't have `user_id` causing problems with constructing aggregator URLs 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
simulating mysterious x-rh-identity 

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
