### PR TITLE
increase AMS API page size to 10k

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -253,4 +253,4 @@ parameters:
 - name: AMS_API_URL
   value: "https://api.stage.openshift.com"
 - name: AMS_API_PAGESIZE
-  value: "6000"
+  value: "10000"


### PR DESCRIPTION
# Description
Some orgs now have over 6k clusters causing the Advisor to be quite slow. Increasing the AMS page size so that it only makes one request.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
