### PR TITLE
Log events too large

### DIFF
--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -79,6 +79,7 @@ func (server HTTPServer) getContentForRuleV1(writer http.ResponseWriter, request
 	if internal := content.IsRuleInternal(ruleID); internal {
 		err := server.checkInternalRulePermissions(request)
 		if err != nil {
+			log.Error().Err(err)
 			handleServerError(writer, err)
 			return
 		}

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -78,6 +78,7 @@ func (server HTTPServer) getContentCheckInternal(ruleID ctypes.RuleID, request *
 	if internal := content.IsRuleInternal(ruleID); internal {
 		err = server.checkInternalRulePermissions(request)
 		if err != nil {
+			log.Error().Err(err)
 			return
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -1164,6 +1164,7 @@ func (server HTTPServer) singleRuleEndpoint(writer http.ResponseWriter, request 
 	if rule.Internal {
 		err = server.checkInternalRulePermissions(request)
 		if err != nil {
+			log.Error().Err(err)
 			handleServerError(writer, err)
 			return
 		}
@@ -1213,7 +1214,6 @@ func (server *HTTPServer) checkInternalRulePermissions(request *http.Request) er
 
 	// If the loop ends without returning nil, then an authentication error should be raised
 	const message = "This organization is not allowed to access this recommendation"
-	log.Error().Msg(message)
 	return &AuthenticationError{ErrString: message}
 }
 

--- a/server/utils.go
+++ b/server/utils.go
@@ -41,7 +41,11 @@ func logClustersReport(orgID types.OrgID, reports map[types.ClusterName]json.Raw
 	for clusterName, jsonReport := range reports {
 		err := json.Unmarshal(jsonReport, &report)
 		if err != nil {
-			log.Error().Err(err).Msg("can't log report for cluster " + string(clusterName))
+			log.Error().
+				Err(err).
+				Int(orgIDTag, int(orgID)).
+				Str(clusterIDTag, string(clusterName)).
+				Msgf("can't log report for cluster. raw json: [%v]", string(jsonReport))
 			continue
 		}
 		logClusterInfos(orgID, clusterName, report)


### PR DESCRIPTION
# Description
- fix confusing `"message":"This organization is not allowed to access this recommendation"`
- extend log to debug `"error":"json: cannot unmarshal object into Go value of type []types.RuleOnReport"`



## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
