### PR TITLE
Use correct endpoint from data engineering

### DIFF
--- a/server/upgrade_risks_prediction.go
+++ b/server/upgrade_risks_prediction.go
@@ -29,7 +29,7 @@ import (
 )
 
 // UpgradeRisksPredictionServiceEndpoint endpoint for the upgrade prediction service
-const UpgradeRisksPredictionServiceEndpoint = "upgrade-risks-prediction/cluster/{cluster}"
+const UpgradeRisksPredictionServiceEndpoint = "cluster/{cluster}/upgrade-risks-prediction"
 
 // method upgradeRisksPrediction returns a recommendation to upgrade or not a cluster
 // and a list of the alerts/operator conditions that were taken into account if the

--- a/server/upgrade_risks_prediction_test.go
+++ b/server/upgrade_risks_prediction_test.go
@@ -97,7 +97,7 @@ func TestHTTPServer_GetUpgradeRisksPrediction(t *testing.T) {
 			helpers.DefaultServicesConfig.UpgradeRisksPredictionEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "upgrade-risks-prediction/cluster/{clusterId}",
+				Endpoint:     "cluster/{clusterId}/upgrade-risks-prediction",
 				EndpointArgs: []interface{}{cluster},
 			}, &helpers.APIResponse{
 				StatusCode: http.StatusOK,
@@ -168,7 +168,7 @@ func TestHTTPServer_GetUpgradeRisksPredictionNotRecommended(t *testing.T) {
 			helpers.DefaultServicesConfig.UpgradeRisksPredictionEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "upgrade-risks-prediction/cluster/{clusterId}",
+				Endpoint:     "cluster/{clusterId}/upgrade-risks-prediction",
 				EndpointArgs: []interface{}{cluster},
 			}, &helpers.APIResponse{
 				StatusCode: http.StatusOK,
@@ -264,7 +264,7 @@ func TestHTTPServer_GetUpgradeRisksPredictionNotFound(t *testing.T) {
 			helpers.DefaultServicesConfig.UpgradeRisksPredictionEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "upgrade-risks-prediction/cluster/{clusterId}",
+				Endpoint:     "cluster/{clusterId}/upgrade-risks-prediction",
 				EndpointArgs: []interface{}{cluster},
 			}, &helpers.APIResponse{
 				StatusCode: http.StatusNotFound,
@@ -306,7 +306,7 @@ func TestHTTPServer_GetUpgradeRisksPredictionInvalidResponse(t *testing.T) {
 			helpers.DefaultServicesConfig.UpgradeRisksPredictionEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "upgrade-risks-prediction/cluster/{clusterId}",
+				Endpoint:     "cluster/{clusterId}/upgrade-risks-prediction",
 				EndpointArgs: []interface{}{cluster},
 			}, &helpers.APIResponse{
 				StatusCode: http.StatusOK,


### PR DESCRIPTION
# Description

Use the new endpoint for the data engineering service

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Unit tests run locally

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
