### PR TITLE
mark ocs rules as internal

### DIFF
--- a/content/content_test.go
+++ b/content/content_test.go
@@ -36,6 +36,7 @@ const (
 	testTimeout = 10 * time.Second
 	internalStr = "internal"
 	externalStr = "external"
+	ocsStr      = "ocs"
 )
 
 var (
@@ -542,9 +543,11 @@ func TestGetInternalRuleIDs(t *testing.T) {
 	defer content.ResetContent()
 
 	internalRule1, internalRule2, externalRule1 := testdata.RuleContent1, testdata.RuleContent1, testdata.RuleContent1
+	ocsRule := testdata.RuleContent1
 	fakeRuleAsInternal(&internalRule1)
 	fakeRuleAsInternal(&internalRule2)
 	fakeRuleAsExternal(&externalRule1)
+	fakeRuleAsOcs(&ocsRule)
 
 	ruleContentDirectory := ctypes.RuleContentDirectory{
 		Config: ctypes.GlobalRuleConfig{
@@ -554,6 +557,7 @@ func TestGetInternalRuleIDs(t *testing.T) {
 			"rc1": internalRule1,
 			"rc2": internalRule2,
 			"rc3": externalRule1,
+			"rc4": ocsRule,
 		},
 	}
 
@@ -561,17 +565,20 @@ func TestGetInternalRuleIDs(t *testing.T) {
 
 	internalRuleIDs, err := content.GetInternalRuleIDs()
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(internalRuleIDs))
+	assert.Equal(t, 3, len(internalRuleIDs))
 }
 
 // TestGetExternalRuleIDs tests if storage.externalRuleIDs is filled correctly
 func TestGetExternalRuleIDs(t *testing.T) {
 	defer content.ResetContent()
 
-	externalRule1, externalRule2, externalRule3 := testdata.RuleContent1, testdata.RuleContent1, testdata.RuleContent1
+	externalRule1, externalRule2 := testdata.RuleContent1, testdata.RuleContent1
+	externalRule3, internalRule4, ocsRule := testdata.RuleContent1, testdata.RuleContent1, testdata.RuleContent1
 	fakeRuleAsExternal(&externalRule1)
 	fakeRuleAsExternal(&externalRule2)
 	fakeRuleAsExternal(&externalRule3)
+	fakeRuleAsInternal(&internalRule4)
+	fakeRuleAsOcs(&ocsRule)
 
 	ruleContentDirectory := ctypes.RuleContentDirectory{
 		Config: ctypes.GlobalRuleConfig{
@@ -581,6 +588,8 @@ func TestGetExternalRuleIDs(t *testing.T) {
 			"rc1": externalRule1,
 			"rc2": externalRule2,
 			"rc3": externalRule3,
+			"rc4": internalRule4,
+			"rc5": ocsRule,
 		},
 	}
 
@@ -674,6 +683,9 @@ func fakeRuleAsExternal(ruleContent *ctypes.RuleContent) {
 	modifyPluginPythonModule(ruleContent, externalStr)
 }
 
+func fakeRuleAsOcs(ruleContent *ctypes.RuleContent) {
+	modifyPluginPythonModule(ruleContent, ocsStr)
+}
 func modifyPluginPythonModule(ruleContent *ctypes.RuleContent, injectStr string) {
 	ruleContentCopy := ruleContent
 	ruleContentCopy.Plugin.PythonModule = fmt.Sprintf("testcontent.%v.%v.rule", injectStr, random.Int())

--- a/content/parsing.go
+++ b/content/parsing.go
@@ -26,7 +26,10 @@ import (
 	"github.com/RedHatInsights/insights-results-smart-proxy/types"
 )
 
-const internalRuleStr = "internal"
+const (
+	internalRuleStr = "internal"
+	ocsRuleStr      = "ocs"
+)
 
 var (
 	timeParseFormats = []string{
@@ -173,11 +176,12 @@ func getActiveStatus(status string) (active, success, missing bool) {
 
 // IsRuleInternal tries to look for the word "internal" in the ruleID / rule module,
 // because it's currently not specified anywhere on it's own
-// TODO: add field indicating restricted/internal status to one of Rule structs in content-service
 func IsRuleInternal(ruleID ctypes.RuleID) bool {
 	splitRuleID := strings.Split(string(ruleID), ".")
 	for _, ruleIDPart := range splitRuleID {
-		if ruleIDPart == internalRuleStr {
+		if ruleIDPart == internalRuleStr ||
+			ruleIDPart == ocsRuleStr {
+
 			return true
 		}
 	}


### PR DESCRIPTION
# Description

we need to mark ocs as internal, so they will be send only to appropriate end point once we start parsing

Fixes CCXDEV-9984

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
- n/a

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
