### PR TITLE
modify endpoints regarding the advisor_ratings table to get rid of user_id

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.4.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20221024073309-fabee4bcb06e
 	github.com/RedHatInsights/insights-operator-utils v1.24.5
-	github.com/RedHatInsights/insights-results-aggregator v1.3.3
+	github.com/RedHatInsights/insights-results-aggregator v1.3.4
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.6
 	github.com/RedHatInsights/insights-results-types v1.3.20
 	github.com/golang-jwt/jwt/v4 v4.2.0

--- a/go.sum
+++ b/go.sum
@@ -93,6 +93,8 @@ github.com/RedHatInsights/insights-results-aggregator v1.3.2 h1:1cP1jrxbsvwcqNBy
 github.com/RedHatInsights/insights-results-aggregator v1.3.2/go.mod h1:mceJE31e1pofOjY9Wkrrxqvw6l1hQCRDNwnkLdnfY1M=
 github.com/RedHatInsights/insights-results-aggregator v1.3.3 h1:hdLmgJc8wmEwNAQ6ZvrUM/6qg9fAhqONqf88HkFjMN8=
 github.com/RedHatInsights/insights-results-aggregator v1.3.3/go.mod h1:mceJE31e1pofOjY9Wkrrxqvw6l1hQCRDNwnkLdnfY1M=
+github.com/RedHatInsights/insights-results-aggregator v1.3.4 h1:co58Suun8+6G8gLm41Ws1K+pifwXs6/LAiRbB/Zir1c=
+github.com/RedHatInsights/insights-results-aggregator v1.3.4/go.mod h1:mceJE31e1pofOjY9Wkrrxqvw6l1hQCRDNwnkLdnfY1M=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -2917,7 +2917,7 @@ func TestHTTPServer_GetRecommendationContentWithUserData(t *testing.T) {
 					&helpers.APIRequest{
 						Method:       http.MethodGet,
 						Endpoint:     ira_server.GetRating,
-						EndpointArgs: []interface{}{testCase.RuleID, testdata.OrgID, userIDOnGoodJWTAuthBearer},
+						EndpointArgs: []interface{}{testCase.RuleID, testdata.OrgID},
 					},
 					&helpers.APIResponse{
 						StatusCode: http.StatusOK,

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -150,7 +150,7 @@ func (server HTTPServer) getRecommendationContent(writer http.ResponseWriter, re
 // getRecommendationContent retrieves the static content for the given ruleID tied
 // with groups info. rule ID is expected to be the composite rule ID (rule.module|ERROR_KEY)
 func (server HTTPServer) getRecommendationContentWithUserData(writer http.ResponseWriter, request *http.Request) {
-	orgID, userID, err := server.GetCurrentOrgIDUserIDFromToken(request)
+	orgID, err := server.GetCurrentOrgID(request)
 	if err != nil {
 		log.Err(err).Msg(orgIDTokenError)
 		handleServerError(writer, err)
@@ -171,7 +171,7 @@ func (server HTTPServer) getRecommendationContentWithUserData(writer http.Respon
 		return
 	}
 
-	rating, err := server.getRatingForRecommendation(writer, orgID, userID, ruleID)
+	rating, err := server.getRatingForRecommendation(writer, orgID, ruleID)
 	if err != nil {
 		switch err.(type) {
 		case *utypes.ItemNotFoundError:

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -49,7 +49,7 @@ func TestHTTPServer_SetRating(t *testing.T) {
 		&helpers.APIRequest{
 			Method:       http.MethodPost,
 			Endpoint:     ira_server.Rating,
-			EndpointArgs: []interface{}{testdata.OrgID, userIDOnGoodJWTAuthBearer},
+			EndpointArgs: []interface{}{testdata.OrgID},
 			Body:         rating,
 		},
 		&helpers.APIResponse{


### PR DESCRIPTION
smart-proxy part for https://github.com/RedHatInsights/insights-results-aggregator/pull/1678

CI will fail again until I bump the aggregator version.


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
alongside aggregator

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
