### PR TITLE
Change CW log stream

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -277,7 +277,7 @@ parameters:
   value: "false"
   required: true
 - name: IRSP_LOG_STREAM
-  value: $HOSTNAME
+  value: "insights-results-smart-proxy"
 - name: CREATE_STREAM_IF_NOT_EXISTS
   value: "true"
 - name: AMS_API_URL


### PR DESCRIPTION
# Description

The log stream was using the `$HOSTNAME` env var which makes the logs unsearchable in Kibana. 

Discussed [here](https://redhat-internal.slack.com/archives/C01A4DTTZN1/p1689326437817629).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
