### PR TITLE
implement GET+POST `cluster/{cluster}/requests` 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/openshift-online/ocm-sdk-go v0.1.238
 	github.com/prometheus/client_golang v1.15.1
 	github.com/redhatinsights/app-common-go v1.6.3
+	github.com/redis/go-redis/v9 v9.0.5
 	github.com/rs/zerolog v1.29.1
 	github.com/spf13/viper v1.15.0
 	github.com/stretchr/testify v1.8.3
@@ -93,7 +94,6 @@ require (
 	github.com/prometheus/common v0.42.0 // indirect
 	github.com/prometheus/procfs v0.9.0 // indirect
 	github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 // indirect
-	github.com/redis/go-redis/v9 v9.0.5 // indirect
 	github.com/segmentio/kafka-go v0.4.10 // indirect
 	github.com/spf13/afero v1.9.3 // indirect
 	github.com/spf13/cast v1.5.0 // indirect

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -400,6 +400,7 @@
       "post": {
         "summary": "Filtered list of stored requests for given cluster ID",
         "description": "A list of requests for given cluster, filtered by the provided request IDs, if any.",
+        "operationId": "getRequestsForClusterPostVariant",
         "parameters": [
           {
             "name": "clusterId",

--- a/server/endpoints_v2.go
+++ b/server/endpoints_v2.go
@@ -58,6 +58,11 @@ const (
 	// Endpoints to manipulate with simplified rule results stored
 	// independently under "tracker_id" identifier in Redis
 
+	// ListAllRequestIDs should return list of all request IDs detected for
+	// given cluster. In reality the list is refreshing as old request IDs
+	// are forgotten after 24 hours
+	ListAllRequestIDs = "cluster/{cluster}/requests"
+
 	// StatusOfRequestID should return status of processing one given
 	// request ID
 	StatusOfRequestID = "clusters/{cluster}/request/{request_id}/status"
@@ -130,6 +135,8 @@ func (server *HTTPServer) addV2EndpointsToRouter(router *mux.Router) {
 // addV2RedisEndpointsToRouter method registers handlers for endpoints that depend on our Redis storage
 // to provide responses.
 func (server *HTTPServer) addV2RedisEndpointsToRouter(router *mux.Router, apiPrefix string) {
+	router.HandleFunc(apiPrefix+ListAllRequestIDs, server.getRequestsForCluster).Methods(http.MethodGet)
+	router.HandleFunc(apiPrefix+ListAllRequestIDs, server.getRequestsForClusterPostVariant).Methods(http.MethodPost)
 	router.HandleFunc(apiPrefix+StatusOfRequestID, server.getRequestStatusForCluster).Methods(http.MethodGet)
 }
 

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -15,6 +15,8 @@
 package server_test
 
 import (
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -36,6 +38,11 @@ import (
 
 const (
 	dotReportRuleModuleSuffix = ".report"
+)
+
+var (
+	receivedTimestampTest  = time.Now().Add(-time.Minute).UTC().Format(time.RFC3339)
+	processedTimestampTest = time.Now().UTC().Format(time.RFC3339)
 )
 
 func TestHTTPServer_SetRating(t *testing.T) {
@@ -773,6 +780,35 @@ func TestHTTPServer_GetSingleClusterInfoClusterNotFound(t *testing.T) {
 	}, testTimeout)
 }
 
+func TestHTTPServer_GetRequestStatusForCluster_RedisError500(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		redisClient, redisServer := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		expectedKey := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
+		redisServer.ExpectScan(0, expectedKey, 0).SetErr(errors.New("Redis server failure"))
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodGet,
+				Endpoint:           server.StatusOfRequestID,
+				EndpointArgs:       []interface{}{testdata.ClusterName, "requestID1"},
+				AuthorizationToken: goodJWTAuthBearer,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusInternalServerError,
+			},
+		)
+
+		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
 func TestHTTPServer_GetRequestStatusForCluster_NoRequestsForCluster(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
@@ -891,6 +927,33 @@ func TestHTTPServer_GetRequestStatusForCluster_BadRequestID(t *testing.T) {
 	}, testTimeout)
 }
 
+func TestHTTPServer_GetRequestStatusForCluster_BadAuthToken(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		// mock server not needed because the request will not get to part requiring Redis
+		redisClient, _ := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		// bad token
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodGet,
+				Endpoint:           server.StatusOfRequestID,
+				EndpointArgs:       []interface{}{testdata.ClusterName, "requestID1"},
+				AuthorizationToken: unparsableJWTAuthBearer,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusForbidden,
+			},
+		)
+
+	}, testTimeout)
+}
+
 func TestHTTPServer_GetRequestStatusForCluster_SingleRequestID(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
@@ -956,5 +1019,590 @@ func TestHTTPServer_GetRequestStatusForCluster_RequestIDOnSecondPage(t *testing.
 		)
 
 		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForCluster_OK1Request(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		redisClient, redisServer := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		expectedKey1stCommand := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
+		redisServer.ExpectScan(0, expectedKey1stCommand, 0).SetVal([]string{"requestID1"}, 0)
+
+		expectedKey2ndCommand := fmt.Sprintf(services.SimplifiedReportKey, testdata.OrgID, testdata.ClusterName, "requestID1")
+		redisServer.ExpectHMGet(
+			expectedKey2ndCommand, services.RequestIDFieldName, services.ReceivedTimestampFieldName, services.ProcessedTimestampFieldName,
+		).SetVal([]interface{}{"requestID1", receivedTimestampTest, processedTimestampTest})
+
+		expectedResponse := fmt.Sprintf(`{
+			"cluster":"%v",
+			"status":"ok",
+			"requests":[
+				{"processed":"%v", "received":"%v", "requestID":"requestID1", "valid":true}
+			]
+		}`, testdata.ClusterName, processedTimestampTest, receivedTimestampTest)
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodGet,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: goodJWTAuthBearer,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       expectedResponse,
+			},
+		)
+
+		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForCluster_OK3Requests(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		redisClient, redisServer := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		requestIDs := make([]string, 3)
+		for i := range requestIDs {
+			requestIDs[i] = fmt.Sprintf("requestID%d", i)
+		}
+
+		expectedKey1stCommand := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
+		redisServer.ExpectScan(0, expectedKey1stCommand, 0).SetVal([]string{requestIDs[0], requestIDs[1], requestIDs[2]}, 0)
+
+		for i := range requestIDs {
+			expectedKey2ndCommand := fmt.Sprintf(services.SimplifiedReportKey, testdata.OrgID, testdata.ClusterName, requestIDs[i])
+
+			redisServer.ExpectHMGet(
+				expectedKey2ndCommand, services.RequestIDFieldName, services.ReceivedTimestampFieldName, services.ProcessedTimestampFieldName,
+			).SetVal([]interface{}{requestIDs[i], receivedTimestampTest, processedTimestampTest})
+		}
+
+		expectedResponse := fmt.Sprintf(`{
+			"cluster":"%v",
+			"status":"ok",
+			"requests":[
+				{"processed":"%v", "received":"%v", "requestID":"%v", "valid":true},
+				{"processed":"%v", "received":"%v", "requestID":"%v", "valid":true},
+				{"processed":"%v", "received":"%v", "requestID":"%v", "valid":true}
+			]
+		}`, testdata.ClusterName,
+			processedTimestampTest, receivedTimestampTest, requestIDs[0],
+			processedTimestampTest, receivedTimestampTest, requestIDs[1],
+			processedTimestampTest, receivedTimestampTest, requestIDs[2],
+		)
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodGet,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: goodJWTAuthBearer,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       expectedResponse,
+			},
+		)
+
+		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForCluster_RequestsNotFound(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		redisClient, redisServer := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		expectedKey := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
+		redisServer.ExpectScan(0, expectedKey, 0).SetVal([]string{}, 0)
+
+		// 2nd Redis call is not expected
+
+		// no request IDs found for given cluster
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodGet,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: goodJWTAuthBearer,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusNotFound,
+				Body:       fmt.Sprintf(`{"status":"%v"}`, server.RequestsForClusterNotFound),
+			},
+		)
+
+		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForCluster_BadRequestClusterID(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		// mock server not needed because the request will not get to part requiring Redis
+		redisClient, _ := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		// invalid clusterID
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodGet,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.BadClusterName}, // bad cluster name
+				AuthorizationToken: goodJWTAuthBearer,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusBadRequest,
+				Body:       `{"status":"Error during parsing param 'cluster' with value 'aaaa'. Error: 'invalid UUID length: 4'"}`,
+			},
+		)
+
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForCluster_BadAuthToken(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		// mock server not needed because the request will not get to part requiring Redis
+		redisClient, _ := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		// invalid clusterID
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodGet,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: unparsableJWTAuthBearer,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusForbidden,
+			},
+		)
+
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForCluster_RedisError500(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		redisClient, redisServer := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		expectedKey1stCommand := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
+		redisServer.ExpectScan(0, expectedKey1stCommand, 0).SetErr(errors.New("Redis server failure"))
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodGet,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: goodJWTAuthBearer,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusInternalServerError,
+			},
+		)
+
+		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForCluster_RedisError500_2ndCmd(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		redisClient, redisServer := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		expectedKey1stCommand := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
+		redisServer.ExpectScan(0, expectedKey1stCommand, 0).SetVal([]string{"requestID1"}, 0)
+
+		expectedKey2ndCommand := fmt.Sprintf(services.SimplifiedReportKey, testdata.OrgID, testdata.ClusterName, "requestID1")
+		redisServer.ExpectHMGet(
+			expectedKey2ndCommand, services.RequestIDFieldName, services.ReceivedTimestampFieldName, services.ProcessedTimestampFieldName,
+		).SetErr(errors.New("redis server failure"))
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodGet,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: goodJWTAuthBearer,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusInternalServerError,
+			},
+		)
+
+		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForClusterPostVariant_OK1Request(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		redisClient, redisServer := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		expectedKey := fmt.Sprintf(services.SimplifiedReportKey, testdata.OrgID, testdata.ClusterName, "requestID1")
+		redisServer.ExpectHMGet(
+			expectedKey, services.RequestIDFieldName, services.ReceivedTimestampFieldName, services.ProcessedTimestampFieldName,
+		).SetVal([]interface{}{"requestID1", receivedTimestampTest, processedTimestampTest})
+
+		expectedResponse := fmt.Sprintf(`{
+			"cluster":"%v",
+			"status":"ok",
+			"requests":[
+				{"processed":"%v", "received":"%v", "requestID":"requestID1", "valid":true}
+			]
+		}`, testdata.ClusterName, processedTimestampTest, receivedTimestampTest)
+
+		requestIDList := []types.RequestID{"requestID1"}
+		reqBody, _ := json.Marshal(requestIDList)
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodPost,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: goodJWTAuthBearer,
+				Body:               reqBody,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       expectedResponse,
+			},
+		)
+
+		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForClusterPostVariant_OK3Request1Found(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		redisClient, redisServer := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		requestIDs := make([]string, 3)
+		for i := range requestIDs {
+			requestIDs[i] = fmt.Sprintf("requestID%d", i)
+
+			expectedKey := fmt.Sprintf(services.SimplifiedReportKey, testdata.OrgID, testdata.ClusterName, requestIDs[i])
+
+			// only third request is found, 1st and 2nd are not
+			if i == 2 {
+				redisServer.ExpectHMGet(
+					expectedKey, services.RequestIDFieldName, services.ReceivedTimestampFieldName, services.ProcessedTimestampFieldName,
+				).SetVal([]interface{}{requestIDs[2], receivedTimestampTest, processedTimestampTest})
+			} else {
+				redisServer.ExpectHMGet(
+					expectedKey, services.RequestIDFieldName, services.ReceivedTimestampFieldName, services.ProcessedTimestampFieldName,
+				).SetVal([]interface{}{nil, nil, nil})
+			}
+		}
+
+		expectedResponse := fmt.Sprintf(`{
+			"cluster":"%v",
+			"status":"ok",
+			"requests":[
+				{"processed":"", "received":"", "requestID":"requestID0", "valid":false},
+				{"processed":"", "received":"", "requestID":"requestID1", "valid":false},
+				{"processed":"%v", "received":"%v", "requestID":"requestID2", "valid":true}
+			]
+		}`, testdata.ClusterName, processedTimestampTest, receivedTimestampTest)
+
+		requestIDList := []types.RequestID{types.RequestID(requestIDs[0]), types.RequestID(requestIDs[1]), types.RequestID(requestIDs[2])}
+		reqBody, _ := json.Marshal(requestIDList)
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodPost,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: goodJWTAuthBearer,
+				Body:               reqBody,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       expectedResponse,
+			},
+		)
+
+		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForClusterPostVariant_OK1RequestNotFound(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		redisClient, redisServer := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		expectedKey := fmt.Sprintf(services.SimplifiedReportKey, testdata.OrgID, testdata.ClusterName, "requestID1")
+		redisServer.ExpectHMGet(
+			expectedKey, services.RequestIDFieldName, services.ReceivedTimestampFieldName, services.ProcessedTimestampFieldName,
+		).SetVal([]interface{}{nil, nil, nil})
+
+		expectedResponse := fmt.Sprintf(`{
+			"cluster":"%v",
+			"status":"ok",
+			"requests":[
+				{"processed":"", "received":"", "requestID":"requestID1", "valid":false}
+			]
+		}`, testdata.ClusterName)
+
+		requestIDList := []types.RequestID{"requestID1"}
+		reqBody, _ := json.Marshal(requestIDList)
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodPost,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: goodJWTAuthBearer,
+				Body:               reqBody,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusOK,
+				Body:       expectedResponse,
+			},
+		)
+
+		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForClusterPostVariant_RedisError500(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		redisClient, redisServer := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		expectedKey := fmt.Sprintf(services.SimplifiedReportKey, testdata.OrgID, testdata.ClusterName, "requestID1")
+		redisServer.ExpectHMGet(
+			expectedKey, services.RequestIDFieldName, services.ReceivedTimestampFieldName, services.ProcessedTimestampFieldName,
+		).SetErr(errors.New("Redis server failure"))
+
+		requestIDList := []types.RequestID{"requestID1"}
+		reqBody, _ := json.Marshal(requestIDList)
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodPost,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: goodJWTAuthBearer,
+				Body:               reqBody,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusInternalServerError,
+			},
+		)
+
+		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForClusterPostVariant_BadRequestClusterID(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		// mock server not needed because the request will not get to part requiring Redis
+		redisClient, _ := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		requestIDList := []types.RequestID{"requestID1"}
+		reqBody, _ := json.Marshal(requestIDList)
+
+		// invalid clusterID
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodPost,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.BadClusterName}, // bad cluster name
+				AuthorizationToken: goodJWTAuthBearer,
+				Body:               reqBody,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusBadRequest,
+				Body:       `{"status":"Error during parsing param 'cluster' with value 'aaaa'. Error: 'invalid UUID length: 4'"}`,
+			},
+		)
+
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForClusterPostVariant_BadAuthToken(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		// mock server not needed because the request will not get to part requiring Redis
+		redisClient, _ := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		requestIDList := []types.RequestID{"requestID1"}
+		reqBody, _ := json.Marshal(requestIDList)
+
+		// invalid clusterID
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodPost,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: unparsableJWTAuthBearer,
+				Body:               reqBody,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusForbidden,
+			},
+		)
+
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForClusterPostVariant_NoBody(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		// mock server not needed because the request will not get to part requiring Redis
+		redisClient, _ := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		// invalid clusterID
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodPost,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: goodJWTAuthBearer,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusBadRequest,
+				Body:       `{"status":"client didn't provide request body"}`,
+			},
+		)
+
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForClusterPostVariant_BadBodyContent(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		// mock server not needed because the request will not get to part requiring Redis
+		redisClient, _ := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		// invalid clusterID
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodPost,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: goodJWTAuthBearer,
+				Body:               "body is not JSON",
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusBadRequest,
+				Body:       `{"status":"client didn't provide a valid request body"}`,
+			},
+		)
+
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForClusterPostVariant_BadRequestID(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		// mock server not needed because the request will not get to part requiring Redis
+		redisClient, _ := helpers.GetMockRedis()
+
+		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+
+		requestIDList := []types.RequestID{"_"}
+		reqBody, _ := json.Marshal(requestIDList)
+
+		// invalid clusterID
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:             http.MethodPost,
+				Endpoint:           server.ListAllRequestIDs,
+				EndpointArgs:       []interface{}{testdata.ClusterName},
+				AuthorizationToken: goodJWTAuthBearer,
+				Body:               reqBody,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusBadRequest,
+				Body:       `{"status":"Error during parsing param 'request_id' with value '_'. Error: 'invalid request ID: '_''"}`,
+			},
+		)
+
 	}, testTimeout)
 }

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -234,8 +234,8 @@ func readRequestIDList(writer http.ResponseWriter, request *http.Request) (
 		return nil, err
 	}
 
-	var validatedRequestList []types.RequestID
-	for _, requestID := range requestList {
+	validatedRequestList := make([]types.RequestID, len(requestList))
+	for i, requestID := range requestList {
 		validatedRequestID, err := ValidateRequestID(requestID)
 		if err != nil {
 			err := &RouterParsingError{
@@ -247,7 +247,8 @@ func readRequestIDList(writer http.ResponseWriter, request *http.Request) (
 			return nil, err
 		}
 
-		validatedRequestList = append(validatedRequestList, validatedRequestID)
+		validatedRequestList[i] = validatedRequestID
 	}
+
 	return validatedRequestList, nil
 }

--- a/types/types.go
+++ b/types/types.go
@@ -269,3 +269,11 @@ type ClustersDetailResponse struct {
 	Data   ClustersDetailData `json:"data"`
 	Status string             `json:"status"`
 }
+
+// RequestStatus contains description about one request ID
+type RequestStatus struct {
+	RequestID string `json:"requestID" redis:"request_id"`
+	Valid     bool   `json:"valid" redis:"-"`
+	Received  string `json:"received" redis:"received_timestamp"`
+	Processed string `json:"processed" redis:"processed_timestamp"`
+}


### PR DESCRIPTION
# Description
- implement GET `cluster/{cluster}/requests`
- implement POST `cluster/{cluster}/requests`
- add missing `operationId` in v2 OpenAPI spec for POST `cluster/{cluster}/requests`
- Redis function to get details of Requests uses Redis pipelines so that our client only makes 1 request to the server to avoid multiple round trips
- because of ^ point, Redis is now a direct dependency

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)
- REST API tests

## Testing steps
local testing with real Redis with data according to spec doc

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
