### PR TITLE
fix external.ocs rules

### DIFF
--- a/content/parsing.go
+++ b/content/parsing.go
@@ -170,12 +170,7 @@ func getActiveStatus(status string) (active, success, missing bool) {
 // because it's currently not specified anywhere on it's own
 func IsRuleInternal(ruleID ctypes.RuleID) bool {
 	splitRuleID := strings.Split(string(ruleID), ".")
-	for _, ruleIDPart := range splitRuleID {
-		if ruleIDPart == internalRuleStr ||
-			ruleIDPart == ocsRuleStr {
-
-			return true
-		}
-	}
-	return false
+	return len(splitRuleID) > 1 &&
+		(splitRuleID[1] == internalRuleStr ||
+			splitRuleID[1] == ocsRuleStr)
 }

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -1822,7 +1822,7 @@ func TestRuleNamesResponse(t *testing.T) {
 
 	expectedBody := `
 		{
-			"rules": ["ccx_rules_ocp.external.rules.node_installer_degraded", "foo.rules.internal.bar"],
+			"rules": ["ccx_rules_ocp.external.rules.node_installer_degraded", "ccx_ocp_rules.internal.bar"],
 			"status": "ok"
 		}
 	`

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -40,7 +40,7 @@ import (
 
 const (
 	testTimeout            = 10 * time.Second
-	internalTestRuleModule = "foo.rules.internal.bar"
+	internalTestRuleModule = "ccx_ocp_rules.internal.bar"
 	internalRuleID         = internalTestRuleModule + "|" + testdata.ErrorKey1
 )
 


### PR DESCRIPTION
# Description

fix for external.ocs rules that were discarded by previous checks

rule Id looks like so
`ocp_rules.internal.other_stuff`
`ocp_rules.external.other_stuff`
`ocp_rules.ocs.other_stuff`
and we check for "internal" and "ocs" HOWEVER a few rules looks like so
`ocp_rules.external.ocs.other_stuff`, so we can't just look for "ocs" , it has to be at the first index

Fixes CCXDEV-100025

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
na

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
