### PR TITLE
fix incorrect behaviour of `GetRequestIDsForClusterID`

### DIFF
--- a/services/redis.go
+++ b/services/redis.go
@@ -104,7 +104,7 @@ func (redis *RedisClient) GetRequestIDsForClusterID(
 	ctx := context.Background()
 
 	scanKey := fmt.Sprintf(RequestIDsScanPattern, orgID, clusterID)
-	log.Debug().Str("Scan key", scanKey).Msg("Key to retrieve item from Redis")
+	log.Info().Str("Scan key", scanKey).Msg("Key to retrieve request IDs from Redis")
 
 	var cursor uint64
 	for {
@@ -224,6 +224,8 @@ func (redis *RedisClient) GetRuleHitsForRequest(
 		return
 	}
 
+	log.Info().Msgf("rule hits CSV retrieved from Redis: %v", simplifiedReport.RuleHitsCSV)
+
 	// validate rule IDs coming from Redis
 	ruleHitsSplit := strings.Split(simplifiedReport.RuleHitsCSV, ",")
 	for _, ruleHit := range ruleHitsSplit {
@@ -231,7 +233,7 @@ func (redis *RedisClient) GetRuleHitsForRequest(
 
 		isRuleIDValid := ruleIDRegex.MatchString(ruleHit)
 		if !isRuleIDValid {
-			log.Error().Msgf("rule_id %v retrieved from Redis is in invalid format", ruleHit)
+			log.Error().Msgf("rule_id [%v] retrieved from Redis is in invalid format", ruleHit)
 			continue
 		}
 

--- a/services/redis.go
+++ b/services/redis.go
@@ -44,8 +44,9 @@ const (
 
 var (
 	// RequestIDsScanPattern is a glob-style pattern to find all matching keys. Uses ?* instead of * to avoid
-	// matching "organization:%v:cluster:%v:request:"
-	RequestIDsScanPattern = "organization:%v:cluster:%v:request:?*"
+	// matching "organization:%v:cluster:%v:request:". [^:reports] is an exclude pattern to not match the
+	// simplified report keys
+	RequestIDsScanPattern = "organization:%v:cluster:%v:request:?*[^:reports]"
 
 	// SimplifiedReportKey is a key under which the information about specific requests is stored
 	SimplifiedReportKey = "organization:%v:cluster:%v:request:%v:reports"


### PR DESCRIPTION
# Description
- fixes a bug where `GetRequestIDsForClusterID` was also matching keys which are used for simplified reports, because they share the same prefix. Initially I thought it cannot be done via the MATCH pattern, because regular glob doesn't support exclusion patterns, however Redis uses "glob-style patterns", which allow exclusion functionality (see https://redis.io/docs/manual/keyspace/) 
  - this unfortunately cannot be covered by UTs because we use redis-mock, therefore we tell the mock what to return
- extends logs for further debugging of another Redis issue

Fixes CCXDEV-11338

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
tested with local Redis, will be tested on stage properly

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
