### PR TITLE
[CCXDEV-10956] Get the timestamp from data-eng instead of generating a new one each time

### DIFF
--- a/server/upgrade_risks_prediction.go
+++ b/server/upgrade_risks_prediction.go
@@ -106,13 +106,16 @@ func (server *HTTPServer) upgradeRisksPrediction(writer http.ResponseWriter, req
 	}
 
 	response := make(map[string]interface{})
-	response["upgrade_recommendation"] = predictionResponse
+	response["upgrade_recommendation"] = types.UpgradeRecommendation{
+		Recommended:     predictionResponse.Recommended,
+		RisksPredictors: predictionResponse.RisksPredictors,
+	}
 	response["status"] = OkMsg
 
 	// TODO: Currently DataEng service doesn't return any timestamp
 	// Getting current time to avoid returning an empty string
 	response["meta"] = types.UpgradeRisksMeta{
-		LastCheckedAt: types.Timestamp(time.Now().UTC().Format(time.RFC3339)),
+		LastCheckedAt: predictionResponse.LastCheckedAt,
 	}
 
 	err = responses.SendOK(
@@ -127,7 +130,7 @@ func (server *HTTPServer) upgradeRisksPrediction(writer http.ResponseWriter, req
 func (server *HTTPServer) fetchUpgradePrediction(
 	cluster types.ClusterName,
 	writer http.ResponseWriter,
-) (*types.UpgradeRecommendation, error) {
+) (*types.DataEngResponse, error) {
 	dataEngURL := httputils.MakeURLToEndpoint(
 		server.ServicesConfig.UpgradeRisksPredictionEndpoint,
 		UpgradeRisksPredictionServiceEndpoint,
@@ -169,7 +172,7 @@ func (server *HTTPServer) fetchUpgradePrediction(
 		}
 		return nil, err
 	}
-	responseData := &types.UpgradeRecommendation{}
+	responseData := &types.DataEngResponse{}
 	err = json.Unmarshal(responseBytes, &responseData)
 	if err != nil {
 		log.Error().Str(clusterIDTag, string(cluster)).Err(err).Msg("error unmarshalling data-engineering response")

--- a/server/upgrade_risks_prediction_test.go
+++ b/server/upgrade_risks_prediction_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func checkBodyWithoutTimestamps(t testing.TB, expected, got []byte) {
+func checkBodyAsMap(t testing.TB, expected, got []byte) {
 	var expectedObj, gotObj map[string]interface{}
 
 	err := json.Unmarshal(expected, &expectedObj)
@@ -41,15 +41,6 @@ func checkBodyWithoutTimestamps(t testing.TB, expected, got []byte) {
 		err = fmt.Errorf(`got is not JSON. value = "%v", err = "%v"`, string(got), err)
 	}
 	assert.NoError(t, err)
-
-	var gotMetaObj map[string]interface{}
-
-	gotMetaObj, ok := gotObj["meta"].(map[string]interface{})
-	if !ok {
-		delete(gotObj, "meta")
-	} else {
-		delete(gotMetaObj, "last_checked_at")
-	}
 
 	assert.Equal(
 		t,
@@ -88,7 +79,9 @@ func TestHTTPServer_GetUpgradeRisksPrediction(t *testing.T) {
 					"operator_conditions": null
 				}
 			},
-			"meta": {},
+			"meta": {
+				"last_checked_at": "0001-01-01T00:00:00Z"
+			},
 			"status":"ok"
 		}
 		`
@@ -119,7 +112,7 @@ func TestHTTPServer_GetUpgradeRisksPrediction(t *testing.T) {
 			}, &helpers.APIResponse{
 				StatusCode:  http.StatusOK,
 				Body:        expectedResponse,
-				BodyChecker: checkBodyWithoutTimestamps,
+				BodyChecker: checkBodyAsMap,
 			},
 		)
 	}, testTimeout)
@@ -161,7 +154,9 @@ func TestHTTPServer_GetUpgradeRisksPredictionNotRecommended(t *testing.T) {
 					]
 				}
 			},
-			"meta": {},
+			"meta": {
+				"last_checked_at": "0001-01-01T00:00:00Z"
+			},
 			"status":"ok"
 		}
 		`
@@ -192,7 +187,7 @@ func TestHTTPServer_GetUpgradeRisksPredictionNotRecommended(t *testing.T) {
 			}, &helpers.APIResponse{
 				StatusCode:  http.StatusOK,
 				Body:        expectedResponse,
-				BodyChecker: checkBodyWithoutTimestamps,
+				BodyChecker: checkBodyAsMap,
 			},
 		)
 	}, testTimeout)

--- a/tests/testdata/upgrade_risks_prediction.go
+++ b/tests/testdata/upgrade_risks_prediction.go
@@ -18,7 +18,8 @@ var (
 	UpgradeRecommended = `
 		{
 			"upgrade_recommended": true,
-			"upgrade_risks_predictors": null
+			"upgrade_risks_predictors": null,
+			"last_checked_at": "0001-01-01T00:00:00Z"
 		}`
 
 	UpgradeNotRecommended = `
@@ -27,7 +28,8 @@ var (
 			"upgrade_risks_predictors": {
 				"alerts": [` + AlertExample1 + `],
 				"operator_conditions": [` + OperatorConditionExample1 + `]
-			}
+			},
+			"last_checked_at": "0001-01-01T00:00:00Z"
 		}
 	`
 

--- a/types/upgrade_risks_predictions.go
+++ b/types/upgrade_risks_predictions.go
@@ -36,6 +36,13 @@ type UpgradeRisksPredictors struct {
 	OperatorConditions []OperatorCondition `json:"operator_conditions"`
 }
 
+// DataEngResponse is the response received from the data-eng service
+type DataEngResponse struct {
+	Recommended     bool                   `json:"upgrade_recommended"`
+	RisksPredictors UpgradeRisksPredictors `json:"upgrade_risks_predictors"`
+	LastCheckedAt   Timestamp              `json:"last_checked_at"`
+}
+
 // UpgradeRecommendation is the inner data structure for the UpgradeRiskPredictionResponse
 type UpgradeRecommendation struct {
 	Recommended     bool                   `json:"upgrade_recommended"`


### PR DESCRIPTION
# Description

Currently we are generating a timestamp of `now()` in every request. As we are implementing a cache in data-eng, let's use the timestamp that data-eng will return.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Locally.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
