### PR TITLE
Pass large rule struct by reference

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Red Hat, Inc
+// Copyright 2020, 2021, 2022, 2023 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -147,12 +147,12 @@ func (s *RulesWithContentStorage) SetRuleWithContent(
 
 // SetRule sets content for rule
 func (s *RulesWithContentStorage) SetRule(
-	ruleID ctypes.RuleID, ruleContent ctypes.RuleContent,
+	ruleID ctypes.RuleID, ruleContent *ctypes.RuleContent,
 ) {
 	s.Lock()
 	defer s.Unlock()
 
-	s.rules[ruleID] = &ruleContent
+	s.rules[ruleID] = ruleContent
 }
 
 // ResetContent clear all the contents
@@ -495,7 +495,7 @@ func UpdateContent(servicesConf services.Configuration) {
 //   - Structure with rules and content
 //   - return true if the rule has been filtered by OSDElegible field. False otherwise
 //   - return error if the one occurred during retrieval
-func FetchRuleContent(rule ctypes.RuleOnReport, OSDEligible bool) (
+func FetchRuleContent(rule *ctypes.RuleOnReport, OSDEligible bool) (
 	ruleWithContentResponse *types.RuleWithContentResponse,
 	osdFiltered bool,
 	err error,

--- a/content/content_test.go
+++ b/content/content_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020, 2021, 2022 Red Hat, Inc
+// Copyright 2020, 2021, 2022, 2023 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -241,7 +241,7 @@ func TestFetchRuleContent_OSDEligibleNotRequiredAdmin(t *testing.T) {
 		content.UpdateContent(helpers.DefaultServicesConfig)
 
 		rule := testdata.RuleOnReport1
-		ruleContent, osdFiltered, err := content.FetchRuleContent(rule, true)
+		ruleContent, osdFiltered, err := content.FetchRuleContent(&rule, true)
 		assert.False(t, osdFiltered)
 		assert.NotNil(t, ruleContent)
 		assert.Nil(t, err)
@@ -288,7 +288,7 @@ func TestFetchRuleContent_NotOSDEligible(t *testing.T) {
 		content.UpdateContent(helpers.DefaultServicesConfig)
 
 		rule := testdata.RuleOnReport1
-		ruleContent, osdFiltered, err := content.FetchRuleContent(rule, false)
+		ruleContent, osdFiltered, err := content.FetchRuleContent(&rule, false)
 		assert.False(t, osdFiltered)
 		assert.NotNil(t, ruleContent)
 		assert.Nil(t, err)
@@ -344,7 +344,7 @@ func TestFetchRuleContent_DisabledRuleExist(t *testing.T) {
 			TemplateData:    testdata.Rule1ExtraData,
 		}
 
-		ruleContent, osdFiltered, err := content.FetchRuleContent(rule, false)
+		ruleContent, osdFiltered, err := content.FetchRuleContent(&rule, false)
 		assert.False(t, osdFiltered)
 		assert.NotNil(t, ruleContent)
 		assert.Nil(t, err)
@@ -376,7 +376,7 @@ func TestFetchRuleContent_RuleDoesNotExist(t *testing.T) {
 			TemplateData:    nil,
 		}
 
-		ruleContent, _, err := content.FetchRuleContent(rule, false)
+		ruleContent, _, err := content.FetchRuleContent(&rule, false)
 		assert.Nil(t, ruleContent)
 		assert.NotNil(t, err)
 

--- a/content/parsing.go
+++ b/content/parsing.go
@@ -74,7 +74,7 @@ func LoadRuleContent(contentDir *ctypes.RuleContentDirectory) {
 				ruleTmp.ErrorKeys[errorKey] = ruleTmpErrorKey
 			}
 			// sets "plugin" level, containing usual fields + list of error keys
-			rulesWithContentStorage.SetRule(ruleID, ruleTmp)
+			rulesWithContentStorage.SetRule(ruleID, &ruleTmp)
 
 			rulesWithContentStorage.SetRuleWithContent(ruleID, ctypes.ErrorKey(errorKey), &types.RuleWithContent{
 				Module:         ruleID,

--- a/server/server.go
+++ b/server/server.go
@@ -1291,7 +1291,8 @@ func filterRulesInResponse(aggregatorReport []ctypes.RuleOnReport, filterOSD, ge
 	okRules = []types.RuleWithContentResponse{}
 	disabledRulesCnt, noContentRulesCnt = 0, 0
 
-	for _, aggregatorRule := range aggregatorReport {
+	for i := range aggregatorReport {
+		aggregatorRule := aggregatorReport[i]
 		if !getDisabled && isDisabledRule(aggregatorRule, systemWideDisabledRules) {
 			log.Info().Msgf("disabled rule ID %v|%v", aggregatorRule.Module, aggregatorRule.ErrorKey)
 			disabledRulesCnt++

--- a/server/server.go
+++ b/server/server.go
@@ -1151,7 +1151,7 @@ func (server HTTPServer) singleRuleEndpoint(writer http.ResponseWriter, request 
 	if err != nil {
 		log.Err(err).Msgf("Got error while parsing `%s` value", OSDEligibleParam)
 	}
-	rule, filtered, err = content.FetchRuleContent(*aggregatorResponse, osdFlag)
+	rule, filtered, err = content.FetchRuleContent(aggregatorResponse, osdFlag)
 
 	if err != nil || filtered {
 		handleFetchRuleContentError(writer, err, filtered)
@@ -1298,7 +1298,7 @@ func filterRulesInResponse(aggregatorReport []ctypes.RuleOnReport, filterOSD, ge
 			continue
 		}
 
-		rule, filtered, err := content.FetchRuleContent(aggregatorRule, filterOSD)
+		rule, filtered, err := content.FetchRuleContent(&aggregatorRule, filterOSD)
 		if err != nil {
 			if !filtered {
 				// rule has not been filtered by OSDEligible field


### PR DESCRIPTION
# Description

Pass large rule struct by reference:

- ruleContent is heavy (153 bytes); pass it by pointer
- rule is heavy too (112 bytes); pass it by pointer

## Type of change

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

To be checked on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
