### PR TITLE
[CCXDEV-10263] Simplify rule content cache update mechanism

### DIFF
--- a/content/content.go
+++ b/content/content.go
@@ -35,13 +35,9 @@ var (
 	ruleContentDirectory      *ctypes.RuleContentDirectory
 	ruleContentDirectoryReady = sync.NewCond(&sync.Mutex{})
 	stopUpdateContentLoop     = make(chan struct{})
-	rulesWithContentStorage   = RulesWithContentStorage{
-		rules:                      map[ctypes.RuleID]*ctypes.RuleContent{},
-		rulesWithContent:           map[ruleIDAndErrorKey]*types.RuleWithContent{},
-		recommendationsWithContent: map[ctypes.RuleID]*types.RuleWithContent{},
-	}
-	contentDirectoryTimeout = 5 * time.Second
-	dotReport               = ".report"
+	rulesWithContentStorage   = getEmptyRulesWithContentMap()
+	contentDirectoryTimeout   = 5 * time.Second
+	dotReport                 = ".report"
 )
 
 type ruleIDAndErrorKey struct {
@@ -52,8 +48,6 @@ type ruleIDAndErrorKey struct {
 // RulesWithContentStorage is a key:value structure to store processed rules.
 // It's thread safe
 type RulesWithContentStorage struct {
-	// TODO: consider naming this attribute
-	sync.RWMutex
 	rules            map[ctypes.RuleID]*ctypes.RuleContent
 	rulesWithContent map[ruleIDAndErrorKey]*types.RuleWithContent
 	// recommendationsWithContent map has the same contents as rulesWithContent but the keys
@@ -72,9 +66,6 @@ func SetRuleContentDirectory(contentDir *ctypes.RuleContentDirectory) {
 func (s *RulesWithContentStorage) GetRuleWithErrorKeyContent(
 	ruleID ctypes.RuleID, errorKey ctypes.ErrorKey,
 ) (*types.RuleWithContent, bool) {
-	s.RLock()
-	defer s.RUnlock()
-
 	res, found := s.rulesWithContent[ruleIDAndErrorKey{
 		RuleID:   ruleID,
 		ErrorKey: errorKey,
@@ -86,18 +77,12 @@ func (s *RulesWithContentStorage) GetRuleWithErrorKeyContent(
 func (s *RulesWithContentStorage) GetContentForRecommendation(
 	ruleID ctypes.RuleID,
 ) (*types.RuleWithContent, bool) {
-	s.RLock()
-	defer s.RUnlock()
-
 	res, found := s.recommendationsWithContent[ruleID]
 	return res, found
 }
 
 // GetAllContentV1 returns content for rule for api v1
 func (s *RulesWithContentStorage) GetAllContentV1() []types.RuleContentV1 {
-	s.RLock()
-	defer s.RUnlock()
-
 	res := make([]types.RuleContentV1, 0, len(s.rules))
 	for _, rule := range s.rules {
 		res = append(res, RuleContentToV1(rule))
@@ -108,9 +93,6 @@ func (s *RulesWithContentStorage) GetAllContentV1() []types.RuleContentV1 {
 
 // GetAllContentV2 returns content for api/v2
 func (s *RulesWithContentStorage) GetAllContentV2() []types.RuleContentV2 {
-	s.RLock()
-	defer s.RUnlock()
-
 	res := make([]types.RuleContentV2, 0, len(s.rules))
 	for _, rule := range s.rules {
 		res = append(res, RuleContentToV2(rule))
@@ -130,9 +112,6 @@ func (s *RulesWithContentStorage) SetRuleWithContent(
 		log.Error().Err(err).Msgf("Error generating composite rule ID for [%v] and [%v]", ruleID, errorKey)
 	}
 
-	s.Lock()
-	defer s.Unlock()
-
 	s.rulesWithContent[ruleIDAndErrorKey{
 		RuleID:   ruleID,
 		ErrorKey: errorKey,
@@ -149,29 +128,11 @@ func (s *RulesWithContentStorage) SetRuleWithContent(
 func (s *RulesWithContentStorage) SetRule(
 	ruleID ctypes.RuleID, ruleContent *ctypes.RuleContent,
 ) {
-	s.Lock()
-	defer s.Unlock()
-
 	s.rules[ruleID] = ruleContent
-}
-
-// ResetContent clear all the contents
-func (s *RulesWithContentStorage) ResetContent() {
-	s.Lock()
-	defer s.Unlock()
-
-	s.rules = make(map[ctypes.RuleID]*ctypes.RuleContent)
-	s.rulesWithContent = make(map[ruleIDAndErrorKey]*types.RuleWithContent)
-	s.recommendationsWithContent = make(map[ctypes.RuleID]*types.RuleWithContent)
-	s.internalRuleIDs = make([]ctypes.RuleID, 0)
-	s.externalRuleIDs = make([]ctypes.RuleID, 0)
 }
 
 // GetRuleIDs gets rule IDs for rules (rule modules)
 func (s *RulesWithContentStorage) GetRuleIDs() []string {
-	s.Lock()
-	defer s.Unlock()
-
 	ruleIDs := make([]string, 0, len(s.rules))
 
 	for _, ruleContent := range s.rules {
@@ -183,17 +144,11 @@ func (s *RulesWithContentStorage) GetRuleIDs() []string {
 
 // GetInternalRuleIDs returns the composite rule IDs ("| format") of internal rules
 func (s *RulesWithContentStorage) GetInternalRuleIDs() []ctypes.RuleID {
-	s.Lock()
-	defer s.Unlock()
-
 	return s.internalRuleIDs
 }
 
 // GetExternalRuleIDs returns the composite rule IDs ("| format") of external rules
 func (s *RulesWithContentStorage) GetExternalRuleIDs() []ctypes.RuleID {
-	s.Lock()
-	defer s.Unlock()
-
 	return s.externalRuleIDs
 }
 
@@ -203,9 +158,6 @@ func (s *RulesWithContentStorage) GetExternalRuleSeverities() (
 	severityMap map[ctypes.RuleID]int,
 	uniqueSeverities []int,
 ) {
-	s.Lock()
-	defer s.Unlock()
-
 	severityMap = make(map[ctypes.RuleID]int)
 	uniqueMap := make(map[int]interface{})
 
@@ -225,9 +177,6 @@ func (s *RulesWithContentStorage) GetExternalRuleSeverities() (
 // GetExternalRulesManagedInfo returns a map of rule IDs and the information whether a rule is managed
 // (has osd_customer tag) or not
 func (s *RulesWithContentStorage) GetExternalRulesManagedInfo() (managedMap map[ctypes.RuleID]bool) {
-	s.Lock()
-	defer s.Unlock()
-
 	managedMap = make(map[ctypes.RuleID]bool)
 
 	for _, ruleID := range s.externalRuleIDs {
@@ -351,9 +300,19 @@ func getRuleContent(ruleID ctypes.RuleID) (*ctypes.RuleContent, error) {
 	return res, nil
 }
 
+func getEmptyRulesWithContentMap() *RulesWithContentStorage {
+	s := RulesWithContentStorage{}
+	s.rules = make(map[types.RuleID]*types.RuleContent)
+	s.rulesWithContent = make(map[ruleIDAndErrorKey]*types.RuleWithContent)
+	s.recommendationsWithContent = make(map[ctypes.RuleID]*types.RuleWithContent)
+	s.internalRuleIDs = make([]ctypes.RuleID, 0)
+	s.externalRuleIDs = make([]ctypes.RuleID, 0)
+	return &s
+}
+
 // ResetContent clear all the content cached
 func ResetContent() {
-	rulesWithContentStorage.ResetContent()
+	rulesWithContentStorage = getEmptyRulesWithContentMap()
 }
 
 // GetRuleIDs returns a list of rule IDs (rule modules)
@@ -486,7 +445,6 @@ func UpdateContent(servicesConf services.Configuration) {
 	if err != nil {
 		return
 	}
-	ResetContent()
 	LoadRuleContent(ruleContentDirectory)
 }
 

--- a/content/content.go
+++ b/content/content.go
@@ -310,11 +310,6 @@ func getEmptyRulesWithContentMap() *RulesWithContentStorage {
 	return &s
 }
 
-// ResetContent clear all the content cached
-func ResetContent() {
-	rulesWithContentStorage = getEmptyRulesWithContentMap()
-}
-
 // GetRuleIDs returns a list of rule IDs (rule modules)
 func GetRuleIDs() ([]string, error) {
 	err := WaitForContentDirectoryToBeReady()

--- a/content/export_test.go
+++ b/content/export_test.go
@@ -27,3 +27,8 @@ package content
 var (
 	RuleContentDirectoryReady = ruleContentDirectoryReady
 )
+
+// ResetContent clear all the content cached
+func ResetContent() {
+	rulesWithContentStorage = getEmptyRulesWithContentMap()
+}

--- a/content/parsing.go
+++ b/content/parsing.go
@@ -42,6 +42,7 @@ var (
 
 // LoadRuleContent loads the parsed rule content into the storage
 func LoadRuleContent(contentDir *ctypes.RuleContentDirectory) {
+	s := getEmptyRulesWithContentMap()
 	for i, rule := range contentDir.Rules {
 		ruleID := ctypes.RuleID(rule.Plugin.PythonModule)
 
@@ -74,9 +75,9 @@ func LoadRuleContent(contentDir *ctypes.RuleContentDirectory) {
 				ruleTmp.ErrorKeys[errorKey] = ruleTmpErrorKey
 			}
 			// sets "plugin" level, containing usual fields + list of error keys
-			rulesWithContentStorage.SetRule(ruleID, &ruleTmp)
+			s.SetRule(ruleID, &ruleTmp)
 
-			rulesWithContentStorage.SetRuleWithContent(ruleID, ctypes.ErrorKey(errorKey), &types.RuleWithContent{
+			s.SetRuleWithContent(ruleID, ctypes.ErrorKey(errorKey), &types.RuleWithContent{
 				Module:         ruleID,
 				Name:           rule.Plugin.Name,
 				Generic:        errorProperties.Generic,
@@ -98,6 +99,7 @@ func LoadRuleContent(contentDir *ctypes.RuleContentDirectory) {
 			})
 		}
 	}
+	rulesWithContentStorage = s
 }
 
 // According to rule content specification, it's explicitly defined as floor((impact + likelihood) / 2), which

--- a/content/rule_content.go
+++ b/content/rule_content.go
@@ -22,9 +22,6 @@ import (
 )
 
 func (s *RulesWithContentStorage) getRuleContent(ruleID ctypes.RuleID) (*ctypes.RuleContent, bool) {
-	s.RLock()
-	defer s.RUnlock()
-
 	res, found := s.rules[ruleID]
 	return res, found
 }

--- a/server/acks_test.go
+++ b/server/acks_test.go
@@ -24,14 +24,12 @@ import (
 	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
 )
 
 func TestHTTPServer_TestReadAckListNoResult(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -77,7 +75,6 @@ func TestHTTPServer_TestReadAckListNoResult(t *testing.T) {
 
 func TestHTTPServer_TestReadAckList1Result(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	disabledAt := time.Now()
 	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
@@ -153,7 +150,6 @@ func TestHTTPServer_TestReadAckList1Result(t *testing.T) {
 
 func TestHTTPServer_TestReadAckList2Results(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	disabledAt := time.Now()
 	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
@@ -256,7 +252,6 @@ func TestHTTPServer_TestReadAckList2Results(t *testing.T) {
 
 func TestHTTPServer_TestReadAckListInvalidToken(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -299,7 +294,6 @@ func TestHTTPServer_TestReadAckListInvalidToken(t *testing.T) {
 
 func TestHTTPServer_TestReadAckListAggregatorError(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -328,7 +322,6 @@ func TestHTTPServer_TestReadAckListAggregatorError(t *testing.T) {
 
 func TestHTTPServer_TestReadAckListUnparsableAggregatorJSON(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -359,7 +352,6 @@ func TestHTTPServer_TestReadAckListUnparsableAggregatorJSON(t *testing.T) {
 
 func TestHTTPServer_TestGetAcknowledgeNotFound(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -397,7 +389,6 @@ func TestHTTPServer_TestGetAcknowledgeNotFound(t *testing.T) {
 
 func TestHTTPServer_TestGetAcknowledgeAggregatorError(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -427,7 +418,6 @@ func TestHTTPServer_TestGetAcknowledgeAggregatorError(t *testing.T) {
 
 func TestHTTPServer_TestGetAcknowledgeUnparsableAggregatorJSON(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -459,7 +449,6 @@ func TestHTTPServer_TestGetAcknowledgeUnparsableAggregatorJSON(t *testing.T) {
 
 func TestHTTPServer_TestGetAcknowledgeFound(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	disabledAt := time.Now()
 	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
@@ -531,7 +520,6 @@ func TestHTTPServer_TestGetAcknowledgeFound(t *testing.T) {
 
 func TestHTTPServer_TestGetAcknowledgeInvalidRuleIDBadRequest(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	disabledAt := time.Now()
 	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
@@ -590,7 +578,6 @@ func TestHTTPServer_TestGetAcknowledgeInvalidRuleIDBadRequest(t *testing.T) {
 
 func TestHTTPServer_TestGetAcknowledgeInvalidToken(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -620,7 +607,6 @@ func TestHTTPServer_TestGetAcknowledgeInvalidToken(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgePostFound(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	disabledAt := time.Now()
 	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
@@ -715,7 +701,6 @@ func TestHTTPServer_TestAcknowledgePostFound(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgePostNewAck(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	disabledAt := time.Now()
 	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
@@ -836,7 +821,6 @@ func TestHTTPServer_TestAcknowledgePostNewAck(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgePostMissingParam(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	justificationNote := "justification test"
 
@@ -863,7 +847,6 @@ func TestHTTPServer_TestAcknowledgePostMissingParam(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgePostBadCompositeRuleID(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	justificationNote := "justification test"
 
@@ -890,7 +873,6 @@ func TestHTTPServer_TestAcknowledgePostBadCompositeRuleID(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgePostAggregatorError1stCall(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	justificationNote := "justification test"
 
@@ -930,7 +912,6 @@ func TestHTTPServer_TestAcknowledgePostAggregatorError1stCall(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgePostAggregatorError2ndCall(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	disabledAt := time.Now()
 	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
@@ -1017,7 +998,6 @@ func TestHTTPServer_TestAcknowledgePostAggregatorError2ndCall(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgePostInvalidToken(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -1042,7 +1022,6 @@ func TestHTTPServer_TestAcknowledgePostInvalidToken(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeUpdateNotFound(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	justificationNote := "justification test"
 
@@ -1091,7 +1070,6 @@ func TestHTTPServer_TestAcknowledgeUpdateNotFound(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeUpdateFound(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	disabledAt := time.Now()
 	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
@@ -1228,7 +1206,6 @@ func TestHTTPServer_TestAcknowledgeUpdateFound(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeUpdateBadCompositeRuleID(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	justificationNote := "justification test"
 
@@ -1256,7 +1233,6 @@ func TestHTTPServer_TestAcknowledgeUpdateBadCompositeRuleID(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeUpdateAggregatorError1st(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	justificationUpdated := "justification updated"
 
@@ -1296,7 +1272,6 @@ func TestHTTPServer_TestAcknowledgeUpdateAggregatorError1st(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeUpdateAggregatorError2nd(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	disabledAt := time.Now()
 	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
@@ -1381,7 +1356,6 @@ func TestHTTPServer_TestAcknowledgeUpdateAggregatorError2nd(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeUpdateAggregatorError3rd(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	disabledAt := time.Now()
 	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
@@ -1480,7 +1454,6 @@ func TestHTTPServer_TestAcknowledgeUpdateAggregatorError3rd(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeUpdateInvalidToken(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -1505,7 +1478,6 @@ func TestHTTPServer_TestAcknowledgeUpdateInvalidToken(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeDeleteFound(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	disabledAt := time.Now()
 	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)
@@ -1577,7 +1549,6 @@ func TestHTTPServer_TestAcknowledgeDeleteFound(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeDeleteNotFound(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -1614,7 +1585,6 @@ func TestHTTPServer_TestAcknowledgeDeleteNotFound(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeDeleteBadRequest(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -1631,7 +1601,6 @@ func TestHTTPServer_TestAcknowledgeDeleteBadRequest(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeDeleteInvalidToken(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -1656,7 +1625,6 @@ func TestHTTPServer_TestAcknowledgeDeleteInvalidToken(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeDeleteAggregatorError1st(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -1693,7 +1661,6 @@ func TestHTTPServer_TestAcknowledgeDeleteAggregatorError1st(t *testing.T) {
 
 func TestHTTPServer_TestAcknowledgeDeleteAggregatorError2nd(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	disabledAt := time.Now()
 	disabledAtRFC := disabledAt.UTC().Format(time.RFC3339)

--- a/server/endpoints_test.go
+++ b/server/endpoints_test.go
@@ -23,7 +23,6 @@ import (
 	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
 )
@@ -60,7 +59,6 @@ func TestHTTPServer_ProxyTo_VoteEndpointsExtractUserID(t *testing.T) {
 		t.Run(testCase.name, func(t *testing.T) {
 			helpers.RunTestWithTimeout(t, func(t testing.TB) {
 				defer helpers.CleanAfterGock(t)
-				defer content.ResetContent()
 				err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 				assert.Nil(t, err)
 

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -319,7 +319,6 @@ func expectNoRulesDisabledPerCluster(t *testing.TB, orgID types.OrgID, userID ty
 
 // TODO: test more cases for report endpoint
 func TestHTTPServer_ReportEndpoint(t *testing.T) {
-	defer content.ResetContent()
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -389,7 +388,6 @@ func TestHTTPServer_ReportEndpoint_UnavailableContentService(t *testing.T) {
 
 // Reproducer for Bug 1977858
 func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
-	defer content.ResetContent()
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -423,7 +421,6 @@ func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpointV2NoContent(t *testing.T) {
-	defer content.ResetContent()
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -469,7 +466,7 @@ func TestHTTPServer_ReportEndpointV2NoContent(t *testing.T) {
 
 // TestHTTPServer_ReportEndpointV2TestAMSData tests that data from AMS API (mocked) is passed correctly to the response
 func TestHTTPServer_ReportEndpointV2TestAMSData(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -518,7 +515,7 @@ func TestHTTPServer_ReportEndpointV2TestAMSData(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpointV2TestManagedClustersRules(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -569,7 +566,7 @@ func TestHTTPServer_ReportEndpointV2TestManagedClustersRules(t *testing.T) {
 
 // Reproducer for Bug 1977858
 func TestHTTPServer_ReportEndpointNoContentFor2Rules(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&RuleContentDirectoryOnly1Rule)
 	assert.Nil(t, err)
 
@@ -603,7 +600,7 @@ func TestHTTPServer_ReportEndpointNoContentFor2Rules(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpoint_WithOnlyOSDEndpoint(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -636,7 +633,7 @@ func TestHTTPServer_ReportEndpoint_WithOnlyOSDEndpoint(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpoint_InsightsOperatorUserAgentManagedCluster(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -690,7 +687,7 @@ func TestHTTPServer_ReportEndpoint_InsightsOperatorUserAgentManagedCluster(t *te
 }
 
 func TestHTTPServer_ReportEndpoint_InsightsOperatorUserAgentNonManagedCluster(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -744,7 +741,7 @@ func TestHTTPServer_ReportEndpoint_InsightsOperatorUserAgentNonManagedCluster(t 
 }
 
 func TestHTTPServer_ReportEndpoint_WithDisabledRulesForCluster(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory5Rules)
 	assert.Nil(t, err)
 
@@ -805,7 +802,7 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRulesForCluster(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpoint_WithDisabledRulesForClusterAndMissingContent(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&RuleContentDirectoryOnlyDisabledRule)
 	assert.Nil(t, err)
 
@@ -838,7 +835,7 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRulesForClusterAndMissingContent(
 }
 
 func TestHTTPServer_ReportEndpoint_WithClusterAndSystemWideDisabledRules(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory5Rules)
 	assert.Nil(t, err)
 
@@ -918,7 +915,6 @@ func TestHTTPServer_ReportMetainfoEndpointNoReports(t *testing.T) {
 		  "status": "ok"
 		}`
 
-	defer content.ResetContent()
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -962,7 +958,6 @@ func TestHTTPServer_ReportMetainfoEndpointTwoReports(t *testing.T) {
 		  "status": "ok"
 		}`
 
-	defer content.ResetContent()
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -996,7 +991,7 @@ func TestHTTPServer_ReportMetainfoEndpointTwoReports(t *testing.T) {
 // TestHTTPServer_ReportMetainfoEndpointForbidden checks how HTTP codes are
 // handled in report/info endpoint handler.
 func TestHTTPServer_ReportMetainfoEndpointForbidden(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1029,7 +1024,6 @@ func TestHTTPServer_ReportMetainfoEndpointForbidden(t *testing.T) {
 func TestHTTPServer_ReportMetainfoEndpointImproperJSON(t *testing.T) {
 	const metainfoResponse = "THIS_IS_NOT_JSON"
 
-	defer content.ResetContent()
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1075,7 +1069,6 @@ func TestHTTPServer_ReportMetainfoEndpointWrongClusterName(t *testing.T) {
 
 	const clusterName = "not-proper-cluster-name"
 
-	defer content.ResetContent()
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1108,7 +1101,7 @@ func TestHTTPServer_ReportMetainfoEndpointWrongClusterName(t *testing.T) {
 
 // TODO: test more cases for rule endpoint
 func TestHTTPServer_RuleEndpoint(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1130,9 +1123,11 @@ func TestHTTPServer_RuleEndpoint(t *testing.T) {
 		})
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.SingleRuleEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName, fmt.Sprintf("%v|%v", testdata.RuleErrorKey1.RuleModule, testdata.RuleErrorKey1.ErrorKey)},
+			Method:   http.MethodGet,
+			Endpoint: server.SingleRuleEndpoint,
+			EndpointArgs: []interface{}{
+				testdata.ClusterName, fmt.Sprintf("%v|%v", testdata.RuleErrorKey1.RuleModule, testdata.RuleErrorKey1.ErrorKey),
+			},
 			UserID:             testdata.UserID,
 			OrgID:              testdata.OrgID,
 			AuthorizationToken: goodJWTAuthBearer,
@@ -1171,9 +1166,11 @@ func TestHTTPServer_RuleEndpoint_UnavailableContentService(t *testing.T) {
 		})
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.SingleRuleEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName, fmt.Sprintf("%v|%v", testdata.RuleErrorKey1.RuleModule, testdata.RuleErrorKey1.ErrorKey)},
+			Method:   http.MethodGet,
+			Endpoint: server.SingleRuleEndpoint,
+			EndpointArgs: []interface{}{
+				testdata.ClusterName, fmt.Sprintf("%v|%v", testdata.RuleErrorKey1.RuleModule, testdata.RuleErrorKey1.ErrorKey),
+			},
 			UserID:             testdata.UserID,
 			OrgID:              testdata.OrgID,
 			AuthorizationToken: goodJWTAuthBearer,
@@ -1185,7 +1182,7 @@ func TestHTTPServer_RuleEndpoint_UnavailableContentService(t *testing.T) {
 }
 
 func TestHTTPServer_RuleEndpoint_WithOSD(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1207,9 +1204,11 @@ func TestHTTPServer_RuleEndpoint_WithOSD(t *testing.T) {
 		})
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.SingleRuleEndpoint + "?" + server.OSDEligibleParam + "=true",
-			EndpointArgs:       []interface{}{testdata.ClusterName, fmt.Sprintf("%v|%v", testdata.RuleErrorKey1.RuleModule, testdata.RuleErrorKey1.ErrorKey)},
+			Method:   http.MethodGet,
+			Endpoint: server.SingleRuleEndpoint + "?" + server.OSDEligibleParam + "=true",
+			EndpointArgs: []interface{}{
+				testdata.ClusterName, fmt.Sprintf("%v|%v", testdata.RuleErrorKey1.RuleModule, testdata.RuleErrorKey1.ErrorKey),
+			},
 			UserID:             testdata.UserID,
 			OrgID:              testdata.OrgID,
 			AuthorizationToken: goodJWTAuthBearer,
@@ -1221,7 +1220,7 @@ func TestHTTPServer_RuleEndpoint_WithOSD(t *testing.T) {
 }
 
 func TestHTTPServer_RuleEndpoint_WithNotOSDRule(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1243,9 +1242,11 @@ func TestHTTPServer_RuleEndpoint_WithNotOSDRule(t *testing.T) {
 		})
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.SingleRuleEndpoint + "?" + server.OSDEligibleParam + "=true",
-			EndpointArgs:       []interface{}{testdata.ClusterName, fmt.Sprintf("%v|%v", testdata.RuleErrorKey2.RuleModule, testdata.RuleErrorKey2.ErrorKey)},
+			Method:   http.MethodGet,
+			Endpoint: server.SingleRuleEndpoint + "?" + server.OSDEligibleParam + "=true",
+			EndpointArgs: []interface{}{
+				testdata.ClusterName, fmt.Sprintf("%v|%v", testdata.RuleErrorKey2.RuleModule, testdata.RuleErrorKey2.ErrorKey),
+			},
 			UserID:             testdata.UserID,
 			OrgID:              testdata.OrgID,
 			AuthorizationToken: goodJWTAuthBearer,
@@ -1258,7 +1259,7 @@ func TestHTTPServer_RuleEndpoint_WithNotOSDRule(t *testing.T) {
 
 // TestHTTPServer_GetContent
 func TestHTTPServer_GetContent(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1278,7 +1279,7 @@ func TestHTTPServer_GetContent(t *testing.T) {
 
 // TestHTTPServer_OverviewEndpoint
 func TestHTTPServer_OverviewEndpoint(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{
@@ -1358,7 +1359,7 @@ func TestHTTPServer_OverviewEndpoint(t *testing.T) {
 // TestHTTPServer_OverviewEndpointManagedClustersRules tests behaviour when a managed cluster is hitting non-managed rules
 // Scenario without managed clusters is tested in other test cases
 func TestHTTPServer_OverviewEndpointManagedClustersRules(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{
@@ -1511,7 +1512,7 @@ func TestHTTPServer_OverviewEndpoint_UnavailableContentService(t *testing.T) {
 }
 
 func TestHTTPServer_OverviewGetEndpointDisabledRule(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory5Rules)
 	assert.Nil(t, err)
 
@@ -1631,7 +1632,7 @@ func TestHTTPServer_OverviewGetEndpointDisabledRule(t *testing.T) {
 
 // TestHTTPServer_OverviewEndpointWithFallback
 func TestHTTPServer_OverviewEndpointWithFallback(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1708,7 +1709,7 @@ func TestHTTPServer_OverviewEndpointWithFallback(t *testing.T) {
 }
 
 func TestInternalOrganizations(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{RuleContentInternal1},
@@ -1812,7 +1813,7 @@ func TestRuleNames(t *testing.T) {
 
 // TestRuleNamesResponse checks the REST API status and response
 func TestRuleNamesResponse(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{RuleContentInternal1, testdata.RuleContent1},
@@ -1858,7 +1859,7 @@ func TestRuleNamesResponse(t *testing.T) {
 
 // TestHTTPServer_OverviewWithClusterIDsEndpoint
 func TestHTTPServer_OverviewWithClusterIDsEndpoint(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1939,7 +1940,7 @@ func TestHTTPServer_OverviewWithClusterIDsEndpoint_UnavailableContentService(t *
 
 // TestHTTPServer_OverviewWithClusterIDsEndpoint
 func TestHTTPServer_OverviewWithClusterIDsEndpointDisabledRules(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -2021,7 +2022,7 @@ func TestHTTPServer_OverviewWithClusterIDsEndpointDisabledRules(t *testing.T) {
 
 // TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing
 func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, testdata.RuleContent2},
@@ -2097,7 +2098,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing(t *testin
 
 // TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisabled1Acked
 func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisabled1Acked(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, testdata.RuleContent2},
@@ -2207,7 +2208,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisab
 
 // TestHTTPServer_RecommendationsListEndpoint2Rules1MissingContent
 func TestHTTPServer_RecommendationsListEndpoint2Rules1MissingContent(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1},
@@ -2285,6 +2286,8 @@ func TestHTTPServer_RecommendationsListEndpoint_NoRuleContent(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
+		err := loadMockRuleContentDir(&ctypes.RuleContentDirectory{})
+		assert.Nil(t, err)
 		clusterInfoList := make([]types.ClusterInfo, 2)
 		for i := range clusterInfoList {
 			clusterInfoList[i] = data.GetRandomClusterInfo()
@@ -2349,7 +2352,7 @@ func TestHTTPServer_RecommendationsListEndpoint_NoRuleContent(t *testing.T) {
 
 // TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_ImpactingTrue
 func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_ImpactingTrue(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, testdata.RuleContent2, RuleContentInternal1},
@@ -2420,7 +2423,7 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 
 // TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_ImpactingFalse
 func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_ImpactingFalse(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, testdata.RuleContent2, RuleContentInternal1},
@@ -2492,7 +2495,7 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 
 // TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_ImpactingMissing
 func TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_ImpactingMissing(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, RuleContentInternal1},
@@ -2567,7 +2570,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_Impactin
 
 // TestHTTPServer_RecommendationsListEndpoint4Rules1Internal2Clusters_ImpactingMissing
 func TestHTTPServer_RecommendationsListEndpoint4Rules1Internal2Clusters_ImpactingMissing(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{
@@ -2676,7 +2679,7 @@ func TestHTTPServer_RecommendationsListEndpoint_BadImpactingParam(t *testing.T) 
 }
 
 func TestHTTPServer_RecommendationsListEndpointAMSManagedClusters(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, testdata.RuleContent2},
@@ -2753,7 +2756,7 @@ func TestHTTPServer_RecommendationsListEndpointAMSManagedClusters(t *testing.T) 
 
 // TestHTTPServer_GetRecommendationContent
 func TestHTTPServer_GetRecommendationContent(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, RuleContentInternal1},
@@ -2831,7 +2834,7 @@ func TestHTTPServer_GetRecommendationContent(t *testing.T) {
 
 // TestHTTPServer_GetRecommendationContentWithUserData
 func TestHTTPServer_GetRecommendationContentWithUserData(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, RuleContentInternal1},
@@ -3014,7 +3017,8 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_NoClusters(t *testing.T) {
 func TestHTTPServer_ClustersRecommendationsEndpoint_ClustersFoundNoInsights(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
-
+		err := loadMockRuleContentDir(&ctypes.RuleContentDirectory{})
+		assert.Nil(t, err)
 		clusterInfoList := data.GetRandomClusterInfoList(2)
 
 		clusterList := types.GetClusterNames(clusterInfoList)
@@ -3073,7 +3077,8 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_ClustersFoundNoInsights(t *t
 func TestHTTPServer_ClustersRecommendationsEndpoint_NoRuleHits(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
-
+		err := loadMockRuleContentDir(&ctypes.RuleContentDirectory{})
+		assert.Nil(t, err)
 		clusterInfoList := data.GetRandomClusterInfoList(2)
 
 		clusterList := types.GetClusterNames(clusterInfoList)
@@ -3144,7 +3149,8 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_NoRuleHits(t *testing.T) {
 func TestHTTPServer_ClustersRecommendationsEndpoint_NoReportInDB(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
-
+		err := loadMockRuleContentDir(&ctypes.RuleContentDirectory{})
+		assert.Nil(t, err)
 		clusterInfoList := data.GetRandomClusterInfoList(2)
 
 		clusterList := types.GetClusterNames(clusterInfoList)
@@ -3202,7 +3208,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_NoReportInDB(t *testing.T) {
 
 // TestHTTPServer_ClustersRecommendationsEndpoint_2ClustersFilled tests clusters received from AMS API with rule hits
 func TestHTTPServer_ClustersRecommendationsEndpoint_2ClustersFilled(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{
@@ -3286,7 +3292,6 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_2ClustersFilled(t *testing.T
 }
 
 func TestHTTPServer_ClustersRecommendationsEndpoint_2Clusters1Managed(t *testing.T) {
-	defer content.ResetContent()
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{
@@ -3371,7 +3376,6 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_2Clusters1Managed(t *testing
 }
 
 func TestHTTPServer_ClustersRecommendationsEndpoint_2Clusters1WithVersion(t *testing.T) {
-	defer content.ResetContent()
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{
@@ -3460,7 +3464,6 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_2Clusters1WithVersion(t *tes
 
 // TestHTTPServer_ClustersRecommendationsEndpoint_AckedRule tests clusters with an acked rule hitting both
 func TestHTTPServer_ClustersRecommendationsEndpoint_AckedRule(t *testing.T) {
-	defer content.ResetContent()
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{
@@ -3565,7 +3568,6 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_AckedRule(t *testing.T) {
 
 // TestHTTPServer_ClustersRecommendationsEndpoint_DisabledRuleSingleCluster tests clusters with a disabled rule on one of them
 func TestHTTPServer_ClustersRecommendationsEndpoint_DisabledRuleSingleCluster(t *testing.T) {
-	defer content.ResetContent()
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{
@@ -3674,7 +3676,6 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_DisabledRuleSingleCluster(t 
 
 // TestHTTPServer_ClustersRecommendationsEndpoint_DisabledAndAcked tests clusters with a disabled rule on one of them and another acked rule
 func TestHTTPServer_ClustersRecommendationsEndpoint_DisabledAndAcked(t *testing.T) {
-	defer content.ResetContent()
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -26,7 +26,6 @@ import (
 	ctypes "github.com/RedHatInsights/insights-results-types"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/services"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
@@ -87,7 +86,6 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 	clusters := []types.ClusterName{data.ClusterInfoResult2Clusters[0].ID, data.ClusterInfoResult2Clusters[1].ID}
 
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -216,7 +214,6 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_ImpactedClusterDi
 	clusters := []types.ClusterName{data.ClusterInfoResult2Clusters[0].ID, data.ClusterInfoResult2Clusters[1].ID}
 
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -328,7 +325,6 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_DisabledClusterNo
 	clusters := []types.ClusterName{testdata.ClusterName, data.ClusterInfoResult2Clusters[1].ID}
 
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -437,7 +433,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_DisabledClusterNo
 }
 
 func TestHTTPServer_ClustersDetailEndpointAMSManagedClusters(t *testing.T) {
-	defer content.ResetContent()
+
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, testdata.RuleContent2},
@@ -513,7 +509,6 @@ func TestHTTPServer_ClustersDetailEndpointAMSManagedClusters(t *testing.T) {
 // forwarded to the client
 func TestHTTPServer_ClustersDetailEndpointAggregatorResponse400(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -578,7 +573,6 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponse400(t *testing.T) {
 // forwarded to the client
 func TestHTTPServer_ClustersDetailEndpointAggregatorResponse404(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
@@ -647,7 +641,6 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponse404(t *testing.T) {
 // forwarded to the client
 func TestHTTPServer_ClustersDetailEndpointAggregatorResponse500(t *testing.T) {
 	defer helpers.CleanAfterGock(t)
-	defer content.ResetContent()
 
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)

--- a/server/rule_toggle_handlers_test.go
+++ b/server/rule_toggle_handlers_test.go
@@ -16,6 +16,7 @@ package server_test
 
 import (
 	"fmt"
+	ctypes "github.com/RedHatInsights/insights-results-types"
 	"net/http"
 	"testing"
 
@@ -23,7 +24,6 @@ import (
 	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
 	"github.com/stretchr/testify/assert"
 
-	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
 )
@@ -31,7 +31,7 @@ import (
 func TestEnableEndpoint(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
-		defer content.ResetContent()
+
 		err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 		assert.Nil(t, err)
 		expectedBody := `{"status": "ok"}`
@@ -74,7 +74,7 @@ func TestEnableEndpoint(t *testing.T) {
 func TestDisableEndpoint(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		defer helpers.CleanAfterGock(t)
-		defer content.ResetContent()
+
 		err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 		assert.Nil(t, err)
 		expectedBody := `{"status": "ok"}`
@@ -115,6 +115,8 @@ func TestDisableEndpoint(t *testing.T) {
 }
 
 func TestEnableEndpointBadErrorKey(t *testing.T) {
+	err := loadMockRuleContentDir(&ctypes.RuleContentDirectory{})
+	assert.Nil(t, err)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		expectedBody := fmt.Sprintf(
 			`{"status":"Item with ID %s/%s was not found in the storage"}`,
@@ -144,6 +146,8 @@ func TestEnableEndpointBadErrorKey(t *testing.T) {
 }
 
 func TestDisableEndpointBadErrorKey(t *testing.T) {
+	err := loadMockRuleContentDir(&ctypes.RuleContentDirectory{})
+	assert.Nil(t, err)
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		expectedBody := fmt.Sprintf(
 			`{"status":"Item with ID %s/%s was not found in the storage"}`,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1243,7 +1243,6 @@ func loadMockRuleContentDir(ruleContentDir *ctypes.RuleContentDirectory) error {
 	if err != nil {
 		return err
 	}
-	content.ResetContent()
 	content.LoadRuleContent(ruleContentDir)
 	return nil
 }


### PR DESCRIPTION
# Description

With this change, we improve the cache in the following way:
- The cache is updated once all the retrieved rules are parsed and added to a temporary RuleWithContentStorage. Every time the content is retrieved, the current cache is swapped with the temporary storage once it is fully prepared. Meanwhile, the previous cache is used to respond to requests related with rules content.
- The `content.ResetContent` function is no longer needed, as we are replacing the `RuleWithContentStorage` by assigning it to a new cache and discarding the previously existing one.
- The  `content.ResetContent` function has been moved to the `export_test.go` file of the content package as a helper for unit tests, and is no longer used in other packages.
- There is no longer a need for using mutexes as there is no simultaneous read and write, which should make the cache even more efficient.

Fixes CCXDEV-10263

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Refactor (refactoring code, removing useless files)

## Testing steps

- CI
- Tested the failing scenario against the service running locally with the fix

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
