### PR TITLE
fix nonsensical logging event (never worked)

### DIFF
--- a/server/utils.go
+++ b/server/utils.go
@@ -24,9 +24,9 @@ import (
 	"github.com/rs/zerolog/log"
 )
 
-func logClusterInfos(orgID types.OrgID, clusterID types.ClusterName, response []types.RuleOnReport) {
+func logClusterInfos(orgID types.OrgID, clusterID types.ClusterName, ruleHits []types.RuleOnReport) {
 	logMessage := fmt.Sprintf("rule hits for %d.%s:", orgID, clusterID)
-	for _, ruleHit := range response {
+	for _, ruleHit := range ruleHits {
 		logMessage += fmt.Sprintf("\n\trule: %s; error key: %s", ruleHit.Module, ruleHit.ErrorKey)
 	}
 	log.Debug().Msg(logMessage)
@@ -37,7 +37,7 @@ func logClusterInfo(orgID types.OrgID, clusterID types.ClusterName, response *ty
 }
 
 func logClustersReport(orgID types.OrgID, reports map[types.ClusterName]json.RawMessage) {
-	var report []types.RuleOnReport
+	var report types.ReportRules
 	for clusterName, jsonReport := range reports {
 		err := json.Unmarshal(jsonReport, &report)
 		if err != nil {
@@ -48,7 +48,7 @@ func logClustersReport(orgID types.OrgID, reports map[types.ClusterName]json.Raw
 				Msgf("can't log report for cluster. raw json: [%v]", string(jsonReport))
 			continue
 		}
-		logClusterInfos(orgID, clusterName, report)
+		logClusterInfos(orgID, clusterName, report.HitRules)
 	}
 }
 


### PR DESCRIPTION
# Description
- fixes `"error":"json: cannot unmarshal object into Go value of type []types.RuleOnReport"`
  - this could've never worked before (almost 2y), first of all it's not a list, second of all it's a totally different struct...
  - the error message was displayed for every single request for relevant endpoints (about 2-3 error messages **PER SECOND**)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Testing steps
locally with relevant endpoints + aggregator response

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
