### PR TITLE
`x-rh-identity` tests final part

### DIFF
--- a/server/acks_test.go
+++ b/server/acks_test.go
@@ -64,9 +64,9 @@ func TestHTTPServer_TestReadAckListNoResult(t *testing.T) {
 	}
 	`
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodGet,
-		Endpoint:           server.AckListEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
+		Method:      http.MethodGet,
+		Endpoint:    server.AckListEndpoint,
+		XRHIdentity: goodXRHAuthToken,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       ackListResponse,
@@ -139,9 +139,9 @@ func TestHTTPServer_TestReadAckList1Result(t *testing.T) {
 	ackListResponse = fmt.Sprintf(ackListResponse, testdata.Rule1CompositeID, justificationNote, disabledAtRFC, disabledAtRFC)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodGet,
-		Endpoint:           server.AckListEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
+		Method:      http.MethodGet,
+		Endpoint:    server.AckListEndpoint,
+		XRHIdentity: goodXRHAuthToken,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       ackListResponse,
@@ -240,9 +240,9 @@ func TestHTTPServer_TestReadAckList2Results(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodGet,
-		Endpoint:           server.AckListEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
+		Method:      http.MethodGet,
+		Endpoint:    server.AckListEndpoint,
+		XRHIdentity: goodXRHAuthToken,
 	}, &helpers.APIResponse{
 		StatusCode:  http.StatusOK,
 		Body:        ackListResponse,
@@ -283,9 +283,9 @@ func TestHTTPServer_TestReadAckListInvalidToken(t *testing.T) {
 	}
 	`
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodGet,
-		Endpoint:           server.AckListEndpoint,
-		AuthorizationToken: badJWTAuthBearer,
+		Method:      http.MethodGet,
+		Endpoint:    server.AckListEndpoint,
+		XRHIdentity: invalidXRHAuthToken,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusForbidden,
 		Body:       ackListResponse,
@@ -312,9 +312,9 @@ func TestHTTPServer_TestReadAckListAggregatorError(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodGet,
-		Endpoint:           server.AckListEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
+		Method:      http.MethodGet,
+		Endpoint:    server.AckListEndpoint,
+		XRHIdentity: goodXRHAuthToken,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusInternalServerError,
 	})
@@ -341,9 +341,9 @@ func TestHTTPServer_TestReadAckListUnparsableAggregatorJSON(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodGet,
-		Endpoint:           server.AckListEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
+		Method:      http.MethodGet,
+		Endpoint:    server.AckListEndpoint,
+		XRHIdentity: goodXRHAuthToken,
 	}, &helpers.APIResponse{
 		// also 500, but testing different condition
 		StatusCode: http.StatusInternalServerError,
@@ -378,10 +378,10 @@ func TestHTTPServer_TestGetAcknowledgeNotFound(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodGet,
-		Endpoint:           server.AckGetEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
+		Method:       http.MethodGet,
+		Endpoint:     server.AckGetEndpoint,
+		XRHIdentity:  goodXRHAuthToken,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusNotFound,
 	})
@@ -407,10 +407,10 @@ func TestHTTPServer_TestGetAcknowledgeAggregatorError(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodGet,
-		Endpoint:           server.AckGetEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
+		Method:       http.MethodGet,
+		Endpoint:     server.AckGetEndpoint,
+		XRHIdentity:  goodXRHAuthToken,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusInternalServerError,
 	})
@@ -437,10 +437,10 @@ func TestHTTPServer_TestGetAcknowledgeUnparsableAggregatorJSON(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodGet,
-		Endpoint:           server.AckGetEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
+		Method:       http.MethodGet,
+		Endpoint:     server.AckGetEndpoint,
+		XRHIdentity:  goodXRHAuthToken,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
 	}, &helpers.APIResponse{
 		// also 500, but testing different condition
 		StatusCode: http.StatusInternalServerError,
@@ -508,10 +508,10 @@ func TestHTTPServer_TestGetAcknowledgeFound(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodGet,
-		Endpoint:           server.AckGetEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
+		Method:       http.MethodGet,
+		Endpoint:     server.AckGetEndpoint,
+		XRHIdentity:  goodXRHAuthToken,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       expectedResponse,
@@ -566,9 +566,9 @@ func TestHTTPServer_TestGetAcknowledgeInvalidRuleIDBadRequest(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodGet,
-		Endpoint:           server.AckGetEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
+		Method:      http.MethodGet,
+		Endpoint:    server.AckGetEndpoint,
+		XRHIdentity: goodXRHAuthToken,
 		// invalid composite rule ID
 		EndpointArgs: []interface{}{testdata.Rule1ID},
 	}, &helpers.APIResponse{
@@ -596,10 +596,10 @@ func TestHTTPServer_TestGetAcknowledgeInvalidToken(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodGet,
-		Endpoint:           server.AckGetEndpoint,
-		AuthorizationToken: invalidJWTAuthBearer,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
+		Method:       http.MethodGet,
+		Endpoint:     server.AckGetEndpoint,
+		XRHIdentity:  invalidXRHAuthToken,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusForbidden,
 	})
@@ -689,10 +689,10 @@ func TestHTTPServer_TestAcknowledgePostFound(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPost,
-		Endpoint:           server.AckAcknowledgePostEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
-		Body:               reqBody,
+		Method:      http.MethodPost,
+		Endpoint:    server.AckAcknowledgePostEndpoint,
+		XRHIdentity: goodXRHAuthToken,
+		Body:        reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       expectedResponse,
@@ -808,10 +808,10 @@ func TestHTTPServer_TestAcknowledgePostNewAck(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPost,
-		Endpoint:           server.AckAcknowledgePostEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
-		Body:               reqBody,
+		Method:      http.MethodPost,
+		Endpoint:    server.AckAcknowledgePostEndpoint,
+		XRHIdentity: goodXRHAuthToken,
+		Body:        reqBody,
 	}, &helpers.APIResponse{
 		// 201 CREATED when rule wasn't acked before
 		StatusCode: http.StatusCreated,
@@ -836,10 +836,10 @@ func TestHTTPServer_TestAcknowledgePostMissingParam(t *testing.T) {
 	reqBody = fmt.Sprintf(reqBody, justificationNote)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPost,
-		Endpoint:           server.AckAcknowledgePostEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
-		Body:               reqBody,
+		Method:      http.MethodPost,
+		Endpoint:    server.AckAcknowledgePostEndpoint,
+		XRHIdentity: goodXRHAuthToken,
+		Body:        reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusBadRequest,
 	})
@@ -862,10 +862,10 @@ func TestHTTPServer_TestAcknowledgePostBadCompositeRuleID(t *testing.T) {
 	reqBody = fmt.Sprintf(reqBody, justificationNote)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPost,
-		Endpoint:           server.AckAcknowledgePostEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
-		Body:               reqBody,
+		Method:      http.MethodPost,
+		Endpoint:    server.AckAcknowledgePostEndpoint,
+		XRHIdentity: goodXRHAuthToken,
+		Body:        reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusBadRequest,
 	})
@@ -901,10 +901,10 @@ func TestHTTPServer_TestAcknowledgePostAggregatorError1stCall(t *testing.T) {
 	reqBody = fmt.Sprintf(reqBody, testdata.Rule1CompositeID, justificationNote)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPost,
-		Endpoint:           server.AckAcknowledgePostEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
-		Body:               reqBody,
+		Method:      http.MethodPost,
+		Endpoint:    server.AckAcknowledgePostEndpoint,
+		XRHIdentity: goodXRHAuthToken,
+		Body:        reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusInternalServerError,
 	})
@@ -987,10 +987,10 @@ func TestHTTPServer_TestAcknowledgePostAggregatorError2ndCall(t *testing.T) {
 	reqBody = fmt.Sprintf(reqBody, testdata.Rule1CompositeID, justificationNote)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPost,
-		Endpoint:           server.AckAcknowledgePostEndpoint,
-		AuthorizationToken: goodJWTAuthBearer,
-		Body:               reqBody,
+		Method:      http.MethodPost,
+		Endpoint:    server.AckAcknowledgePostEndpoint,
+		XRHIdentity: goodXRHAuthToken,
+		Body:        reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusInternalServerError,
 	})
@@ -1011,10 +1011,10 @@ func TestHTTPServer_TestAcknowledgePostInvalidToken(t *testing.T) {
 	reqBody = fmt.Sprintf(reqBody, testdata.Rule1CompositeID, "justification")
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPost,
-		Endpoint:           server.AckAcknowledgePostEndpoint,
-		AuthorizationToken: invalidJWTAuthBearer,
-		Body:               reqBody,
+		Method:      http.MethodPost,
+		Endpoint:    server.AckAcknowledgePostEndpoint,
+		XRHIdentity: invalidXRHAuthToken,
+		Body:        reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusForbidden,
 	})
@@ -1058,11 +1058,11 @@ func TestHTTPServer_TestAcknowledgeUpdateNotFound(t *testing.T) {
 	reqBody = fmt.Sprintf(reqBody, justificationNote)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPut,
-		Endpoint:           server.AckUpdateEndpoint,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
-		AuthorizationToken: goodJWTAuthBearer,
-		Body:               reqBody,
+		Method:       http.MethodPut,
+		Endpoint:     server.AckUpdateEndpoint,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
+		XRHIdentity:  goodXRHAuthToken,
+		Body:         reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusNotFound,
 	})
@@ -1193,11 +1193,11 @@ func TestHTTPServer_TestAcknowledgeUpdateFound(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPut,
-		Endpoint:           server.AckUpdateEndpoint,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
-		AuthorizationToken: goodJWTAuthBearer,
-		Body:               reqBody,
+		Method:       http.MethodPut,
+		Endpoint:     server.AckUpdateEndpoint,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
+		XRHIdentity:  goodXRHAuthToken,
+		Body:         reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Body:       expectedResponse,
@@ -1221,11 +1221,11 @@ func TestHTTPServer_TestAcknowledgeUpdateBadCompositeRuleID(t *testing.T) {
 	reqBody = fmt.Sprintf(reqBody, justificationNote)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPut,
-		Endpoint:           server.AckUpdateEndpoint,
-		EndpointArgs:       []interface{}{"invalid rule id"},
-		AuthorizationToken: goodJWTAuthBearer,
-		Body:               reqBody,
+		Method:       http.MethodPut,
+		Endpoint:     server.AckUpdateEndpoint,
+		EndpointArgs: []interface{}{"invalid rule id"},
+		XRHIdentity:  goodXRHAuthToken,
+		Body:         reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusBadRequest,
 	})
@@ -1260,11 +1260,11 @@ func TestHTTPServer_TestAcknowledgeUpdateAggregatorError1st(t *testing.T) {
 	reqBody = fmt.Sprintf(reqBody, justificationUpdated)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPut,
-		Endpoint:           server.AckUpdateEndpoint,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
-		AuthorizationToken: goodJWTAuthBearer,
-		Body:               reqBody,
+		Method:       http.MethodPut,
+		Endpoint:     server.AckUpdateEndpoint,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
+		XRHIdentity:  goodXRHAuthToken,
+		Body:         reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusInternalServerError,
 	})
@@ -1344,11 +1344,11 @@ func TestHTTPServer_TestAcknowledgeUpdateAggregatorError2nd(t *testing.T) {
 	reqBody = fmt.Sprintf(reqBody, justificationUpdated)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPut,
-		Endpoint:           server.AckUpdateEndpoint,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
-		AuthorizationToken: goodJWTAuthBearer,
-		Body:               reqBody,
+		Method:       http.MethodPut,
+		Endpoint:     server.AckUpdateEndpoint,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
+		XRHIdentity:  goodXRHAuthToken,
+		Body:         reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusInternalServerError,
 	})
@@ -1442,11 +1442,11 @@ func TestHTTPServer_TestAcknowledgeUpdateAggregatorError3rd(t *testing.T) {
 	reqBody = fmt.Sprintf(reqBody, justificationUpdated)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPut,
-		Endpoint:           server.AckUpdateEndpoint,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
-		AuthorizationToken: goodJWTAuthBearer,
-		Body:               reqBody,
+		Method:       http.MethodPut,
+		Endpoint:     server.AckUpdateEndpoint,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
+		XRHIdentity:  goodXRHAuthToken,
+		Body:         reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusInternalServerError,
 	})
@@ -1466,11 +1466,11 @@ func TestHTTPServer_TestAcknowledgeUpdateInvalidToken(t *testing.T) {
 	reqBody = fmt.Sprintf(reqBody, "justification")
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodPut,
-		Endpoint:           server.AckUpdateEndpoint,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
-		AuthorizationToken: invalidJWTAuthBearer,
-		Body:               reqBody,
+		Method:       http.MethodPut,
+		Endpoint:     server.AckUpdateEndpoint,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
+		XRHIdentity:  invalidXRHAuthToken,
+		Body:         reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusForbidden,
 	})
@@ -1538,10 +1538,10 @@ func TestHTTPServer_TestAcknowledgeDeleteFound(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodDelete,
-		Endpoint:           server.AckDeleteEndpoint,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
-		AuthorizationToken: goodJWTAuthBearer,
+		Method:       http.MethodDelete,
+		Endpoint:     server.AckDeleteEndpoint,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
+		XRHIdentity:  goodXRHAuthToken,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusNoContent,
 	})
@@ -1574,10 +1574,10 @@ func TestHTTPServer_TestAcknowledgeDeleteNotFound(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodDelete,
-		Endpoint:           server.AckDeleteEndpoint,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
-		AuthorizationToken: goodJWTAuthBearer,
+		Method:       http.MethodDelete,
+		Endpoint:     server.AckDeleteEndpoint,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
+		XRHIdentity:  goodXRHAuthToken,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusNotFound,
 	})
@@ -1590,10 +1590,10 @@ func TestHTTPServer_TestAcknowledgeDeleteBadRequest(t *testing.T) {
 	assert.Nil(t, err)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodDelete,
-		Endpoint:           server.AckDeleteEndpoint,
-		EndpointArgs:       []interface{}{"invalid rule id"},
-		AuthorizationToken: goodJWTAuthBearer,
+		Method:       http.MethodDelete,
+		Endpoint:     server.AckDeleteEndpoint,
+		EndpointArgs: []interface{}{"invalid rule id"},
+		XRHIdentity:  goodXRHAuthToken,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusBadRequest,
 	})
@@ -1613,11 +1613,11 @@ func TestHTTPServer_TestAcknowledgeDeleteInvalidToken(t *testing.T) {
 	reqBody = fmt.Sprintf(reqBody, "justification")
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodDelete,
-		Endpoint:           server.AckDeleteEndpoint,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
-		AuthorizationToken: invalidJWTAuthBearer,
-		Body:               reqBody,
+		Method:       http.MethodDelete,
+		Endpoint:     server.AckDeleteEndpoint,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
+		XRHIdentity:  invalidXRHAuthToken,
+		Body:         reqBody,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusForbidden,
 	})
@@ -1650,10 +1650,10 @@ func TestHTTPServer_TestAcknowledgeDeleteAggregatorError1st(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodDelete,
-		Endpoint:           server.AckDeleteEndpoint,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
-		AuthorizationToken: goodJWTAuthBearer,
+		Method:       http.MethodDelete,
+		Endpoint:     server.AckDeleteEndpoint,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
+		XRHIdentity:  goodXRHAuthToken,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusInternalServerError,
 	})
@@ -1721,10 +1721,10 @@ func TestHTTPServer_TestAcknowledgeDeleteAggregatorError2nd(t *testing.T) {
 	)
 
 	helpers.AssertAPIv2Request(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-		Method:             http.MethodDelete,
-		Endpoint:           server.AckDeleteEndpoint,
-		EndpointArgs:       []interface{}{testdata.Rule1CompositeID},
-		AuthorizationToken: goodJWTAuthBearer,
+		Method:       http.MethodDelete,
+		Endpoint:     server.AckDeleteEndpoint,
+		EndpointArgs: []interface{}{testdata.Rule1CompositeID},
+		XRHIdentity:  goodXRHAuthToken,
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusInternalServerError,
 	})

--- a/server/endpoints_test.go
+++ b/server/endpoints_test.go
@@ -72,12 +72,12 @@ func TestHTTPServer_ProxyTo_VoteEndpointsExtractUserID(t *testing.T) {
 				})
 
 				helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-					Method:             testCase.method,
-					Endpoint:           testCase.endpoint,
-					EndpointArgs:       []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1},
-					UserID:             testdata.UserID,
-					OrgID:              testdata.OrgID,
-					AuthorizationToken: goodJWTAuthBearer,
+					Method:       testCase.method,
+					Endpoint:     testCase.endpoint,
+					EndpointArgs: []interface{}{testdata.ClusterName, testdata.Rule1ID, testdata.ErrorKey1},
+					UserID:       testdata.UserID,
+					OrgID:        testdata.OrgID,
+					XRHIdentity:  goodXRHAuthToken,
 				}, &helpers.APIResponse{
 					StatusCode: http.StatusOK,
 					Body:       `{"status": "ok"}`,

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -336,12 +336,12 @@ func TestHTTPServer_ReportEndpoint(t *testing.T) {
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportEndpoint,
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyV1ReportResponse3Rules),
@@ -373,12 +373,12 @@ func TestHTTPServer_ReportEndpoint_UnavailableContentService(t *testing.T) {
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportEndpoint,
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusServiceUnavailable,
 			Body:       expectedBody,
@@ -407,12 +407,12 @@ func TestHTTPServer_ReportEndpointNoContent(t *testing.T) {
 
 		// previously was InternalServerError, but it was changed as an edge-case which will appear as "No issues found"
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportEndpoint,
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyV1ReportResponse1RuleNoContent),
@@ -586,12 +586,12 @@ func TestHTTPServer_ReportEndpointNoContentFor2Rules(t *testing.T) {
 
 		// 1 rule returned, but count = 3
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportEndpoint,
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyV1ReportResponse3Rules2NoContent),
@@ -619,12 +619,12 @@ func TestHTTPServer_ReportEndpoint_WithOnlyOSDEndpoint(t *testing.T) {
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportEndpoint + "?" + server.OSDEligibleParam + "=true",
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportEndpoint + "?" + server.OSDEligibleParam + "=true",
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyV1ReportResponse3RulesWithOnlyOSD),
@@ -762,12 +762,12 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRulesForCluster(t *testing.T) {
 		}
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportEndpoint + "?" + server.GetDisabledParam + "=false",
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportEndpoint + "?" + server.GetDisabledParam + "=false",
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyV1ReportResponse3RulesOnlyEnabled),
@@ -775,12 +775,12 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRulesForCluster(t *testing.T) {
 
 		// Not using the parameter gets the same result as using with =false
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportEndpoint,
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyV1ReportResponse3RulesOnlyEnabled),
@@ -788,12 +788,12 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRulesForCluster(t *testing.T) {
 
 		// Enabling the parameter
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportEndpoint + "?" + server.GetDisabledParam + "=true",
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportEndpoint + "?" + server.GetDisabledParam + "=true",
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyV1ReportResponse3RulesAll),
@@ -821,12 +821,12 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRulesForClusterAndMissingContent(
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportEndpoint,
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyV1EmptyResponseDisabledRulesMissingContent),
@@ -862,12 +862,12 @@ func TestHTTPServer_ReportEndpoint_WithClusterAndSystemWideDisabledRules(t *test
 		}
 		// Get report with get_disabled = false
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportEndpoint + "?" + server.GetDisabledParam + "=false",
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportEndpoint + "?" + server.GetDisabledParam + "=false",
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyReportRule1),
@@ -875,12 +875,12 @@ func TestHTTPServer_ReportEndpoint_WithClusterAndSystemWideDisabledRules(t *test
 
 		// Get report without specifying get_disabled => same result as above
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportEndpoint,
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyReportRule1),
@@ -889,12 +889,12 @@ func TestHTTPServer_ReportEndpoint_WithClusterAndSystemWideDisabledRules(t *test
 		// Get report with get_disabled = true
 		// => Report contains disabled rules for cluster and org-wide disabled rules
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportEndpoint + "?" + server.GetDisabledParam + "=true",
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportEndpoint + "?" + server.GetDisabledParam + "=true",
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyV1ReportResponse3RulesAll),
@@ -932,12 +932,12 @@ func TestHTTPServer_ReportMetainfoEndpointNoReports(t *testing.T) {
 
 		// check the Smart Proxy report/info endpoint
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportMetainfoEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportMetainfoEndpoint,
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(ReportMetainfoAPIResponseNoReports),
@@ -975,12 +975,12 @@ func TestHTTPServer_ReportMetainfoEndpointTwoReports(t *testing.T) {
 
 		// check the Smart Proxy report/info endpoint
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportMetainfoEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportMetainfoEndpoint,
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(ReportMetainfoAPIResponseTwoReports),
@@ -1007,12 +1007,12 @@ func TestHTTPServer_ReportMetainfoEndpointForbidden(t *testing.T) {
 		})
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportMetainfoEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportMetainfoEndpoint,
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusForbidden,
 		})
@@ -1041,12 +1041,12 @@ func TestHTTPServer_ReportMetainfoEndpointImproperJSON(t *testing.T) {
 
 		// check the Smart Proxy report/info endpoint
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportMetainfoEndpoint,
-			EndpointArgs:       []interface{}{testdata.ClusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportMetainfoEndpoint,
+			EndpointArgs: []interface{}{testdata.ClusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusBadRequest,
 			Body:       helpers.ToJSONString(ReportMetainfoAPIResponseInvalidJSON),
@@ -1086,12 +1086,12 @@ func TestHTTPServer_ReportMetainfoEndpointWrongClusterName(t *testing.T) {
 
 		// check the Smart Proxy report/info endpoint
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.ReportMetainfoEndpoint,
-			EndpointArgs:       []interface{}{clusterName},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:       http.MethodGet,
+			Endpoint:     server.ReportMetainfoEndpoint,
+			EndpointArgs: []interface{}{clusterName},
+			UserID:       testdata.UserID,
+			OrgID:        testdata.OrgID,
+			XRHIdentity:  goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusBadRequest,
 			Body:       helpers.ToJSONString(ReportMetainfoAPIResponseInvalidClusterName),
@@ -1128,9 +1128,9 @@ func TestHTTPServer_RuleEndpoint(t *testing.T) {
 			EndpointArgs: []interface{}{
 				testdata.ClusterName, fmt.Sprintf("%v|%v", testdata.RuleErrorKey1.RuleModule, testdata.RuleErrorKey1.ErrorKey),
 			},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			UserID:      testdata.UserID,
+			OrgID:       testdata.OrgID,
+			XRHIdentity: goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyReportResponse3SingleRule),
@@ -1171,9 +1171,9 @@ func TestHTTPServer_RuleEndpoint_UnavailableContentService(t *testing.T) {
 			EndpointArgs: []interface{}{
 				testdata.ClusterName, fmt.Sprintf("%v|%v", testdata.RuleErrorKey1.RuleModule, testdata.RuleErrorKey1.ErrorKey),
 			},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			UserID:      testdata.UserID,
+			OrgID:       testdata.OrgID,
+			XRHIdentity: goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusServiceUnavailable,
 			Body:       expectedBody,
@@ -1209,9 +1209,9 @@ func TestHTTPServer_RuleEndpoint_WithOSD(t *testing.T) {
 			EndpointArgs: []interface{}{
 				testdata.ClusterName, fmt.Sprintf("%v|%v", testdata.RuleErrorKey1.RuleModule, testdata.RuleErrorKey1.ErrorKey),
 			},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			UserID:      testdata.UserID,
+			OrgID:       testdata.OrgID,
+			XRHIdentity: goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(SmartProxyReportResponse3SingleRule),
@@ -1247,9 +1247,9 @@ func TestHTTPServer_RuleEndpoint_WithNotOSDRule(t *testing.T) {
 			EndpointArgs: []interface{}{
 				testdata.ClusterName, fmt.Sprintf("%v|%v", testdata.RuleErrorKey2.RuleModule, testdata.RuleErrorKey2.ErrorKey),
 			},
-			UserID:             testdata.UserID,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			UserID:      testdata.UserID,
+			OrgID:       testdata.OrgID,
+			XRHIdentity: goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusNotFound,
 			Body:       helpers.ToJSONString(SmartProxyReportResponse3NoRuleFound),
@@ -1265,9 +1265,9 @@ func TestHTTPServer_GetContent(t *testing.T) {
 
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.Content,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:      http.MethodGet,
+			Endpoint:    server.Content,
+			XRHIdentity: goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode:  http.StatusOK,
 			Body:        helpers.ToJSONString(GetContentResponse3Rules),
@@ -1882,12 +1882,12 @@ func TestHTTPServer_OverviewWithClusterIDsEndpoint(t *testing.T) {
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodPost,
-			Endpoint:           server.OverviewEndpoint,
-			OrgID:              testdata.OrgID,
-			UserID:             testdata.UserID,
-			Body:               helpers.ToJSONString(data.ClusterIDListInReq),
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:      http.MethodPost,
+			Endpoint:    server.OverviewEndpoint,
+			OrgID:       testdata.OrgID,
+			UserID:      testdata.UserID,
+			Body:        helpers.ToJSONString(data.ClusterIDListInReq),
+			XRHIdentity: goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(OverviewResponsePostEndpoint),
@@ -1925,12 +1925,12 @@ func TestHTTPServer_OverviewWithClusterIDsEndpoint_UnavailableContentService(t *
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodPost,
-			Endpoint:           server.OverviewEndpoint,
-			OrgID:              testdata.OrgID,
-			UserID:             testdata.UserID,
-			Body:               helpers.ToJSONString(data.ClusterIDListInReq),
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:      http.MethodPost,
+			Endpoint:    server.OverviewEndpoint,
+			OrgID:       testdata.OrgID,
+			UserID:      testdata.UserID,
+			Body:        helpers.ToJSONString(data.ClusterIDListInReq),
+			XRHIdentity: goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusServiceUnavailable,
 			Body:       expectedBody,
@@ -1971,12 +1971,12 @@ func TestHTTPServer_OverviewWithClusterIDsEndpointDisabledRules(t *testing.T) {
 		})
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodPost,
-			Endpoint:           server.OverviewEndpoint,
-			OrgID:              testdata.OrgID,
-			UserID:             testdata.UserID,
-			Body:               helpers.ToJSONString(data.ClusterIDListInReq),
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:      http.MethodPost,
+			Endpoint:    server.OverviewEndpoint,
+			OrgID:       testdata.OrgID,
+			UserID:      testdata.UserID,
+			Body:        helpers.ToJSONString(data.ClusterIDListInReq),
+			XRHIdentity: goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(OverviewResponsePostEndpointRule1Disabled),
@@ -2007,12 +2007,12 @@ func TestHTTPServer_OverviewWithClusterIDsEndpointDisabledRules(t *testing.T) {
 		})
 
 		helpers.AssertAPIRequest(t, nil, nil, nil, nil, nil, &helpers.APIRequest{
-			Method:             http.MethodPost,
-			Endpoint:           server.OverviewEndpoint,
-			OrgID:              testdata.OrgID,
-			UserID:             testdata.UserID,
-			Body:               helpers.ToJSONString(data.ClusterIDListInReq),
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:      http.MethodPost,
+			Endpoint:    server.OverviewEndpoint,
+			OrgID:       testdata.OrgID,
+			UserID:      testdata.UserID,
+			Body:        helpers.ToJSONString(data.ClusterIDListInReq),
+			XRHIdentity: goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       helpers.ToJSONString(OverviewResponsePostEndpointRule2Disabled),
@@ -2656,7 +2656,7 @@ func TestHTTPServer_RecommendationsListEndpoint_BadToken(t *testing.T) {
 		helpers.AssertAPIv2Request(t, &helpers.DefaultServerConfigXRH, nil, nil, nil, nil, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.RecommendationsListEndpoint,
-			XRHIdentity: invalidJWTAuthBearer,
+			XRHIdentity: invalidXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusForbidden,
 		})
@@ -3825,10 +3825,10 @@ func TestHTTPServer_GroupsEndpoint(t *testing.T) {
 		}`
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		helpers.AssertAPIRequest(t, nil, nil, groupsChannel, errorFoundChannel, errorChannel, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.RuleGroupsEndpoint,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:      http.MethodGet,
+			Endpoint:    server.RuleGroupsEndpoint,
+			OrgID:       testdata.OrgID,
+			XRHIdentity: goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusOK,
 			Body:       expectedBody,
@@ -3851,10 +3851,10 @@ func TestHTTPServer_GroupsEndpoint_UnavailableContentService(t *testing.T) {
 
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		helpers.AssertAPIRequest(t, nil, nil, groupsChannel, errorFoundChannel, errorChannel, &helpers.APIRequest{
-			Method:             http.MethodGet,
-			Endpoint:           server.RuleGroupsEndpoint,
-			OrgID:              testdata.OrgID,
-			AuthorizationToken: goodJWTAuthBearer,
+			Method:      http.MethodGet,
+			Endpoint:    server.RuleGroupsEndpoint,
+			OrgID:       testdata.OrgID,
+			XRHIdentity: goodXRHAuthToken,
 		}, &helpers.APIResponse{
 			StatusCode: http.StatusServiceUnavailable,
 			Body:       expectedBody,

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -46,24 +46,6 @@ const (
 
 // TODO: consider moving to data repo
 var (
-	// badJWTAuthBearer contains:
-	// {
-	// 	"account_number": "5213476",
-	// 	"org_id": "1234"
-	// }
-	badJWTAuthBearer = "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJhY2NvdW50X251bWJlciI6IjUyMTM0NzYiLCJvcmdfaWQiOiIxMjM0In0.Y9nNaZXbMEO6nz2EHNaCvHxPM0IaeT7GGR-T8u8h_nr_2b5dYsCQiZGzzkBupRJruHy9K6acgJ08JN2Q28eOAEVk_ZD2EqO43rSOS6oe8uZmVo-nCecdqovHa9PqW8RcZMMxVfGXednw82kKI8j1aT_nbJ1j9JZt3hnHM4wtqydelMij7zKyZLHTWFeZbDDCuEIkeWA6AdIBCMdywdFTSTsccVcxT2rgv4mKpxY1Fn6Vu_Xo27noZW88QhPTHbzM38l9lknGrvJVggrzMTABqWEXNVHbph0lXjPWsP7pe6v5DalYEBN2r3a16A6s3jPfI86cRC6_oeXotlW6je0iKQ"
-	// goodJWTAuthBearer contains:
-	// {
-	// 	"account_number": "5213476",
-	// 	"org_id": "1",
-	// 	"user_id": "1",
-	// 	"jti": "05443b99-d824-480b-a4be-37977405f093",
-	// 	"iat": 1594126340,
-	// 	"exp": 1594141847
-	// }
-	goodJWTAuthBearer = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NvdW50X251bWJlciI6IjUyMTM0NzYiLCJvcmdfaWQiOiIxIiwidXNlcl9pZCI6IjEiLCJqdGkiOiIwNTQ0M2I5OS1kODI0LTQ4MGItYTRiZS0zNzk3NzQwNWYwOTMiLCJpYXQiOjE1OTQxMjYzNDAsImV4cCI6MTU5NDE0MTg0N30K.pp32mPoypnRjOYE95SrBar0fdLS9t_hndOtP5qUvB-c"
-	// invalidJWTAuthBearer is goodJWTAuthBearer with the org_id type set as int
-	invalidJWTAuthBearer      = "Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJhY2NvdW50X251bWJlciI6IjUyMTM0NzYiLCJvcmdfaWQiOjEsImp0aSI6IjA1NDQzYjk5LWQ4MjQtNDgwYi1hNGJlLTM3OTc3NDA1ZjA5MyIsImlhdCI6MTU5NDEyNjM0MCwiZXhwIjoxNTk0MTQxODQ3fQ.GndJUWNaG4IWm8OkKBs_1uvD1-vaJqL2Xvf9QiGvlRw"
 	userIDOnGoodJWTAuthBearer = "1"
 	// goodXRHAuthToken is in following structure https://docs.google.com/document/d/1PAzJqcUXlxg7t5cX1lsPsQtBPT_95bZbyB9Iiv_ekGM/
 	// with expected values (org_id == 1, account_number == 1)

--- a/tests/helpers/http.go
+++ b/tests/helpers/http.go
@@ -140,7 +140,7 @@ func AssertAPIRequest(
 ) {
 	// if custom server configuration is not provided, use default one
 	if serverConfig == nil {
-		serverConfig = &DefaultServerConfig
+		serverConfig = &DefaultServerConfigXRH
 	}
 
 	assertAPIRequest(
@@ -170,7 +170,7 @@ func AssertAPIv2Request(
 ) {
 	// if custom server configuration is not provided, use default one
 	if serverConfig == nil {
-		serverConfig = &DefaultServerConfig
+		serverConfig = &DefaultServerConfigXRH
 	}
 
 	assertAPIRequest(
@@ -227,7 +227,7 @@ func CreateHTTPServer(
 ) *server.HTTPServer {
 	// if custom server configuration is not provided, use default one
 	if serverConfig == nil {
-		serverConfig = &DefaultServerConfig
+		serverConfig = &DefaultServerConfigXRH
 	}
 
 	// if custom services configuration is not provided, use default one


### PR DESCRIPTION
# Description
- all UTs using default test server configuration are now using XRH identity type
- all future UTs will be using XRH identity too
- remove (now) unused variables which were used to test JWT auth type

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps
`make before_commit`

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
