### PR TITLE
update OpenAPI spec with a new field 'resolution_risk'

### DIFF
--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -870,6 +870,17 @@
                           "description": "Whether the rule has been disabled/acked for all clusters or not.",
                           "type": "boolean",
                           "example": "false"
+                        },
+                        "resolution_risk": {
+                          "description": "Indicates the impact of the resolution steps on the cluster and other associated risks. Behaves in the same way as total_risk, 0 is returned when the rule doesn't have a resolution_risk defined.",
+                          "enum": [
+                            0,
+                            1,
+                            2,
+                            3,
+                            4
+                          ],
+                          "type": "integer"
                         }
                       }
                     },
@@ -1366,6 +1377,17 @@
                 3,
                 4
               ]
+            },
+            "resolution_risk": {
+              "description": "Indicates the impact of the resolution steps on the cluster and other associated risks. Behaves in the same way as total_risk, 0 is returned when the rule doesn't have a resolution_risk defined.",
+              "enum": [
+                0,
+                1,
+                2,
+                3,
+                4
+              ],
+              "type": "integer"
             },
             "tags": {
               "description": "List of tags that the rule contains",


### PR DESCRIPTION
# Description
- with the `resolution_risk` feature in progress, we need to update the OpenAPI spec early for the QE and FE teams. New field added to these endpoints:
  - `/v2/rule/{ruleId}`
  - `/v2/rule`
- the OpenAPI mentions `risk_of_change` in several places, which returns `0` for 25 months :D I've created a [separate task](https://issues.redhat.com/browse/CCXDEV-9654) to get rid of the `risk_of_change` in favour of `resolution_risk` but we need to check with IQE tests whether we can remove it or we need some additional changes to them. So please ignore the obsolete `risk_of_change` for now
- I will not merge this PR until we modify the IQE suite to expect the `resolution_risk`.

Fixes # (issue)

## Type of change

- Documentation update

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
