### PR TITLE
Adding possible errors in some of the endpoints related to voting/disabling rules

### DIFF
--- a/server/api/v1/openapi.json
+++ b/server/api/v1/openapi.json
@@ -273,6 +273,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/status"
+          },
+          "400": {
+            "description": "Invalid request, usually caused when some cluster belongs to different organization."
+          },
+          "404": {
+            "description": "Resource not found, usually caused when the rule ID and error key combination doesn't exist in the content service"
           }
         },
         "operationId": "addLikeToRule",
@@ -300,6 +306,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/status"
+          },
+          "400": {
+            "description": "Invalid request, usually caused when some cluster belongs to different organization."
+          },
+          "404": {
+            "description": "Resource not found, usually caused when the rule ID and error key combination doesn't exist in the content service"
           }
         },
         "operationId": "addDislikeToRule",
@@ -327,6 +339,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/status"
+          },
+          "400": {
+            "description": "Invalid request, usually caused when some cluster belongs to different organization."
+          },
+          "404": {
+            "description": "Resource not found, usually caused when the rule ID and error key combination doesn't exist in the content service"
           }
         },
         "operationId": "resetVoteForRule",
@@ -477,6 +495,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/status"
+          },
+          "400": {
+            "description": "Invalid request, usually caused when some cluster belongs to different organization."
+          },
+          "404": {
+            "description": "Resource not found, usually caused when the rule ID and error key combination doesn't exist in the content service"
           }
         },
         "operationId": "disableRule",
@@ -536,6 +560,12 @@
               }
             },
             "description": "Status ok"
+          },
+          "400": {
+            "description": "Invalid request, usually caused when some cluster belongs to different organization."
+          },
+          "404": {
+            "description": "Resource not found, usually caused when the rule ID and error key combination doesn't exist in the content service"
           }
         },
         "operationId": "disableRuleFeedback",
@@ -563,6 +593,12 @@
         "responses": {
           "200": {
             "$ref": "#/components/responses/status" 
+          },
+          "400": {
+            "description": "Invalid request, usually caused when some cluster belongs to different organization."
+          },
+          "404": {
+            "description": "Resource not found, usually caused when the rule ID and error key combination doesn't exist in the content service"
           }
         },
         "operationId": "enableRule",


### PR DESCRIPTION
# Description

The endpoints for voting, resetting votes, enabling and disabling rules in the v1 API miss the possible error values 400 and 404. Adding them to those endpoints.

Fixes #CCXDEV-9359

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Documentation update

## Testing steps

OpenAPI checks locally

## Checklist
* [ ] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
