### PR TITLE
try to fix 'zerolog: could not write event: InvalidParameterException

### DIFF
--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -277,7 +277,7 @@ func (server HTTPServer) getRecommendations(writer http.ResponseWriter, request 
 		log.Error().
 			Err(err).
 			Int(orgIDTag, int(orgID)).
-			Msgf("problem getting impacting recommendations from aggregator for cluster list: %v", clusterIDList)
+			Msgf("problem getting impacting recommendations from aggregator for cluster list (# of clusters: %v)", len(clusterIDList))
 
 		return
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1458,7 +1458,7 @@ func (server *HTTPServer) getClusterListAndUserData(
 			Err(err).
 			Int(orgIDTag, int(orgID)).
 			Str(userIDTag, string(userID)).
-			Msgf("problem getting clusters and impacting recommendations from aggregator for cluster list: %v", clusterInfoList)
+			Msgf("problem getting clusters and impacting recommendations from aggregator for cluster list (# of clusters %v)", len(clusterInfoList))
 
 		return
 	}


### PR DESCRIPTION
# Description
attempting to fix another logging issue:
`zerolog: could not write event: InvalidParameterException: Log event too large: 1763670 bytes exceeds limit of 262144`

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
