### PR TITLE
implement `clusters/{cluster}/request/{request_id}/status` endpoint

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/BurntSushi/toml v1.2.1
 	github.com/RedHatInsights/insights-content-service v0.0.0-20230515093827-cefc7fd75fc7
-	github.com/RedHatInsights/insights-operator-utils v1.24.7
+	github.com/RedHatInsights/insights-operator-utils v1.24.9
 	github.com/RedHatInsights/insights-results-aggregator v1.3.4
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.8
 	github.com/RedHatInsights/insights-results-types v1.3.22
@@ -17,7 +17,6 @@ require (
 	github.com/openshift-online/ocm-sdk-go v0.1.238
 	github.com/prometheus/client_golang v1.15.1
 	github.com/redhatinsights/app-common-go v1.6.3
-	github.com/redis/go-redis/v9 v9.0.5
 	github.com/rs/zerolog v1.29.1
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.3
@@ -53,7 +52,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/mock v1.6.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
-	github.com/golang/snappy v0.0.2 // indirect
+	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/gorilla/css v1.0.0 // indirect
 	github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 // indirect
@@ -94,6 +93,7 @@ require (
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
+	github.com/redis/go-redis/v9 v9.0.5 // indirect
 	github.com/segmentio/kafka-go v0.4.10 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,8 +74,8 @@ github.com/RedHatInsights/insights-operator-utils v1.21.2/go.mod h1:3Pfsgsi7GCu2
 github.com/RedHatInsights/insights-operator-utils v1.21.8/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
 github.com/RedHatInsights/insights-operator-utils v1.22.0/go.mod h1:4G1aWUV3SBc5tRflpAZX2BjoWB8afxXtSutg+5/sLE8=
 github.com/RedHatInsights/insights-operator-utils v1.24.5/go.mod h1:7qR/8rlMdiqoXAkZyQ5JhVrVNCa6SBwNUt4KMq/17j4=
-github.com/RedHatInsights/insights-operator-utils v1.24.7 h1:Itxd19oqE6+4RYX5+EAf66ZLB32tRaJNHykPwKQ9Dtw=
-github.com/RedHatInsights/insights-operator-utils v1.24.7/go.mod h1:+PYvAKGWx/jXEDhvAkmA+RkxcFFO6RFn9QEgPwRno10=
+github.com/RedHatInsights/insights-operator-utils v1.24.9 h1:z4kaXy2W/B19oetL43HIjPpZHD6u4kedcU1uryOlqD4=
+github.com/RedHatInsights/insights-operator-utils v1.24.9/go.mod h1:4PpsFOgDkHvZ7K+IWGOALkdmAbXp4A3PFN6bj+mNK3M=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator v1.3.4 h1:co58Suun8+6G8gLm41Ws1K+pifwXs6/LAiRbB/Zir1c=
 github.com/RedHatInsights/insights-results-aggregator v1.3.4/go.mod h1:mceJE31e1pofOjY9Wkrrxqvw6l1hQCRDNwnkLdnfY1M=
@@ -333,8 +333,9 @@ github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.1/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
-github.com/golang/snappy v0.0.2 h1:aeE13tS0IiQgFjYdoL8qN3K1N2bXXtI6Vi51/y7BpMw=
 github.com/golang/snappy v0.0.2/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/golang/snappy v0.0.3 h1:fHPg5GQYlCeLIPB9BZqMVR5nR9A+IM5zcgeTdjMYmLA=
+github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/gomodule/redigo v1.7.1-0.20190724094224-574c33c3df38/go.mod h1:B4C85qUVwatsJoIUNIfCRsp7qO0iAmpGFZ4EELWSbC4=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
@@ -773,7 +774,7 @@ github.com/redis/go-redis/v9 v9.0.5 h1:CuQcn5HIEeK7BgElubPP8CGtE0KakrnbBSTLjathl
 github.com/redis/go-redis/v9 v9.0.5/go.mod h1:WqMKv5vnQbRuZstUwxQI195wHy+t4PuXDOjzMvcuQHk=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
+github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=

--- a/server/endpoints_v2.go
+++ b/server/endpoints_v2.go
@@ -55,6 +55,13 @@ const (
 	// ContentV2 returns all the static content available for the user
 	ContentV2 = "content"
 
+	// Endpoints to manipulate with simplified rule results stored
+	// independently under "tracker_id" identifier in Redis
+
+	// StatusOfRequestID should return status of processing one given
+	// request ID
+	StatusOfRequestID = "clusters/{cluster}/request/{request_id}/status"
+
 	// Endpoints to acknowledge rule and to manipulate with
 	// acknowledgements.
 
@@ -104,6 +111,9 @@ func (server *HTTPServer) addV2EndpointsToRouter(router *mux.Router) {
 	// Rules related endpoints
 	server.addV2RuleEndpointsToRouter(router, apiV2Prefix, aggregatorBaseEndpoint)
 
+	// Endpoints requiring Redis to work
+	server.addV2RedisEndpointsToRouter(router, apiV2Prefix)
+
 	// Prometheus metrics
 	router.Handle(apiV2Prefix+MetricsEndpoint, promhttp.Handler()).Methods(http.MethodGet)
 
@@ -115,6 +125,12 @@ func (server *HTTPServer) addV2EndpointsToRouter(router *mux.Router) {
 		openAPIv2URL,
 		httputils.CreateOpenAPIHandler(server.Config.APIv2SpecFile, server.Config.Debug, true),
 	).Methods(http.MethodGet)
+}
+
+// addV2RedisEndpointsToRouter method registers handlers for endpoints that depend on our Redis storage
+// to provide responses.
+func (server *HTTPServer) addV2RedisEndpointsToRouter(router *mux.Router, apiPrefix string) {
+	router.HandleFunc(apiPrefix+StatusOfRequestID, server.readStatusOfRequestID).Methods(http.MethodGet)
 }
 
 // addV2ReportsEndpointsToRouter method registers handlers for endpoints that

--- a/server/endpoints_v2.go
+++ b/server/endpoints_v2.go
@@ -130,7 +130,7 @@ func (server *HTTPServer) addV2EndpointsToRouter(router *mux.Router) {
 // addV2RedisEndpointsToRouter method registers handlers for endpoints that depend on our Redis storage
 // to provide responses.
 func (server *HTTPServer) addV2RedisEndpointsToRouter(router *mux.Router, apiPrefix string) {
-	router.HandleFunc(apiPrefix+StatusOfRequestID, server.readStatusOfRequestID).Methods(http.MethodGet)
+	router.HandleFunc(apiPrefix+StatusOfRequestID, server.getRequestStatusForCluster).Methods(http.MethodGet)
 }
 
 // addV2ReportsEndpointsToRouter method registers handlers for endpoints that

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -3832,7 +3832,7 @@ func TestHTTPServer_GroupsEndpoint(t *testing.T) {
 			StatusCode: http.StatusOK,
 			Body:       expectedBody,
 		})
-	}, testTimeout)
+	}, 30*time.Second)
 }
 
 func TestHTTPServer_GroupsEndpoint_UnavailableContentService(t *testing.T) {
@@ -3858,7 +3858,7 @@ func TestHTTPServer_GroupsEndpoint_UnavailableContentService(t *testing.T) {
 			StatusCode: http.StatusServiceUnavailable,
 			Body:       expectedBody,
 		})
-	}, testTimeout)
+	}, 30*time.Second)
 }
 
 // TestServeInfoMap checks the REST API server behaviour for info endpoint

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -54,7 +54,7 @@ const (
 	// StatusProcessed is a message returned for already processed reports stored in Redis
 	StatusProcessed = "processed"
 	// RequestsForClusterNotFound is a message returned when no request IDs were found for a given clusterID
-	RequestsForClusterNotFound = "Requests for cluster not found"
+	RequestsForClusterNotFound = "No requests found for given cluster"
 	// RequestIDNotFound is returned when the requested request ID was not found in the list of request IDs
 	// for given cluster
 	RequestIDNotFound = "Request ID not found for given org_id and cluster_id"

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -1128,9 +1128,9 @@ func (server *HTTPServer) processClustersDetailResponse(
 	return responses.Send(http.StatusOK, writer, response)
 }
 
-// readStatusOfRequestID method implements endpoint that should return a status
+// getRequestStatusForCluster method implements endpoint that should return a status
 // for given request ID.
-func (server *HTTPServer) readStatusOfRequestID(writer http.ResponseWriter, request *http.Request) {
+func (server *HTTPServer) getRequestStatusForCluster(writer http.ResponseWriter, request *http.Request) {
 	orgID, err := server.GetCurrentOrgID(request)
 	if err != nil {
 		log.Error().Msg(authTokenFormatError)

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -773,7 +773,7 @@ func TestHTTPServer_GetSingleClusterInfoClusterNotFound(t *testing.T) {
 	}, testTimeout)
 }
 
-func TestHTTPServer_ReadStatusOfRequestID_NoRequestsForCluster(t *testing.T) {
+func TestHTTPServer_GetRequestStatusForCluster_NoRequestsForCluster(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -804,7 +804,7 @@ func TestHTTPServer_ReadStatusOfRequestID_NoRequestsForCluster(t *testing.T) {
 	}, testTimeout)
 }
 
-func TestHTTPServer_ReadStatusOfRequestID_RequestNotFound(t *testing.T) {
+func TestHTTPServer_GetRequestStatusForCluster_RequestNotFound(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -835,7 +835,7 @@ func TestHTTPServer_ReadStatusOfRequestID_RequestNotFound(t *testing.T) {
 	}, testTimeout)
 }
 
-func TestHTTPServer_ReadStatusOfRequestID_BadRequestClusterID(t *testing.T) {
+func TestHTTPServer_GetRequestStatusForCluster_BadRequestClusterID(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -863,7 +863,7 @@ func TestHTTPServer_ReadStatusOfRequestID_BadRequestClusterID(t *testing.T) {
 	}, testTimeout)
 }
 
-func TestHTTPServer_ReadStatusOfRequestID_BadRequestID(t *testing.T) {
+func TestHTTPServer_GetRequestStatusForCluster_BadRequestID(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -891,7 +891,7 @@ func TestHTTPServer_ReadStatusOfRequestID_BadRequestID(t *testing.T) {
 	}, testTimeout)
 }
 
-func TestHTTPServer_ReadStatusOfRequestID_SingleRequestID(t *testing.T) {
+func TestHTTPServer_GetRequestStatusForCluster_SingleRequestID(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -924,7 +924,7 @@ func TestHTTPServer_ReadStatusOfRequestID_SingleRequestID(t *testing.T) {
 	}, testTimeout)
 }
 
-func TestHTTPServer_ReadStatusOfRequestID_RequestIDOnSecondPage(t *testing.T) {
+func TestHTTPServer_GetRequestStatusForCluster_RequestIDOnSecondPage(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
 

--- a/services/export_test.go
+++ b/services/export_test.go
@@ -25,6 +25,5 @@ package services
 // to see why this trick is needed for using package internal
 // symbols (externally invisible) in unit tests.
 var (
-	GetFromURL        = getFromURL
-	CreateRedisClient = createRedisClient
+	GetFromURL = getFromURL
 )

--- a/services/redis.go
+++ b/services/redis.go
@@ -26,10 +26,6 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-const (
-	redisExecutionFailedMsg = "unexpected response from Redis server"
-)
-
 var (
 	// RequestIDsScanPattern is a glob-style pattern to find all matching keys. Uses ?* instead of * to avoid
 	// matching "organization:%v:cluster:%v:request:"

--- a/tests/helpers/redis.go
+++ b/tests/helpers/redis.go
@@ -1,0 +1,57 @@
+// Copyright 2021, 2022, 2023 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package helpers
+
+import (
+	"testing"
+
+	redisutils "github.com/RedHatInsights/insights-operator-utils/redis"
+	"github.com/RedHatInsights/insights-results-smart-proxy/services"
+
+	"github.com/go-redis/redismock/v9"
+)
+
+var (
+	// DefaultRedisConf is the default Redis configuration used in tests
+	DefaultRedisConf services.RedisConfiguration
+)
+
+// set default configuration
+func init() {
+	DefaultRedisConf = services.RedisConfiguration{
+		RedisEndpoint:       "localhost:6379",
+		RedisDatabase:       0,
+		RedisPassword:       "psw",
+		RedisTimeoutSeconds: 30,
+	}
+}
+
+// GetMockRedis is used to get a mocked Redis client to expect and respond to queries
+func GetMockRedis() (
+	mockClient services.RedisClient, mockServer redismock.ClientMock,
+) {
+	client, mockServer := redismock.NewClientMock()
+	mockClient = services.RedisClient{
+		Client: redisutils.Client{Connection: client},
+	}
+	return
+}
+
+// RedisExpectationsMet helper function used to ensure mock expectations were met
+func RedisExpectationsMet(t *testing.T, mock redismock.ClientMock) {
+	if err := mock.ExpectationsWereMet(); err != nil {
+		t.Error(err)
+	}
+}

--- a/types/types.go
+++ b/types/types.go
@@ -48,6 +48,10 @@ type OrgID = types.OrgID
 // ImpactingFlag controls the behaviour of 'impacting' param on GET /rule/
 type ImpactingFlag int
 
+// RequestID is used to store the request ID supplied in input Kafka records as
+// a unique identifier of payloads. Empty string represents a missing request ID.
+type RequestID string
+
 // RuleWithContentResponse represents a single rule in the response of /report endpoint
 type RuleWithContentResponse struct {
 	RuleID          types.RuleID    `json:"rule_id"`


### PR DESCRIPTION
# Description
- uses moved Redis client from utils repo
- implements `clusters/{cluster}/request/{request_id}/status` endpoint
- function utilizing Redis `GetRequestIDsForClusterID` will be used in other endpoints as well

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- Bump-up dependent library (no changes in the code)
- REST API tests

## Testing steps
local testing with real Redis

NOTE: `make before_commit` doesn't pass locally for some reason, errcheck returns ambiguous error `error: failed to check packages: errors while loading package github.com/RedHatInsights/insights-results-smart-proxy_test` but no new package was added ... let's see what CI has to say

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
