### PR TITLE
extend v1/report functionality to differentiate between requests coming from insights-operator

### DIFF
--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -19,6 +19,7 @@ import (
 	"net/http"
 	"regexp"
 	"strconv"
+	"strings"
 
 	httputils "github.com/RedHatInsights/insights-operator-utils/http"
 	ctypes "github.com/RedHatInsights/insights-results-types"
@@ -155,4 +156,19 @@ func readOSDEligible(request *http.Request) (bool, error) {
 // readImpactingParam returns the value of the "impacting" parameter in query if available
 func readImpactingParam(request *http.Request) (bool, error) {
 	return readQueryBoolParam(ImpactingParam, true, request)
+}
+
+// readUserAgentHeaderProduct returns the produt part of the standard User Agent syntax
+// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent#syntax
+func readUserAgentHeaderProduct(request *http.Request) (userAgentProduct string) {
+	userAgent := request.Header.Get(userAgentHeader)
+	if userAgent == "" {
+		return
+	}
+
+	userAgentSplit := strings.Split(userAgent, "/")
+
+	// we're only interested in the product name
+	userAgentProduct = userAgentSplit[0]
+	return
 }


### PR DESCRIPTION
# Description
We were asked to modify the v1/report endpoint to differentiate between requests coming from IO and all other requesters. Any other consumer of this endpoint MUSTN'T be affected by this change. 
 
The reason being is that IO shipped with OCP v4.10 and older still uses this v1 endpoint, whereas in 4.11, IO was updated to use the new v2 endpoint, which already takes managed clusters and rules into account. This creates an inconsistency in the data the customers can see in different places (Web console didn't match Advisor). 

Because this only affects managed clusters and customers cannot simply upgrade their clusters to 4.11, we need to accommodate for this case ourselves.

In theory, we could remove this after all customers are on 4.11 and newer, but we would never know if someone may have installed an older version for some reason, so this ugly hack is probably here to stay....

Fixes https://issues.redhat.com/browse/CCXDEV-9393
https://issues.redhat.com/browse/CCXDEV-9386

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Unit tests (no changes in the code)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
