### PR TITLE
[CCXDEV-10458] Update openapi.json adding prod tag to URP endpoint

### DIFF
--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -233,6 +233,9 @@
     },
     "/cluster/{clusterId}/upgrade-risks-prediction": {
       "get": {
+        "tags": [
+          "prod"
+        ],
         "summary": "",
         "operationId": "getUpgradeRisksPrediction",
         "description": "The title of the rule, a short description.",


### PR DESCRIPTION
# Description

Update `openapi.json` adding prod tag to URP endpoint. Needed in order to run fuzz tests from IQE to this endpoint too, as the framework filters by tag: [see](https://gitlab.cee.redhat.com/insights-qe/iqe-ccx-plugin/-/blob/master/iqe_ccx/tests/test_fuzz.py#L48).

## Type of change

- Configuration update

## Testing steps

Locally.

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
