### PR TITLE
fix OpenAPI spec for POST /cluster/{clusterId}/requests endpoint

### DIFF
--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -420,18 +420,10 @@
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "requestIDs": {
-                    "type": "array",
-                    "items": {
-                      "$ref": "#/components/schemas/requestId"
-                    }
-                  }
-                },
-                "required": [
-                  "requestIDs"
-                ]
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/requestId"
+                }
               }
             }
           }


### PR DESCRIPTION
# Description
the expected format is a plain list of request IDs, not an object containing the list. fixing to the correct format. thanks @matysek 

Fixes https://issues.redhat.com/browse/CCXDEV-11326

## Type of change

Please delete options that are not relevant.

- Documentation update

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
