### PR TITLE
Exclude invalid cluster UUIDs from the AMS API response

### DIFF
--- a/amsclient/amsclient.go
+++ b/amsclient/amsclient.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/uuid"
 	sdk "github.com/openshift-online/ocm-sdk-go"
 	accMgmt "github.com/openshift-online/ocm-sdk-go/accountsmgmt/v1"
 	"github.com/rs/zerolog/log"
@@ -269,6 +270,11 @@ func (c *amsClientImpl) executeSubscriptionListRequest(
 					log.Error().Msgf("No external or internal cluster ID. Cluster [%v]", item)
 				}
 
+				continue
+			}
+
+			if _, err := uuid.Parse(clusterIDstr); err != nil {
+				log.Error().Str(clusterIDTag, clusterIDstr).Msg("Invalid cluster UUID")
 				continue
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.6
 	github.com/RedHatInsights/insights-results-types v1.3.20
 	github.com/golang-jwt/jwt/v4 v4.2.0
+	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
 	github.com/openshift-online/ocm-sdk-go v0.1.238

--- a/server/api/v1/openapi.json
+++ b/server/api/v1/openapi.json
@@ -643,7 +643,7 @@
           },
           {
             "name": "get_disabled",
-            "description": "If true, disabled rules will be sent too.",
+            "description": "If true, only disabled rules will be sent. If false, only enabled rules will be sent. If ommitted, all rules will be sent.",
             "in": "query",
             "schema": {
               "type": "boolean",

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -133,6 +133,16 @@
             },
             "in": "path",
             "required": true
+          },
+          {
+            "name": "get_disabled",
+            "description": "If true, only disabled rules will be sent. If false, only enabled rules will be sent. If ommitted, all rules will be sent.",
+            "in": "query",
+            "schema": {
+              "type": "boolean",
+              "default": false
+            },
+            "required": false
           }
         ],
         "responses": {

--- a/tests/testdata/amstestdata.go
+++ b/tests/testdata/amstestdata.go
@@ -97,6 +97,29 @@ var (
 		},
 	}
 
+	// SubscriptionsResponseInvalidUUID contains a valid response for subscription from AMS, 2 clusters, one with invalid UUID
+	SubscriptionsResponseInvalidUUID map[string]interface{} = map[string]interface{}{
+		"kind":  "SubscriptionList",
+		"page":  1,
+		"size":  2,
+		"total": 2,
+		"items": []map[string]interface{}{
+			{
+				"display_name":        ClusterDisplayName1,
+				"external_cluster_id": ClusterName1,
+				"id":                  "1YfQ9bR7LTDz24YzfFmaCdeB0sS",
+				"managed":             true,
+				"status":              ActiveStatus,
+			},
+			{
+				"display_name":        "",
+				"external_cluster_id": "not-uuid",
+				"id":                  "1YfQLCOCZZOEXgOp8uIbqe5i5z2",
+				"managed":             false,
+				"status":              ActiveStatus,
+			},
+		},
+	}
 	// SubscriptionsResponseEmptyClusterIDs contains a valid response for subscription from AMS, 3 clusters,
 	// but 2 of them are expected to be filtered out, even if they have display name and internal ID,
 	// as they don't have the external_cluster_id


### PR DESCRIPTION
# Description
- for some reason, it's possible to register a cluster in AMS with empty (already covered) or invalid cluster UUID (fixing in this PR), this cause this invalid cluster to appear in the response of the  `/clusters` endpoint)
- fixed OpenAPI problem regarding missing `get_disabled` param blocking tests

Fixes https://issues.redhat.com/browse/CCXDEV-8878 https://issues.redhat.com/browse/CCXDEV-8829 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)

## Testing steps
`make before_commit`

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
