### PR TITLE
change LOG LEVEL to info

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -100,6 +100,8 @@ objects:
               value: "${IRSP_INTERNAL_RULES_ORGANIZATIONS_CSV_FILE}"
             - name: INSIGHTS_RESULTS_SMART_PROXY__LOGGING__LOGGING_TO_CLOUD_WATCH_ENABLED
               value: ${LOGGING_TO_CLOUD_WATCH_ENABLED}
+            - name: INSIGHTS_RESULTS_SMART_PROXY__LOGGING__LOG_LEVEL
+              value: ${LOG_LEVEL}
             - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__DEBUG
               value: ${CLOUDWATCH_DEBUG}
             - name: INSIGHTS_RESULTS_SMART_PROXY__CLOUDWATCH__STREAM_NAME
@@ -273,6 +275,8 @@ parameters:
 - name: LOGGING_TO_CLOUD_WATCH_ENABLED
   value: "true"
   required: true
+- name: LOG_LEVEL
+  value: "INFO"
 - name: CLOUDWATCH_DEBUG
   value: "false"
   required: true


### PR DESCRIPTION
# Description
attempting to reduce # of log messages sent to CloudWatch.
- add logging.log_level as configurable
- change log level to `INFO` (default in case the var is not defined is `DEBUG`)

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Configuration update

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
