### PR TITLE
Fix runtime NPE when Redis client is not initialized during startup

### DIFF
--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -1157,8 +1157,8 @@ func (server *HTTPServer) getRequestStatusForCluster(writer http.ResponseWriter,
 	}
 
 	// make sure we don't access server.redis when it's nil
-	if server.redis == nil {
-		handleServerError(writer, errors.New(RedisNotInitializedErrorMessage))
+	if !server.checkServerReadiness() {
+		// error has been handled already
 		return
 	}
 
@@ -1224,8 +1224,8 @@ func (server *HTTPServer) getRequestsForCluster(writer http.ResponseWriter, requ
 	}
 
 	// make sure we don't access server.redis when it's nil
-	if server.redis == nil {
-		handleServerError(writer, errors.New(RedisNotInitializedErrorMessage))
+	if !server.checkServerReadiness() {
+		// error has been handled already
 		return
 	}
 
@@ -1300,8 +1300,8 @@ func (server *HTTPServer) getRequestsForClusterPostVariant(writer http.ResponseW
 	}
 
 	// make sure we don't access server.redis when it's nil
-	if server.redis == nil {
-		handleServerError(writer, errors.New(RedisNotInitializedErrorMessage))
+	if !server.checkServerReadiness() {
+		// error has been handled already
 		return
 	}
 
@@ -1349,8 +1349,8 @@ func (server *HTTPServer) getReportForRequest(writer http.ResponseWriter, reques
 	}
 
 	// make sure we don't access server.redis when it's nil
-	if server.redis == nil {
-		handleServerError(writer, errors.New(RedisNotInitializedErrorMessage))
+	if !server.checkServerReadiness() {
+		// error has been handled already
 		return
 	}
 
@@ -1464,4 +1464,13 @@ func (server HTTPServer) getDisabledRulesForClusterMap(
 	}
 
 	return
+}
+
+// checkRedisClientReadiness method checks if Redis client has been initialized
+func (server *HTTPServer) checkRedisClientReadiness() bool {
+	if server.redis == nil {
+		handleServerError(writer, errors.New(RedisNotInitializedErrorMessage))
+		return false
+	}
+	return true
 }

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -1157,7 +1157,7 @@ func (server *HTTPServer) getRequestStatusForCluster(writer http.ResponseWriter,
 	}
 
 	// make sure we don't access server.redis when it's nil
-	if !server.checkServerReadiness() {
+	if !server.checkRedisClientReadiness(writer) {
 		// error has been handled already
 		return
 	}
@@ -1224,7 +1224,7 @@ func (server *HTTPServer) getRequestsForCluster(writer http.ResponseWriter, requ
 	}
 
 	// make sure we don't access server.redis when it's nil
-	if !server.checkServerReadiness() {
+	if !server.checkRedisClientReadiness(writer) {
 		// error has been handled already
 		return
 	}
@@ -1300,7 +1300,7 @@ func (server *HTTPServer) getRequestsForClusterPostVariant(writer http.ResponseW
 	}
 
 	// make sure we don't access server.redis when it's nil
-	if !server.checkServerReadiness() {
+	if !server.checkRedisClientReadiness(writer) {
 		// error has been handled already
 		return
 	}
@@ -1349,7 +1349,7 @@ func (server *HTTPServer) getReportForRequest(writer http.ResponseWriter, reques
 	}
 
 	// make sure we don't access server.redis when it's nil
-	if !server.checkServerReadiness() {
+	if !server.checkRedisClientReadiness(writer) {
 		// error has been handled already
 		return
 	}
@@ -1467,7 +1467,7 @@ func (server HTTPServer) getDisabledRulesForClusterMap(
 }
 
 // checkRedisClientReadiness method checks if Redis client has been initialized
-func (server *HTTPServer) checkRedisClientReadiness() bool {
+func (server *HTTPServer) checkRedisClientReadiness(writer http.ResponseWriter) bool {
 	if server.redis == nil {
 		handleServerError(writer, errors.New(RedisNotInitializedErrorMessage))
 		return false

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -59,7 +59,7 @@ const (
 	// RequestIDNotFound is returned when the requested request ID was not found in the list of request IDs
 	// for given cluster
 	RequestIDNotFound = "Request ID not found for given org_id and cluster_id"
-	// Error send to log when Redis client is not initialized properly
+	// RedisNotInitializedErrorMessage is an error message written into log when Redis client is not initialized properly
 	RedisNotInitializedErrorMessage = "Redis is not initialized, request can not be finished correctly"
 )
 

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -773,6 +773,28 @@ func TestHTTPServer_GetSingleClusterInfoClusterNotFound(t *testing.T) {
 	}, testTimeout)
 }
 
+func TestHTTPServer_GetRequestStatusForCluster_RedisNil(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, nil, nil, nil, nil, nil)
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:       http.MethodGet,
+				Endpoint:     server.StatusOfRequestID,
+				EndpointArgs: []interface{}{testdata.ClusterName, "requestID1"},
+				XRHIdentity:  goodXRHAuthToken,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusInternalServerError,
+			},
+		)
+	}, testTimeout)
+}
+
 func TestHTTPServer_GetRequestStatusForCluster_RedisError500(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
@@ -1203,6 +1225,28 @@ func TestHTTPServer_GetRequestsForCluster_BadAuthToken(t *testing.T) {
 	}, testTimeout)
 }
 
+func TestHTTPServer_GetRequestsForCluster_NoRedis(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, nil, nil, nil, nil, nil)
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:       http.MethodGet,
+				Endpoint:     server.ListAllRequestIDs,
+				EndpointArgs: []interface{}{testdata.ClusterName},
+				XRHIdentity:  goodXRHAuthToken,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusInternalServerError,
+			},
+		)
+	}, testTimeout)
+}
+
 func TestHTTPServer_GetRequestsForCluster_RedisError500(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
@@ -1410,6 +1454,33 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_OK1RequestNotFound(t *testi
 		)
 
 		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetRequestsForClusterPostVariant_NoRedis(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, nil, nil, nil, nil, nil)
+
+		requestIDList := []types.RequestID{"requestID1"}
+		reqBody, _ := json.Marshal(requestIDList)
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:       http.MethodPost,
+				Endpoint:     server.ListAllRequestIDs,
+				EndpointArgs: []interface{}{testdata.ClusterName},
+				XRHIdentity:  goodXRHAuthToken,
+				Body:         reqBody,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusInternalServerError,
+			},
+		)
+
 	}, testTimeout)
 }
 
@@ -2203,5 +2274,34 @@ func TestHTTPServer_GetReportForRequest_AggregatorError_2ndCall(t *testing.T) {
 		)
 
 		helpers.RedisExpectationsMet(t, redisServer)
+	}, testTimeout)
+}
+
+func TestHTTPServer_GetReportForRequest_NoRedis(t *testing.T) {
+	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
+		defer helpers.CleanAfterGock(t)
+
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, nil, nil, nil, nil, nil)
+
+		requestIDList := []types.RequestID{"requestID1"}
+		reqBody, _ := json.Marshal(requestIDList)
+
+		expectedResponse := `{"status": "Internal Server Error"}`
+
+		iou_helpers.AssertAPIRequest(
+			t,
+			testServer,
+			serverConfigJWT.APIv2Prefix,
+			&helpers.APIRequest{
+				Method:       http.MethodGet,
+				Endpoint:     server.RuleHitsForRequestID,
+				EndpointArgs: []interface{}{testdata.ClusterName, "requestID1"},
+				XRHIdentity:  goodXRHAuthToken,
+				Body:         reqBody,
+			}, &helpers.APIResponse{
+				StatusCode: http.StatusInternalServerError,
+				Body:       expectedResponse,
+			},
+		)
 	}, testTimeout)
 }

--- a/services/redis.go
+++ b/services/redis.go
@@ -104,6 +104,7 @@ func (redis *RedisClient) GetRequestIDsForClusterID(
 	ctx := context.Background()
 
 	scanKey := fmt.Sprintf(RequestIDsScanPattern, orgID, clusterID)
+	log.Debug().Str("Scan key", scanKey).Msg("Key to retrieve item from Redis")
 
 	var cursor uint64
 	for {


### PR DESCRIPTION
# Description

Fix runtime NPE when Redis client is not initialized during startup.
When Redis is not available/reachable during startup, the `server.redis == nil` and it causes NPE in runtime.

Fixes https://issues.redhat.com/browse/CCXDEV-11328

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

- Start Smart Proxy with improper Redis configuration or w/o Redis at all
- Request the following endpoint smart_proxy_localhost:smart_proxy_port/api/v2/cluster/00000000-1111-0000-0000-000000000000/requests

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
