### PR TITLE
Update OpenAPI specs to reflect report endpoints can return 404

### DIFF
--- a/server/api/v1/openapi.json
+++ b/server/api/v1/openapi.json
@@ -740,6 +740,9 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Resource not found, usually caused when the cluster ID is not registered and request come from Insights Operator."
           }
         },
         "deprecated": false,

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -158,6 +158,9 @@
           },
           "400": {
             "description": "Invalid request, usually caused when some cluster belongs to different organization."
+          },
+          "404": {
+            "description": "Cluster report is not available, probably not connected cluster."
           }
         }
       }


### PR DESCRIPTION
# Description

Update OpenAPI specs for both v1 and v2 in order to show the 404 possible response on cluster report endpoints.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

`make openapi-check` locally

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
