### PR TITLE
Setting AMS token from secret

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -136,7 +136,11 @@ objects:
             - name: INSIGHTS_RESULTS_SMART_PROXY__AMSCLIENT__PAGE_SIZE
               value: ${AMS_API_PAGESIZE}
             - name: INSIGHTS_RESULTS_SMART_PROXY__AMSCLIENT__TOKEN
-              value: ${AMS_TOKEN}
+              valueFrom:
+                secretKeyRef:
+                  name: ams-client-auth
+                  key: amsclient_token
+                  optional: true
           image: ${IMAGE}:${IMAGE_TAG}
           livenessProbe:
             failureThreshold: 3
@@ -265,5 +269,3 @@ parameters:
   value: "10000"
 - name: ORG_CLUSTERS_FALLBACK
   value: "false"
-- name: AMS_TOKEN
-  value: ""


### PR DESCRIPTION
# Description

Setting the AMS client TOKEN to be read from the same secret that might have client ID and secret

## Type of change

- Configuration update

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
