### PR TITLE
`x-rh-identity` tests 1st part

### DIFF
--- a/server/auth.go
+++ b/server/auth.go
@@ -32,6 +32,10 @@ import (
 )
 
 const (
+	// JWTAuthTokenHeader reprsents the name of the header used in JWT authorization type
+	JWTAuthTokenHeader = "Authorization"
+	// XRHAuthTokenHeader reprsents the name of the header used in XRH authorization type
+	XRHAuthTokenHeader = "x-rh-identity"
 	// #nosec G101
 	malformedTokenMessage = "Malformed authentication token"
 	invalidTokenMessage   = "Invalid/Malformed auth token"
@@ -190,7 +194,7 @@ func (server *HTTPServer) getAuthTokenHeader(w http.ResponseWriter, r *http.Requ
 		log.Info().Msg("Retrieving jwt token")
 
 		// Grab the token from the header
-		tokenHeader = r.Header.Get("Authorization")
+		tokenHeader = r.Header.Get(JWTAuthTokenHeader)
 
 		if tokenHeader == "" {
 			log.Error().Msg(missingTokenMessage)
@@ -217,7 +221,7 @@ func (server *HTTPServer) getAuthTokenHeader(w http.ResponseWriter, r *http.Requ
 	} else {
 		log.Info().Msg("Retrieving x-rh-identity token")
 		// Grab the token from the header
-		tokenHeader = r.Header.Get("x-rh-identity")
+		tokenHeader = r.Header.Get(XRHAuthTokenHeader)
 	}
 
 	log.Info().Int("Length", len(tokenHeader)).Msg("Token retrieved")

--- a/server/auth.go
+++ b/server/auth.go
@@ -33,8 +33,10 @@ import (
 
 const (
 	// JWTAuthTokenHeader reprsents the name of the header used in JWT authorization type
+	// #nosec G101
 	JWTAuthTokenHeader = "Authorization"
 	// XRHAuthTokenHeader reprsents the name of the header used in XRH authorization type
+	// #nosec G101
 	XRHAuthTokenHeader = "x-rh-identity"
 	// #nosec G101
 	malformedTokenMessage = "Malformed authentication token"

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -67,16 +67,16 @@ func TestHTTPServer_SetRating(t *testing.T) {
 
 	helpers.AssertAPIv2Request(
 		t,
-		&serverConfigJWT,
+		&helpers.DefaultServerConfigXRH,
 		nil,
 		nil,
 		nil,
 		nil,
 		&helpers.APIRequest{
-			Method:             http.MethodPost,
-			Endpoint:           server.Rating,
-			Body:               rating,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:      http.MethodPost,
+			Endpoint:    server.Rating,
+			Body:        rating,
+			XRHIdentity: goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       rating,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -69,6 +69,7 @@ var (
 	// invalidJWTAuthBearer is goodJWTAuthBearer with the org_id type set as int
 	invalidJWTAuthBearer      = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NvdW50X251bWJlciI6IjUyMTM0NzYiLCJvcmdfaWQiOjEsImp0aSI6IjA1NDQzYjk5LWQ4MjQtNDgwYi1hNGJlLTM3OTc3NDA1ZjA5MyIsImlhdCI6MTU5NDEyNjM0MCwiZXhwIjoxNTk0MTQxODQ3fQ.GndJUWNaG4IWm8OkKBs_1uvD1-vaJqL2Xvf9QiGvlRw"
 	userIDOnGoodJWTAuthBearer = "1"
+	goodXRHAuthToken          = `eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjAzNjkyMzMiLCJvcmdfaWQiOiIxIiwidHlwZSI6IlVzZXIiLCJ1c2VyIjp7InVzZXJuYW1lIjoiamRvZSIsImVtYWlsIjoiamRvZUBhY21lLmNvbSIsImZpcnN0X25hbWUiOiJKb2huIiwibGFzdF9uYW1lIjoiRG9lIiwiaXNfYWN0aXZlIjp0cnVlLCJpc19vcmdfYWRtaW4iOmZhbHNlLCJpc19pbnRlcm5hbCI6ZmFsc2UsImxvY2FsZSI6ImVuX1VTIn0sImludGVybmFsIjp7Im9yZ19pZCI6IjEiLCJhdXRoX3R5cGUiOiJiYXNpYy1hdXRoIiwiYXV0aF90aW1lIjo2MzAwfX19Cg==`
 	testTimeStr               = "2021-01-02T15:04:05Z"
 	testTimestamp             = types.Timestamp(testTimeStr)
 

--- a/tests/helpers/http.go
+++ b/tests/helpers/http.go
@@ -81,6 +81,21 @@ var (
 		EnableInternalRulesOrganizations: false,
 	}
 
+	DefaultServerConfigXRH = server.Configuration{
+		Address:                          ":8081",
+		APIdbgPrefix:                     "/api/dbg/",
+		APIv1Prefix:                      "/api/v1/",
+		APIv2Prefix:                      "/api/v2/",
+		APIv1SpecFile:                    "server/api/v1/openapi.json",
+		APIv2SpecFile:                    "server/api/v2/openapi.json",
+		Debug:                            true,
+		Auth:                             true,
+		AuthType:                         "xrh",
+		UseHTTPS:                         false,
+		EnableCORS:                       false,
+		EnableInternalRulesOrganizations: false,
+	}
+
 	// DefaultServerConfigCORS is data structure that represents default
 	// server configuration with CORS enabled
 	DefaultServerConfigCORS = server.Configuration{

--- a/tests/helpers/http.go
+++ b/tests/helpers/http.go
@@ -81,6 +81,8 @@ var (
 		EnableInternalRulesOrganizations: false,
 	}
 
+	// DefaultServerConfigXRH is data structure that represents default HTTP
+	// server configuration with XRH auth type. XRH type is used in all pre-prod/prod environments.
 	DefaultServerConfigXRH = server.Configuration{
 		Address:                          ":8081",
 		APIdbgPrefix:                     "/api/dbg/",


### PR DESCRIPTION
# Description
1st part of adding UT coverage for `x-rh-identity` auth header type.

JWT auth type is not used in any environment anymore, so until now, we practically had zero coverage for the auth type we're actually using.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps
`make before_commit`

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
