### PR TITLE
modify cluster_rule_toggle endpoints to get rid of user_id

### DIFF
--- a/server/endpoints_v1.go
+++ b/server/endpoints_v1.go
@@ -178,7 +178,7 @@ func (server *HTTPServer) addV1RuleEndpointsToRouter(router *mux.Router, apiPref
 	router.HandleFunc(apiPrefix+DisableRuleForClusterEndpoint, server.proxyTo(
 		aggregatorBaseEndpoint,
 		&ProxyOptions{RequestModifiers: []RequestModifier{
-			server.extractUserIDOrgIDFromTokenToURLRequestModifier(ira_server.DisableRuleForClusterEndpoint),
+			server.extractOrgIDFromTokenToURLRequestModifier(ira_server.DisableRuleForClusterEndpoint),
 			checkRuleIDAndErrorKeyAreValid(),
 		}},
 	)).Methods(http.MethodPut, http.MethodOptions)
@@ -186,7 +186,7 @@ func (server *HTTPServer) addV1RuleEndpointsToRouter(router *mux.Router, apiPref
 	router.HandleFunc(apiPrefix+EnableRuleForClusterEndpoint, server.proxyTo(
 		aggregatorBaseEndpoint,
 		&ProxyOptions{RequestModifiers: []RequestModifier{
-			server.extractUserIDOrgIDFromTokenToURLRequestModifier(ira_server.EnableRuleForClusterEndpoint),
+			server.extractOrgIDFromTokenToURLRequestModifier(ira_server.EnableRuleForClusterEndpoint),
 			checkRuleIDAndErrorKeyAreValid(),
 		}},
 	)).Methods(http.MethodPut, http.MethodOptions)

--- a/server/rule_toggle_handlers_test.go
+++ b/server/rule_toggle_handlers_test.go
@@ -41,7 +41,7 @@ func TestEnableEndpoint(t *testing.T) {
 			&helpers.APIRequest{
 				Method:       http.MethodPut,
 				Endpoint:     ira_server.EnableRuleForClusterEndpoint,
-				EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, userIDOnGoodJWTAuthBearer},
+				EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID},
 			},
 			&helpers.APIResponse{
 				StatusCode: http.StatusOK,
@@ -84,7 +84,7 @@ func TestDisableEndpoint(t *testing.T) {
 			&helpers.APIRequest{
 				Method:       http.MethodPut,
 				Endpoint:     ira_server.DisableRuleForClusterEndpoint,
-				EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID, userIDOnGoodJWTAuthBearer},
+				EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1, testdata.OrgID},
 			},
 			&helpers.APIResponse{
 				StatusCode: http.StatusOK,


### PR DESCRIPTION
# Description
smart-proxy part for https://github.com/RedHatInsights/insights-results-aggregator/pull/1676
needs version bump of aggregator

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Testing steps
alongisde locally modified aggregator

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
