### PR TITLE
attempt to hotfix 404 issue (user id is only used for rule feedbacks)

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -185,6 +185,11 @@ func (server *HTTPServer) GetCurrentOrgIDUserID(request *http.Request) (
 		return types.OrgID(0), types.UserID("0"), err
 	}
 
+	if identity.User.UserID == "" {
+		log.Info().Msgf("empty userID for username [%v] email [%v]", identity.User.Username, identity.User.Email)
+		return identity.Internal.OrgID, types.UserID("0"), nil
+	}
+
 	return identity.Internal.OrgID, identity.User.UserID, nil
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -1177,8 +1177,13 @@ func (server HTTPServer) newExtractUserIDFromTokenToURLRequestModifier(newEndpoi
 			return nil, err
 		}
 
+		userID := identity.User.UserID
+		if identity.User.UserID == "" {
+			userID = "0"
+		}
+
 		vars := mux.Vars(request)
-		vars["user_id"] = string(identity.User.UserID)
+		vars["user_id"] = fmt.Sprintf("%v", userID)
 
 		newURL := httputils.MakeURLToEndpointMapString(server.Config.APIv1Prefix, newEndpoint, vars)
 		request.URL, err = url.Parse(newURL)


### PR DESCRIPTION
# Description
For some reason, most users don't have `user_id` causing problems with constructing aggregator URLs 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
simulating mysterious x-rh-identity 

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
