### PR TITLE
Expose AMS client token so it can be overwritten by tests in ephemeral

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -135,6 +135,8 @@ objects:
                   optional: true
             - name: INSIGHTS_RESULTS_SMART_PROXY__AMSCLIENT__PAGE_SIZE
               value: ${AMS_API_PAGESIZE}
+            - name: INSIGHTS_RESULTS_SMART_PROXY__AMSCLIENT__TOKEN
+              value: ${AMS_TOKEN}
           image: ${IMAGE}:${IMAGE_TAG}
           livenessProbe:
             failureThreshold: 3
@@ -263,3 +265,5 @@ parameters:
   value: "10000"
 - name: ORG_CLUSTERS_FALLBACK
   value: "false"
+- name: AMS_TOKEN
+  value: ""


### PR DESCRIPTION
# Description

Testing in ephemeral with a mock instance of AMS requires a valid auth mechanism. Thus, it requires a valid client and secret or a token. Token is used by tests, and given that the goal is to enable ephemeral testing, we follow the same approach.

It is set as an env. var. instead of a secret to make it easier to set it via `bonfire` command flags and thus not requiring deploying a new secret and restarting the service.

## Type of change

- Configuration update

## Testing steps

None

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
