### PR TITLE
Assign public service apiPath in clowder config

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -48,6 +48,7 @@ objects:
         webServices:
           public:
             enabled: true
+            apiPath: insights-results-aggregator
           private:
             enabled: true
           metrics:


### PR DESCRIPTION
# Description

This explicitly sets a value for `apiPath` in public webservice configuration to `insights-results-aggregator`. The change is requested by the platform team in order to sync frontend and backend apps in ephemeral environments and enable frontend to migrate to containerized builds: https://consoledot.pages.redhat.com/docs/dev/getting-started/frontend-migration.html#_step_0_add_apipath_to_back_end_clowdapp_web_service.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
