### PR TITLE
`x-rh-identity` tests 4th part

### DIFF
--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -927,7 +927,7 @@ func TestHTTPServer_GetRequestStatusForCluster_BadAuthToken(t *testing.T) {
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, nil, &redisClient, nil, nil, nil)
 
 		// bad token
 		iou_helpers.AssertAPIRequest(
@@ -935,10 +935,10 @@ func TestHTTPServer_GetRequestStatusForCluster_BadAuthToken(t *testing.T) {
 			testServer,
 			serverConfigJWT.APIv2Prefix,
 			&helpers.APIRequest{
-				Method:             http.MethodGet,
-				Endpoint:           server.StatusOfRequestID,
-				EndpointArgs:       []interface{}{testdata.ClusterName, "requestID1"},
-				AuthorizationToken: unparsableJWTAuthBearer,
+				Method:       http.MethodGet,
+				Endpoint:     server.StatusOfRequestID,
+				EndpointArgs: []interface{}{testdata.ClusterName, "requestID1"},
+				XRHIdentity:  invalidXRHAuthToken,
 			}, &helpers.APIResponse{
 				StatusCode: http.StatusForbidden,
 			},
@@ -1183,7 +1183,7 @@ func TestHTTPServer_GetRequestsForCluster_BadAuthToken(t *testing.T) {
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, nil, &redisClient, nil, nil, nil)
 
 		// invalid clusterID
 		iou_helpers.AssertAPIRequest(
@@ -1191,10 +1191,10 @@ func TestHTTPServer_GetRequestsForCluster_BadAuthToken(t *testing.T) {
 			testServer,
 			serverConfigJWT.APIv2Prefix,
 			&helpers.APIRequest{
-				Method:             http.MethodGet,
-				Endpoint:           server.ListAllRequestIDs,
-				EndpointArgs:       []interface{}{testdata.ClusterName},
-				AuthorizationToken: unparsableJWTAuthBearer,
+				Method:       http.MethodGet,
+				Endpoint:     server.ListAllRequestIDs,
+				EndpointArgs: []interface{}{testdata.ClusterName},
+				XRHIdentity:  invalidXRHAuthToken,
 			}, &helpers.APIResponse{
 				StatusCode: http.StatusForbidden,
 			},
@@ -1487,7 +1487,7 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_BadAuthToken(t *testing.T) 
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, nil, &redisClient, nil, nil, nil)
 
 		requestIDList := []types.RequestID{"requestID1"}
 		reqBody, _ := json.Marshal(requestIDList)
@@ -1498,11 +1498,11 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_BadAuthToken(t *testing.T) 
 			testServer,
 			serverConfigJWT.APIv2Prefix,
 			&helpers.APIRequest{
-				Method:             http.MethodPost,
-				Endpoint:           server.ListAllRequestIDs,
-				EndpointArgs:       []interface{}{testdata.ClusterName},
-				AuthorizationToken: unparsableJWTAuthBearer,
-				Body:               reqBody,
+				Method:       http.MethodPost,
+				Endpoint:     server.ListAllRequestIDs,
+				EndpointArgs: []interface{}{testdata.ClusterName},
+				XRHIdentity:  invalidXRHAuthToken,
+				Body:         reqBody,
 			}, &helpers.APIResponse{
 				StatusCode: http.StatusForbidden,
 			},
@@ -1784,7 +1784,7 @@ func TestHTTPServer_GetReportForRequest_BadAuthToken(t *testing.T) {
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&serverConfigJWT, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, nil, &redisClient, nil, nil, nil)
 
 		// invalid clusterID
 		iou_helpers.AssertAPIRequest(
@@ -1792,10 +1792,10 @@ func TestHTTPServer_GetReportForRequest_BadAuthToken(t *testing.T) {
 			testServer,
 			serverConfigJWT.APIv2Prefix,
 			&helpers.APIRequest{
-				Method:             http.MethodGet,
-				Endpoint:           server.RuleHitsForRequestID,
-				EndpointArgs:       []interface{}{testdata.ClusterName, "requestID1"},
-				AuthorizationToken: unparsableJWTAuthBearer,
+				Method:       http.MethodGet,
+				Endpoint:     server.RuleHitsForRequestID,
+				EndpointArgs: []interface{}{testdata.ClusterName, "requestID1"},
+				XRHIdentity:  invalidXRHAuthToken,
 			}, &helpers.APIResponse{
 				StatusCode: http.StatusForbidden,
 			},

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -62,10 +62,6 @@ var (
 	// 	"exp": 1594141847
 	// }
 	goodJWTAuthBearer = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NvdW50X251bWJlciI6IjUyMTM0NzYiLCJvcmdfaWQiOiIxIiwidXNlcl9pZCI6IjEiLCJqdGkiOiIwNTQ0M2I5OS1kODI0LTQ4MGItYTRiZS0zNzk3NzQwNWYwOTMiLCJpYXQiOjE1OTQxMjYzNDAsImV4cCI6MTU5NDE0MTg0N30K.pp32mPoypnRjOYE95SrBar0fdLS9t_hndOtP5qUvB-c"
-	// unparsableJWTAuthBearer cannot be parsed
-	unparsableJWTAuthBearer = "Bearer this_is^not.a-token"
-	// anemicJWTAuthBearer is goodJWTAuthBearer without account_number
-	anemicJWTAuthBearer = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJvcmdfaWQiOiIxIiwidXNlcl9pZCI6IjEiLCJqdGkiOiIwNTQ0M2I5OS1kODI0LTQ4MGItYTRiZS0zNzk3NzQwNWYwOTMiLCJpYXQiOjE1OTQxMjYzNDAsImV4cCI6MTU5NDE0MTg0N30K.P6-6BJ4hUpLzCqsmGHthe0B1opU3Tz6nMtCQ-Yvuea4"
 	// invalidJWTAuthBearer is goodJWTAuthBearer with the org_id type set as int
 	invalidJWTAuthBearer      = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NvdW50X251bWJlciI6IjUyMTM0NzYiLCJvcmdfaWQiOjEsImp0aSI6IjA1NDQzYjk5LWQ4MjQtNDgwYi1hNGJlLTM3OTc3NDA1ZjA5MyIsImlhdCI6MTU5NDEyNjM0MCwiZXhwIjoxNTk0MTQxODQ3fQ.GndJUWNaG4IWm8OkKBs_1uvD1-vaJqL2Xvf9QiGvlRw"
 	userIDOnGoodJWTAuthBearer = "1"

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -69,9 +69,16 @@ var (
 	// invalidJWTAuthBearer is goodJWTAuthBearer with the org_id type set as int
 	invalidJWTAuthBearer      = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NvdW50X251bWJlciI6IjUyMTM0NzYiLCJvcmdfaWQiOjEsImp0aSI6IjA1NDQzYjk5LWQ4MjQtNDgwYi1hNGJlLTM3OTc3NDA1ZjA5MyIsImlhdCI6MTU5NDEyNjM0MCwiZXhwIjoxNTk0MTQxODQ3fQ.GndJUWNaG4IWm8OkKBs_1uvD1-vaJqL2Xvf9QiGvlRw"
 	userIDOnGoodJWTAuthBearer = "1"
-	goodXRHAuthToken          = `eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEiLCJvcmdfaWQiOiIxIiwidHlwZSI6IlVzZXIiLCJ1c2VyIjp7InVzZXJuYW1lIjoiamRvZSIsInVzZXJfaWQiOiIxIiwiZW1haWwiOiJqZG9lQGFjbWUuY29tIiwiZmlyc3RfbmFtZSI6IkpvaG4iLCJsYXN0X25hbWUiOiJEb2UiLCJpc19hY3RpdmUiOnRydWUsImlzX29yZ19hZG1pbiI6ZmFsc2UsImlzX2ludGVybmFsIjpmYWxzZSwibG9jYWxlIjoiZW5fVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMSIsImF1dGhfdHlwZSI6ImJhc2ljLWF1dGgiLCJhdXRoX3RpbWUiOjYzMDB9fX0K`
-	testTimeStr               = "2021-01-02T15:04:05Z"
-	testTimestamp             = types.Timestamp(testTimeStr)
+	// goodXRHAuthToken is in following structure https://docs.google.com/document/d/1PAzJqcUXlxg7t5cX1lsPsQtBPT_95bZbyB9Iiv_ekGM/
+	// with expected values (org_id == 1, account_number == 1)
+	goodXRHAuthToken = `eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEiLCJvcmdfaWQiOiIxIiwidHlwZSI6IlVzZXIiLCJ1c2VyIjp7InVzZXJuYW1lIjoiamRvZSIsInVzZXJfaWQiOiIxIiwiZW1haWwiOiJqZG9lQGFjbWUuY29tIiwiZmlyc3RfbmFtZSI6IkpvaG4iLCJsYXN0X25hbWUiOiJEb2UiLCJpc19hY3RpdmUiOnRydWUsImlzX29yZ19hZG1pbiI6ZmFsc2UsImlzX2ludGVybmFsIjpmYWxzZSwibG9jYWxlIjoiZW5fVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMSIsImF1dGhfdHlwZSI6ImJhc2ljLWF1dGgiLCJhdXRoX3RpbWUiOjYzMDB9fX0K`
+	// badXRHAuthToken has correct structure, but unexpected values (org_id == 1234, account_number == 1234)
+	badXRHAuthToken = `eyJpZGVudGl0eSI6eyJhY2NvdW50X251bWJlciI6IjEyMzQiLCJvcmdfaWQiOiIxMjM0IiwidHlwZSI6IlVzZXIiLCJ1c2VyIjp7InVzZXJuYW1lIjoiamRvZSIsInVzZXJfaWQiOiIxMjM0IiwiZW1haWwiOiJqZG9lQGFjbWUuY29tIiwiZmlyc3RfbmFtZSI6IkpvaG4iLCJsYXN0X25hbWUiOiJEb2UiLCJpc19hY3RpdmUiOnRydWUsImlzX29yZ19hZG1pbiI6ZmFsc2UsImlzX2ludGVybmFsIjpmYWxzZSwibG9jYWxlIjoiZW5fVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMTIzNCIsImF1dGhfdHlwZSI6ImJhc2ljLWF1dGgiLCJhdXRoX3RpbWUiOjYzMDB9fX0K`
+	// anemicXRHAuthToken has correct structure, but is missing account_number
+	anemicXRHAuthToken  = `eyJpZGVudGl0eSI6eyJvcmdfaWQiOiIxIiwidHlwZSI6IlVzZXIiLCJ1c2VyIjp7InVzZXJuYW1lIjoiamRvZSIsInVzZXJfaWQiOiIxIiwiZW1haWwiOiJqZG9lQGFjbWUuY29tIiwiZmlyc3RfbmFtZSI6IkpvaG4iLCJsYXN0X25hbWUiOiJEb2UiLCJpc19hY3RpdmUiOnRydWUsImlzX29yZ19hZG1pbiI6ZmFsc2UsImlzX2ludGVybmFsIjpmYWxzZSwibG9jYWxlIjoiZW5fVVMifSwiaW50ZXJuYWwiOnsib3JnX2lkIjoiMSIsImF1dGhfdHlwZSI6ImJhc2ljLWF1dGgiLCJhdXRoX3RpbWUiOjYzMDB9fX0K`
+	invalidXRHAuthToken = `invalid token`
+	testTimeStr         = "2021-01-02T15:04:05Z"
+	testTimestamp       = types.Timestamp(testTimeStr)
 
 	serverConfigJWT = server.Configuration{
 		Address:                          ":8081",
@@ -96,7 +103,7 @@ var (
 		APIv2SpecFile:                    "server/api/v2/openapi.json",
 		Debug:                            true,
 		Auth:                             true,
-		AuthType:                         "jwt",
+		AuthType:                         "xrh",
 		UseHTTPS:                         false,
 		EnableCORS:                       false,
 		EnableInternalRulesOrganizations: true,
@@ -113,7 +120,7 @@ var (
 		APIv2SpecFile:                    "server/api/v2/openapi.json",
 		Debug:                            true,
 		Auth:                             true,
-		AuthType:                         "jwt",
+		AuthType:                         "xrh",
 		UseHTTPS:                         false,
 		EnableCORS:                       false,
 		EnableInternalRulesOrganizations: true,


### PR DESCRIPTION
# Description
- change negative test cases (unparsable token/token with bad values) to XRH identity
- change test cases for anemic tenants (missing account_number from token) to XRH identity

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
