### PR TITLE
Check rule id error key

### DIFF
--- a/server/endpoints_test.go
+++ b/server/endpoints_test.go
@@ -23,6 +23,7 @@ import (
 	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
 )
@@ -59,6 +60,9 @@ func TestHTTPServer_ProxyTo_VoteEndpointsExtractUserID(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			helpers.RunTestWithTimeout(t, func(t testing.TB) {
 				defer helpers.CleanAfterGock(t)
+				defer content.ResetContent()
+				err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+				assert.Nil(t, err)
 
 				helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
 					Method:       testCase.method,

--- a/server/endpoints_v1.go
+++ b/server/endpoints_v1.go
@@ -155,6 +155,7 @@ func (server *HTTPServer) addV1RuleEndpointsToRouter(router *mux.Router, apiPref
 		aggregatorBaseEndpoint,
 		&ProxyOptions{RequestModifiers: []RequestModifier{
 			server.extractUserIDOrgIDFromTokenToURLRequestModifier(ira_server.LikeRuleEndpoint),
+			checkRuleIDAndErrorKeyAreValid(),
 		}},
 	)).Methods(http.MethodPut, http.MethodOptions)
 
@@ -162,6 +163,7 @@ func (server *HTTPServer) addV1RuleEndpointsToRouter(router *mux.Router, apiPref
 		aggregatorBaseEndpoint,
 		&ProxyOptions{RequestModifiers: []RequestModifier{
 			server.extractUserIDOrgIDFromTokenToURLRequestModifier(ira_server.DislikeRuleEndpoint),
+			checkRuleIDAndErrorKeyAreValid(),
 		}},
 	)).Methods(http.MethodPut, http.MethodOptions)
 
@@ -169,6 +171,7 @@ func (server *HTTPServer) addV1RuleEndpointsToRouter(router *mux.Router, apiPref
 		aggregatorBaseEndpoint,
 		&ProxyOptions{RequestModifiers: []RequestModifier{
 			server.extractUserIDOrgIDFromTokenToURLRequestModifier(ira_server.ResetVoteOnRuleEndpoint),
+			checkRuleIDAndErrorKeyAreValid(),
 		}},
 	)).Methods(http.MethodPut, http.MethodOptions)
 
@@ -176,6 +179,7 @@ func (server *HTTPServer) addV1RuleEndpointsToRouter(router *mux.Router, apiPref
 		aggregatorBaseEndpoint,
 		&ProxyOptions{RequestModifiers: []RequestModifier{
 			server.extractUserIDOrgIDFromTokenToURLRequestModifier(ira_server.DisableRuleForClusterEndpoint),
+			checkRuleIDAndErrorKeyAreValid(),
 		}},
 	)).Methods(http.MethodPut, http.MethodOptions)
 
@@ -183,6 +187,7 @@ func (server *HTTPServer) addV1RuleEndpointsToRouter(router *mux.Router, apiPref
 		aggregatorBaseEndpoint,
 		&ProxyOptions{RequestModifiers: []RequestModifier{
 			server.extractUserIDOrgIDFromTokenToURLRequestModifier(ira_server.EnableRuleForClusterEndpoint),
+			checkRuleIDAndErrorKeyAreValid(),
 		}},
 	)).Methods(http.MethodPut, http.MethodOptions)
 
@@ -190,6 +195,7 @@ func (server *HTTPServer) addV1RuleEndpointsToRouter(router *mux.Router, apiPref
 		aggregatorBaseEndpoint,
 		&ProxyOptions{RequestModifiers: []RequestModifier{
 			server.extractUserIDOrgIDFromTokenToURLRequestModifier(ira_server.DisableRuleFeedbackEndpoint),
+			checkRuleIDAndErrorKeyAreValid(),
 		}},
 	)).Methods(http.MethodPost, http.MethodOptions)
 }

--- a/server/request_modifiers.go
+++ b/server/request_modifiers.go
@@ -15,9 +15,11 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 
 	httputils "github.com/RedHatInsights/insights-operator-utils/http"
+	utypes "github.com/RedHatInsights/insights-operator-utils/types"
 	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 	ctypes "github.com/RedHatInsights/insights-results-types"
 )
@@ -27,7 +29,7 @@ import (
 // in the content service
 func checkRuleIDAndErrorKeyAreValid() RequestModifier {
 	return func(request *http.Request) (*http.Request, error) {
-		ruleID, err := httputils.GetRouterParam(request, "rule_id")
+		ruleID, err := httputils.GetRouterParam(request, RuleIDParamName)
 		if err != nil {
 			return nil, err
 		}
@@ -42,7 +44,7 @@ func checkRuleIDAndErrorKeyAreValid() RequestModifier {
 
 		// if valid, perform request to aggregator and return response as usual
 		if err != nil {
-			return nil, err
+			return nil, &utypes.ItemNotFoundError{ItemID: fmt.Sprintf("%s/%s", ruleID, errorKey)}
 		}
 
 		return request, nil

--- a/server/request_modifiers.go
+++ b/server/request_modifiers.go
@@ -1,0 +1,50 @@
+// Copyright 2022  Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+
+	httputils "github.com/RedHatInsights/insights-operator-utils/http"
+	"github.com/RedHatInsights/insights-results-smart-proxy/content"
+	ctypes "github.com/RedHatInsights/insights-results-types"
+)
+
+// checkRuleIDAndErrorKeyAreValid request modifier that only checks if
+// both rule_id and error_key are valid, given the rules and errors defined
+// in the content service
+func checkRuleIDAndErrorKeyAreValid() RequestModifier {
+	return func(request *http.Request) (*http.Request, error) {
+		ruleID, err := httputils.GetRouterParam(request, "rule_id")
+		if err != nil {
+			return nil, err
+		}
+
+		errorKey, err := httputils.GetRouterParam(request, "error_key")
+		if err != nil {
+			return nil, err
+		}
+
+		// Check if rule id and error key are valid ones
+		_, err = content.GetRuleWithErrorKeyContent(ctypes.RuleID(ruleID), ctypes.ErrorKey(errorKey))
+
+		// if valid, perform request to aggregator and return response as usual
+		if err != nil {
+			return nil, err
+		}
+
+		return request, nil
+	}
+}

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -34,10 +34,12 @@ const (
 	GetDisabledParam = "get_disabled"
 	// ImpactingParam parameter used to show/hide recommendations not hitting any clusters
 	ImpactingParam = "impacting"
+	// RuleIDParamName parameter name in the URL
+	RuleIDParamName = "rule_id"
 )
 
 func readRuleIDWithErrorKey(writer http.ResponseWriter, request *http.Request) (ctypes.RuleID, ctypes.ErrorKey, error) {
-	ruleIDWithErrorKey, err := httputils.GetRouterParam(request, "rule_id")
+	ruleIDWithErrorKey, err := httputils.GetRouterParam(request, RuleIDParamName)
 	if err != nil {
 		const message = "unable to get rule id"
 		log.Error().Err(err).Msg(message)
@@ -48,7 +50,7 @@ func readRuleIDWithErrorKey(writer http.ResponseWriter, request *http.Request) (
 	ruleID, errorKey, err := types.RuleIDWithErrorKeyFromCompositeRuleID(ctypes.RuleID(ruleIDWithErrorKey))
 	if err != nil {
 		handleServerError(writer, &RouterParsingError{
-			paramName:  "rule_id",
+			paramName:  RuleIDParamName,
 			paramValue: ruleIDWithErrorKey,
 			errString:  err.Error(),
 		})
@@ -62,7 +64,7 @@ func readCompositeRuleID(request *http.Request) (
 	ruleID ctypes.RuleID,
 	err error,
 ) {
-	ruleIDParam, err := httputils.GetRouterParam(request, "rule_id")
+	ruleIDParam, err := httputils.GetRouterParam(request, RuleIDParamName)
 	if err != nil {
 		const message = "unable to get rule id"
 		log.Error().Err(err).Msg(message)
@@ -75,7 +77,7 @@ func readCompositeRuleID(request *http.Request) (
 	if !isCompositeRuleIDValid {
 		msg := fmt.Errorf("invalid composite rule ID. Must be in the format 'rule.plugin.module|ERROR_KEY'")
 		err = &RouterParsingError{
-			paramName:  "rule_id",
+			paramName:  RuleIDParamName,
 			paramValue: ruleIDParam,
 			errString:  msg.Error(),
 		}

--- a/server/rule_toggle_handlers_test.go
+++ b/server/rule_toggle_handlers_test.go
@@ -20,7 +20,9 @@ import (
 
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
 	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
+	"github.com/stretchr/testify/assert"
 
+	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
 )
@@ -28,6 +30,9 @@ import (
 func TestEnableEndpoint(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
+		defer content.ResetContent()
+		err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+		assert.Nil(t, err)
 		expectedBody := `{"status": "ok"}`
 		helpers.GockExpectAPIRequest(
 			t,
@@ -68,6 +73,9 @@ func TestEnableEndpoint(t *testing.T) {
 func TestDisableEndpoint(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
+		defer content.ResetContent()
+		err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+		assert.Nil(t, err)
 		expectedBody := `{"status": "ok"}`
 		helpers.GockExpectAPIRequest(
 			t,

--- a/server/rule_toggle_handlers_test.go
+++ b/server/rule_toggle_handlers_test.go
@@ -15,6 +15,7 @@
 package server_test
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -106,6 +107,64 @@ func TestDisableEndpoint(t *testing.T) {
 			},
 			&helpers.APIResponse{
 				StatusCode: http.StatusOK,
+				Body:       expectedBody,
+			},
+		)
+
+	}, testTimeout)
+}
+
+func TestEnableEndpointBadErrorKey(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(t testing.TB) {
+		expectedBody := fmt.Sprintf(
+			`{"status":"Item with ID %s/%s was not found in the storage"}`,
+			testdata.Rule1ID,
+			testdata.ErrorKey1,
+		)
+		helpers.AssertAPIRequest(
+			t,
+			&serverConfigJWT,
+			&helpers.DefaultServicesConfig,
+			nil,
+			nil,
+			nil,
+			&helpers.APIRequest{
+				Method:             http.MethodPut,
+				Endpoint:           server.EnableRuleForClusterEndpoint,
+				EndpointArgs:       []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1},
+				AuthorizationToken: goodJWTAuthBearer,
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusNotFound,
+				Body:       expectedBody,
+			},
+		)
+
+	}, testTimeout)
+}
+
+func TestDisableEndpointBadErrorKey(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(t testing.TB) {
+		expectedBody := fmt.Sprintf(
+			`{"status":"Item with ID %s/%s was not found in the storage"}`,
+			testdata.Rule1ID,
+			testdata.ErrorKey1,
+		)
+		helpers.AssertAPIRequest(
+			t,
+			&serverConfigJWT,
+			&helpers.DefaultServicesConfig,
+			nil,
+			nil,
+			nil,
+			&helpers.APIRequest{
+				Method:             http.MethodPut,
+				Endpoint:           server.DisableRuleForClusterEndpoint,
+				EndpointArgs:       []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1},
+				AuthorizationToken: goodJWTAuthBearer,
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusNotFound,
 				Body:       expectedBody,
 			},
 		)

--- a/server/server.go
+++ b/server/server.go
@@ -1163,51 +1163,6 @@ func (server HTTPServer) checkInternalRulePermissions(request *http.Request) err
 	return &AuthenticationError{errString: message}
 }
 
-func (server HTTPServer) newExtractUserIDFromTokenToURLRequestModifier(newEndpoint string) RequestModifier {
-	return func(request *http.Request) (*http.Request, error) {
-		userID, err := server.GetCurrentUserID(request)
-		if err != nil {
-			return nil, err
-		}
-
-		vars := mux.Vars(request)
-		vars["user_id"] = fmt.Sprintf("%v", userID)
-
-		newURL := httputils.MakeURLToEndpointMapString(server.Config.APIv1Prefix, newEndpoint, vars)
-		request.URL, err = url.Parse(newURL)
-		if err != nil {
-			return nil, &ParamsParsingError{}
-		}
-
-		request.RequestURI = request.URL.RequestURI()
-
-		return request, nil
-	}
-}
-
-func (server HTTPServer) extractUserIDOrgIDFromTokenToURLRequestModifier(newEndpoint string) RequestModifier {
-	return func(request *http.Request) (*http.Request, error) {
-		orgID, userID, err := server.GetCurrentOrgIDUserIDFromToken(request)
-		if err != nil {
-			return nil, &ParamsParsingError{}
-		}
-
-		vars := mux.Vars(request)
-		vars["user_id"] = string(userID)
-		vars["org_id"] = fmt.Sprintf("%v", orgID)
-
-		newURL := httputils.MakeURLToEndpointMapString(server.Config.APIv1Prefix, newEndpoint, vars)
-		request.URL, err = url.Parse(newURL)
-		if err != nil {
-			return nil, &ParamsParsingError{}
-		}
-
-		request.RequestURI = request.URL.RequestURI()
-
-		return request, nil
-	}
-}
-
 // getGroupsConfig retrieves the groups configuration from a channel to get the
 // latest valid one
 func (server HTTPServer) getGroupsConfig() (


### PR DESCRIPTION
# Description

With this commits, Smart Proxy will be able to check if the combination of rule ID and error key provided by a customer are present and consistent with the content in the content service.

Now, if some the the enable/disable/voting endpoints are provided with a rule ID + error Key that are not consistent, it will return a 404.

## Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)

## Testing steps
Regular UTs

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
