### PR TITLE
implement `cluster/{cluster}/request/{request_id}/report` endpoint

### DIFF
--- a/server/endpoints_v2.go
+++ b/server/endpoints_v2.go
@@ -67,6 +67,10 @@ const (
 	// request ID
 	StatusOfRequestID = "clusters/{cluster}/request/{request_id}/status"
 
+	// RuleHitsForRequestID should return simplified results for given
+	// cluster and requestID
+	RuleHitsForRequestID = "cluster/{cluster}/request/{request_id}/report"
+
 	// Endpoints to acknowledge rule and to manipulate with
 	// acknowledgements.
 
@@ -138,6 +142,7 @@ func (server *HTTPServer) addV2RedisEndpointsToRouter(router *mux.Router, apiPre
 	router.HandleFunc(apiPrefix+ListAllRequestIDs, server.getRequestsForCluster).Methods(http.MethodGet)
 	router.HandleFunc(apiPrefix+ListAllRequestIDs, server.getRequestsForClusterPostVariant).Methods(http.MethodPost)
 	router.HandleFunc(apiPrefix+StatusOfRequestID, server.getRequestStatusForCluster).Methods(http.MethodGet)
+	router.HandleFunc(apiPrefix+RuleHitsForRequestID, server.getReportForRequest).Methods(http.MethodGet)
 }
 
 // addV2ReportsEndpointsToRouter method registers handlers for endpoints that

--- a/types/types.go
+++ b/types/types.go
@@ -50,7 +50,7 @@ type ImpactingFlag int
 
 // RequestID is used to store the request ID supplied in input Kafka records as
 // a unique identifier of payloads. Empty string represents a missing request ID.
-type RequestID string
+type RequestID types.RequestID
 
 // RuleWithContentResponse represents a single rule in the response of /report endpoint
 type RuleWithContentResponse struct {
@@ -270,10 +270,26 @@ type ClustersDetailResponse struct {
 	Status string             `json:"status"`
 }
 
-// RequestStatus contains description about one request ID
+// RequestStatus contains description about one request ID returned by the sercice to IO
 type RequestStatus struct {
 	RequestID string `json:"requestID" redis:"request_id"`
 	Valid     bool   `json:"valid" redis:"-"`
 	Received  string `json:"received" redis:"received_timestamp"`
 	Processed string `json:"processed" redis:"processed_timestamp"`
+}
+
+// SimplifiedRuleHit structure represents one simplified rule hit for On Demand Data Gathering
+type SimplifiedRuleHit struct {
+	RuleFQDN    string `json:"rule_fqdn"`
+	ErrorKey    string `json:"error_key"`
+	Description string `json:"description"`
+	TotalRisk   int    `json:"total_risk"`
+}
+
+// SimplifiedReport structure is used to handle single Request data hashes in Redis
+type SimplifiedReport struct {
+	RequestID          string `redis:"request_id"`
+	ReceivedTimestamp  string `redis:"received_timestamp"`
+	ProcessedTimestamp string `redis:"processed_timestamp"`
+	RuleHits           string `redis:"rule_hits"`
 }


### PR DESCRIPTION
# Description
- adds `cluster/{cluster}/request/{request_id}/report` handler to get simplified reports
- fixes some old bugs where it was possible to return HTTP 200 when aggregator returned 500

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- REST API tests

## Testing steps
local testing with real Redis with data according to spec doc

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
