### PR TITLE
[CCXDEV-10215] CI: Use openapi-generator-cli docker image instead of installing it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,15 +33,14 @@ jobs:
         - env
         - bash <(curl -s https://codecov.io/bash)
     - stage: openapi-checks
-      language: node_js
-      node_js:
-        - 17
-        - node
+      services:
+        - docker
+      before_install:
+        - docker pull openapitools/openapi-generator-cli
       script:
-        - npm install -g @openapitools/openapi-generator-cli
-        - openapi-generator-cli validate -i server/api/v1/openapi.json
-        - openapi-generator-cli validate -i server/api/v2/openapi.json
-        - openapi-generator-cli validate -i server/api/dbg/openapi.json
+        - docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli validate -i /local/server/api/v1/openapi.json
+        - docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli validate -i /local/server/api/v2/openapi.json
+        - docker run --rm -v ${PWD}:/local openapitools/openapi-generator-cli validate -i /local/server/api/dbg/openapi.json
     - stage: bdd tests
       services:
         - docker


### PR DESCRIPTION
# Description

Use the docker image provided by the OpenApiTools organization instead of installing the `openapi-generator-cli` every time a PR is verified.

The installation seems to fail quite often due to downtimes of the repository used to verify and download the jar file used by the verification tool.

The issue does not seem to have been fixed yet. See https://github.com/OpenAPITools/openapi-generator-cli/issues/680 and https://github.com/OpenAPITools/openapi-generator/issues/9349. So using the docker image allows us to use the tool without interacting with the "failing" repository.

Fixes CCXDEV-10215

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
