### PR TITLE
fix issues in acknowledge endpoints, add UT coverage for all endpoints

### DIFF
--- a/server/acks_handlers.go
+++ b/server/acks_handlers.go
@@ -365,7 +365,8 @@ func (server *HTTPServer) deleteAcknowledge(writer http.ResponseWriter, request 
 	_, found, err := server.readRuleDisableStatus(types.Component(ruleID), errorKey, orgID)
 	if err != nil {
 		log.Error().Err(err).Msg(readRuleStatusError)
-		http.Error(writer, err.Error(), http.StatusBadRequest)
+		err := errors.New("Problem retrieving response from aggregator endpoint")
+		handleServerError(writer, err)
 		return
 	}
 
@@ -381,7 +382,8 @@ func (server *HTTPServer) deleteAcknowledge(writer http.ResponseWriter, request 
 	err = server.deleteAckRuleSystemWide(types.Component(ruleID), errorKey, orgID)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to delete rule acknowledgement")
-		http.Error(writer, err.Error(), http.StatusBadRequest)
+		err := errors.New("Problem retrieving response from aggregator endpoint")
+		handleServerError(writer, err)
 		return
 	}
 

--- a/server/acks_handlers.go
+++ b/server/acks_handlers.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/RedHatInsights/insights-operator-utils/generators"
@@ -125,7 +126,8 @@ func (server *HTTPServer) getAcknowledge(writer http.ResponseWriter, request *ht
 	ruleAck, found, err := server.readRuleDisableStatus(types.Component(ruleID), errorKey, orgID)
 	if err != nil {
 		log.Error().Err(err).Msg(readRuleStatusError)
-		http.Error(writer, err.Error(), http.StatusBadRequest)
+		err = errors.New("Problem retrieving response from aggregator endpoint")
+		handleServerError(writer, err)
 		return
 	}
 

--- a/server/acks_handlers.go
+++ b/server/acks_handlers.go
@@ -44,12 +44,6 @@ const (
 //   "meta": {
 //     "count": 0
 //   },
-//   "links": {
-//     "first": "string",
-//     "previous": "string",
-//     "next": "string",
-//     "last": "string"
-//   },
 //   "data": [
 //     {
 //       "rule": "string",
@@ -60,9 +54,6 @@ const (
 //     }
 //   ]
 // }
-//
-// Please note that for the sake of simplicity we don't use links section as
-// pagination is not supported ATM.
 func (server *HTTPServer) readAckList(writer http.ResponseWriter, request *http.Request) {
 	orgID, err := server.GetCurrentOrgID(request)
 	if err != nil {
@@ -74,7 +65,7 @@ func (server *HTTPServer) readAckList(writer http.ResponseWriter, request *http.
 	acks, err := server.readListOfAckedRules(orgID)
 	if err != nil {
 		log.Error().Err(err).Msg(ackedRulesError)
-		// server error has been handled already
+		handleServerError(writer, err)
 		return
 	}
 

--- a/server/acks_handlers.go
+++ b/server/acks_handlers.go
@@ -36,6 +36,7 @@ const (
 	improperRuleSelectorFormat = "improper rule selector format"
 	readRuleStatusError        = "read rule status error"
 	readRuleJustificationError = "can not retrieve rule disable justification from Aggregator"
+	aggregatorResponseError    = "Problem retrieving response from aggregator endpoint"
 )
 
 // method readAckList list acks from this account where the rule is active.
@@ -127,7 +128,7 @@ func (server *HTTPServer) getAcknowledge(writer http.ResponseWriter, request *ht
 	ruleAck, found, err := server.readRuleDisableStatus(types.Component(ruleID), errorKey, orgID)
 	if err != nil {
 		log.Error().Err(err).Msg(readRuleStatusError)
-		err = errors.New("Problem retrieving response from aggregator endpoint")
+		err = errors.New(aggregatorResponseError)
 		handleServerError(writer, err)
 		return
 	}
@@ -209,7 +210,7 @@ func (server *HTTPServer) acknowledgePost(writer http.ResponseWriter, request *h
 	_, previouslyAcked, err := server.readRuleDisableStatus(ruleID, errorKey, orgID)
 	if err != nil {
 		log.Error().Err(err).Msg(readRuleStatusError)
-		err = errors.New("Problem retrieving response from aggregator endpoint")
+		err = errors.New(aggregatorResponseError)
 		handleServerError(writer, err)
 		return
 	}
@@ -235,7 +236,7 @@ func (server *HTTPServer) acknowledgePost(writer http.ResponseWriter, request *h
 	updatedAcknowledgement, _, err := server.readRuleDisableStatus(ruleID, errorKey, orgID)
 	if err != nil {
 		log.Error().Err(err).Msg(readRuleJustificationError)
-		err := errors.New("Problem retrieving response from aggregator endpoint")
+		err := errors.New(aggregatorResponseError)
 		handleServerError(writer, err)
 		return
 	}
@@ -303,7 +304,7 @@ func (server *HTTPServer) updateAcknowledge(writer http.ResponseWriter, request 
 	_, found, err := server.readRuleDisableStatus(types.Component(ruleID), errorKey, orgID)
 	if err != nil {
 		log.Error().Err(err).Msg(readRuleStatusError)
-		err := errors.New("Problem retrieving response from aggregator endpoint")
+		err := errors.New(aggregatorResponseError)
 		handleServerError(writer, err)
 		return
 	}
@@ -320,7 +321,7 @@ func (server *HTTPServer) updateAcknowledge(writer http.ResponseWriter, request 
 	err = server.updateAckRuleSystemWide(types.Component(ruleID), errorKey, orgID, parameters.Value)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to update justification for rule acknowledgement")
-		err := errors.New("Problem retrieving response from aggregator endpoint")
+		err := errors.New(aggregatorResponseError)
 		handleServerError(writer, err)
 		return
 	}
@@ -330,7 +331,7 @@ func (server *HTTPServer) updateAcknowledge(writer http.ResponseWriter, request 
 	updatedAcknowledgement, _, err := server.readRuleDisableStatus(types.Component(ruleID), errorKey, orgID)
 	if err != nil {
 		log.Error().Err(err).Msg(readRuleJustificationError)
-		err := errors.New("Problem retrieving response from aggregator endpoint")
+		err := errors.New(aggregatorResponseError)
 		handleServerError(writer, err)
 		return
 	}
@@ -365,7 +366,7 @@ func (server *HTTPServer) deleteAcknowledge(writer http.ResponseWriter, request 
 	_, found, err := server.readRuleDisableStatus(types.Component(ruleID), errorKey, orgID)
 	if err != nil {
 		log.Error().Err(err).Msg(readRuleStatusError)
-		err := errors.New("Problem retrieving response from aggregator endpoint")
+		err := errors.New(aggregatorResponseError)
 		handleServerError(writer, err)
 		return
 	}
@@ -382,7 +383,7 @@ func (server *HTTPServer) deleteAcknowledge(writer http.ResponseWriter, request 
 	err = server.deleteAckRuleSystemWide(types.Component(ruleID), errorKey, orgID)
 	if err != nil {
 		log.Error().Err(err).Msg("Unable to delete rule acknowledgement")
-		err := errors.New("Problem retrieving response from aggregator endpoint")
+		err := errors.New(aggregatorResponseError)
 		handleServerError(writer, err)
 		return
 	}

--- a/server/acks_test.go
+++ b/server/acks_test.go
@@ -1244,6 +1244,7 @@ func TestHTTPServer_TestAcknowledgeUpdateBadCompositeRuleID(t *testing.T) {
 		"justification": "%v"
 	}
 	`
+
 	reqBody = fmt.Sprintf(reqBody, justificationNote)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{

--- a/server/acks_test.go
+++ b/server/acks_test.go
@@ -853,7 +853,7 @@ func TestHTTPServer_TestAcknowledgePostMissingParam(t *testing.T) {
 		"justification": "%v"
 	}
 	`
-	reqBody = fmt.Sprintf(reqBody, testdata.Rule1CompositeID, justificationNote)
+	reqBody = fmt.Sprintf(reqBody, justificationNote)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
 		Method:             http.MethodPost,
@@ -880,7 +880,7 @@ func TestHTTPServer_TestAcknowledgePostBadCompositeRuleID(t *testing.T) {
 		"justification": "%v"
 	}
 	`
-	reqBody = fmt.Sprintf(reqBody, testdata.Rule1CompositeID, justificationNote)
+	reqBody = fmt.Sprintf(reqBody, justificationNote)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
 		Method:             http.MethodPost,
@@ -1080,7 +1080,7 @@ func TestHTTPServer_TestAcknowledgeUpdateNotFound(t *testing.T) {
 		"justification": "%v"
 	}
 	`
-	reqBody = fmt.Sprintf(reqBody, testdata.Rule1CompositeID, justificationNote)
+	reqBody = fmt.Sprintf(reqBody, justificationNote)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
 		Method:             http.MethodPut,
@@ -1244,7 +1244,7 @@ func TestHTTPServer_TestAcknowledgeUpdateBadCompositeRuleID(t *testing.T) {
 		"justification": "%v"
 	}
 	`
-	reqBody = fmt.Sprintf(reqBody, testdata.Rule1CompositeID, justificationNote)
+	reqBody = fmt.Sprintf(reqBody, justificationNote)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
 		Method:             http.MethodPut,

--- a/server/acks_test.go
+++ b/server/acks_test.go
@@ -1,0 +1,362 @@
+// Copyright 2023 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//deleteAcknowledge
+
+//generateRuleAckMap
+
+package server_test
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
+	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/RedHatInsights/insights-results-smart-proxy/content"
+	"github.com/RedHatInsights/insights-results-smart-proxy/server"
+	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
+)
+
+func TestHTTPServer_TestReadAckListNoResult(t *testing.T) {
+	defer helpers.CleanAfterGock(t)
+	defer content.ResetContent()
+
+	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+	assert.Nil(t, err)
+
+	ackedRulesAggregatorResponse := `
+	{
+		"disabledRules":[],
+		"status":"ok"
+	}
+	`
+
+	helpers.GockExpectAPIRequest(
+		t,
+		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+		&helpers.APIRequest{
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ListOfDisabledRulesSystemWide,
+			EndpointArgs: []interface{}{testdata.OrgID},
+		},
+		&helpers.APIResponse{
+			StatusCode: http.StatusOK,
+			Body:       ackedRulesAggregatorResponse,
+		},
+	)
+
+	ackListResponse := `
+	{
+		"data":[],
+		"meta": {
+			"count": 0
+		}
+	}
+	`
+	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
+		Method:             http.MethodGet,
+		Endpoint:           server.AckListEndpoint,
+		AuthorizationToken: goodJWTAuthBearer,
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusOK,
+		Body:       ackListResponse,
+	})
+}
+
+func TestHTTPServer_TestReadAckList1Result(t *testing.T) {
+	defer helpers.CleanAfterGock(t)
+	defer content.ResetContent()
+
+	disabledAt := time.Now()
+	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
+	justificationNote := "justification test"
+
+	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+	assert.Nil(t, err)
+
+	ackedRulesAggregatorResponse := `
+	{
+		"disabledRules":[
+			{
+				"rule_id": "%v",
+				"error_key": "%v",
+				"justification": "%v",
+				"created_at": {
+					"Time": "%v",
+					"Valid": true
+				},
+				"updated_at": {
+					"Time": "%v",
+					"Valid": true
+				}
+			}
+		],
+		"status":"ok"
+	}
+	`
+	ackedRulesAggregatorResponse = fmt.Sprintf(
+		ackedRulesAggregatorResponse, testdata.Rule1ID, testdata.ErrorKey1, justificationNote, disabledAtRFC, disabledAtRFC,
+	)
+	helpers.GockExpectAPIRequest(
+		t,
+		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+		&helpers.APIRequest{
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ListOfDisabledRulesSystemWide,
+			EndpointArgs: []interface{}{testdata.OrgID},
+		},
+		&helpers.APIResponse{
+			StatusCode: http.StatusOK,
+			Body:       ackedRulesAggregatorResponse,
+		},
+	)
+
+	ackListResponse := `
+	{
+		"data":[
+			{
+				"rule": "%v",
+				"justification": "%v",
+				"created_by": "",
+				"created_at": "%v",
+				"updated_at": "%v"
+			}
+		],
+		"meta": {
+			"count": 1
+		}
+	}
+	`
+	ackListResponse = fmt.Sprintf(ackListResponse, testdata.Rule1CompositeID, justificationNote, disabledAtRFC, disabledAtRFC)
+
+	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
+		Method:             http.MethodGet,
+		Endpoint:           server.AckListEndpoint,
+		AuthorizationToken: goodJWTAuthBearer,
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusOK,
+		Body:       ackListResponse,
+	})
+}
+
+func TestHTTPServer_TestReadAckList2Results(t *testing.T) {
+	defer helpers.CleanAfterGock(t)
+	defer content.ResetContent()
+
+	disabledAt := time.Now()
+	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
+	justificationNote := "justification test"
+	justificationNote2 := "different justification"
+
+	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+	assert.Nil(t, err)
+
+	ackedRulesAggregatorResponse := `
+	{
+		"disabledRules":[
+			{
+				"rule_id": "%v",
+				"error_key": "%v",
+				"justification": "%v",
+				"created_at": {
+					"Time": "%v",
+					"Valid": true
+				},
+				"updated_at": {
+					"Time": "%v",
+					"Valid": true
+				}
+			},
+			{
+				"rule_id": "%v",
+				"error_key": "%v",
+				"justification": "%v",
+				"created_at": {
+					"Time": "%v",
+					"Valid": true
+				},
+				"updated_at": {
+					"Time": "%v",
+					"Valid": true
+				}
+			}
+		],
+		"status":"ok"
+	}
+	`
+	ackedRulesAggregatorResponse = fmt.Sprintf(ackedRulesAggregatorResponse,
+		testdata.Rule1ID, testdata.ErrorKey1, justificationNote, disabledAtRFC, disabledAtRFC,
+		// 2nd entry
+		testdata.Rule2ID, testdata.ErrorKey2, justificationNote2, disabledAtRFC, disabledAtRFC,
+	)
+	helpers.GockExpectAPIRequest(
+		t,
+		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+		&helpers.APIRequest{
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ListOfDisabledRulesSystemWide,
+			EndpointArgs: []interface{}{testdata.OrgID},
+		},
+		&helpers.APIResponse{
+			StatusCode: http.StatusOK,
+			Body:       ackedRulesAggregatorResponse,
+		},
+	)
+
+	ackListResponse := `
+	{
+		"data":[
+			{
+				"rule": "%v",
+				"justification": "%v",
+				"created_by": "",
+				"created_at": "%v",
+				"updated_at": "%v"
+			},
+			{
+				"rule": "%v",
+				"justification": "%v",
+				"created_by": "",
+				"created_at": "%v",
+				"updated_at": "%v"
+			}
+		],
+		"meta": {
+			"count": 2
+		}
+	}
+	`
+	ackListResponse = fmt.Sprintf(ackListResponse,
+		testdata.Rule1CompositeID, justificationNote, disabledAtRFC, disabledAtRFC,
+		testdata.Rule2CompositeID, justificationNote2, disabledAtRFC, disabledAtRFC,
+	)
+
+	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
+		Method:             http.MethodGet,
+		Endpoint:           server.AckListEndpoint,
+		AuthorizationToken: goodJWTAuthBearer,
+	}, &helpers.APIResponse{
+		StatusCode:  http.StatusOK,
+		Body:        ackListResponse,
+		BodyChecker: ackInResponseChecker,
+	})
+}
+
+func TestHTTPServer_TestReadAckListInvalidToken(t *testing.T) {
+	defer helpers.CleanAfterGock(t)
+	defer content.ResetContent()
+
+	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+	assert.Nil(t, err)
+
+	ackedRulesAggregatorResponse := `
+	{
+		"disabledRules":[],
+		"status":"ok"
+	}
+	`
+
+	helpers.GockExpectAPIRequest(
+		t,
+		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+		&helpers.APIRequest{
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ListOfDisabledRulesSystemWide,
+			EndpointArgs: []interface{}{testdata.OrgID},
+		},
+		&helpers.APIResponse{
+			StatusCode: http.StatusOK,
+			Body:       ackedRulesAggregatorResponse,
+		},
+	)
+
+	ackListResponse := `
+	{
+		"status": "Malformed authentication token"
+	}
+	`
+	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
+		Method:             http.MethodGet,
+		Endpoint:           server.AckListEndpoint,
+		AuthorizationToken: badJWTAuthBearer,
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusForbidden,
+		Body:       ackListResponse,
+	})
+}
+
+func TestHTTPServer_TestReadAckListAggregatorError(t *testing.T) {
+	defer helpers.CleanAfterGock(t)
+	defer content.ResetContent()
+
+	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+	assert.Nil(t, err)
+
+	helpers.GockExpectAPIRequest(
+		t,
+		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+		&helpers.APIRequest{
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ListOfDisabledRulesSystemWide,
+			EndpointArgs: []interface{}{testdata.OrgID},
+		},
+		&helpers.APIResponse{
+			StatusCode: http.StatusInternalServerError,
+		},
+	)
+
+	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
+		Method:             http.MethodGet,
+		Endpoint:           server.AckListEndpoint,
+		AuthorizationToken: goodJWTAuthBearer,
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusInternalServerError,
+	})
+}
+
+func TestHTTPServer_TestReadAckListUnparsableAggregatorJSON(t *testing.T) {
+	defer helpers.CleanAfterGock(t)
+	defer content.ResetContent()
+
+	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
+	assert.Nil(t, err)
+
+	helpers.GockExpectAPIRequest(
+		t,
+		helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+		&helpers.APIRequest{
+			Method:       http.MethodGet,
+			Endpoint:     ira_server.ListOfDisabledRulesSystemWide,
+			EndpointArgs: []interface{}{testdata.OrgID},
+		},
+		&helpers.APIResponse{
+			StatusCode: http.StatusOK,
+			Body:       "{invalid json body",
+		},
+	)
+
+	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
+		Method:             http.MethodGet,
+		Endpoint:           server.AckListEndpoint,
+		AuthorizationToken: goodJWTAuthBearer,
+	}, &helpers.APIResponse{
+		// also 500, but testing different condition
+		StatusCode: http.StatusInternalServerError,
+	})
+}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1419,6 +1419,23 @@ func clusterInResponseChecker(t testing.TB, expected, got []byte) {
 	assert.ElementsMatch(t, expectedResp.Clusters, gotResp.Clusters)
 }
 
+func ackInResponseChecker(t testing.TB, expected, got []byte) {
+	var expectedResp, gotResp ctypes.AcknowledgementsResponse
+
+	if err := json.Unmarshal(expected, &expectedResp); err != nil {
+		err = fmt.Errorf(`"expected" is not JSON. value = "%v", err = "%v"`, expected, err)
+		helpers.FailOnError(t, err)
+	}
+
+	if err := json.Unmarshal(got, &gotResp); err != nil {
+		err = fmt.Errorf(`"got" is not JSON. value = "%v", err = "%v"`, got, err)
+		helpers.FailOnError(t, err)
+	}
+
+	assert.ElementsMatch(t, expectedResp.Data, gotResp.Data)
+	assert.Equal(t, expectedResp.Metadata.Count, gotResp.Metadata.Count)
+}
+
 func TestFillImpacted(t *testing.T) {
 	var response []types.RuleWithContentResponse
 	var aggregatorReport []ctypes.RuleOnReport


### PR DESCRIPTION
# Description
- fixes several issues with acknowledge endpoints (some of them stem from us attempting to copy the RHEL Advisor API, some don't), more info in respective JIRA issues
- I checked with Advisor folks that nothing will break by changing the error responses (they're not checked)
- adds unit test coverage for all acknowledge endpoints. Coverage is quite high (83% and 85% for handlers and utils, previously was 4% and 23% respectively)
- I created a few tasks for the issue fixing as I spent some time figuring out the issues and the reasoning behind them

JIRA:
[1](https://issues.redhat.com/browse/CCXDEV-10337), [2](https://issues.redhat.com/browse/CCXDEV-10338), [3](https://issues.redhat.com/browse/CCXDEV-10339), [4](https://issues.redhat.com/browse/CCXDEV-10340), [UTs](https://issues.redhat.com/browse/CCXDEV-6745)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)
- REST API tests

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
