### PR TITLE
Fix URL for data eng service

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -235,7 +235,7 @@ parameters:
 - name: INSIGHTS_CONTENT_SERVICE_URL
   value: "http://ccx-insights-content-service:10000/api/v1/"
 - name: INSIGHTS_DATA_ENGINEERING_URL
-  value: "http://ccx-upgrades-data-eng:8000/"
+  value: "http://ccx-upgrades-data-eng-svc:8000/"
 - name: INSIGHTS_CONTENT_SERVICE_POLL_TIME
   value: "60s"
 - name: IRSP_API_DBG_PREFIX


### PR DESCRIPTION
# Description

Wrong URL for the data engineering service was set as default

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Configuration update

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
