### PR TITLE
Run more linters

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -27,7 +27,9 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          args: --timeout=3m
+          args: >
+            --enable=goimports,gosimple,nilerr,prealloc,revive,staticcheck,unconvert,unused,whitespace,zerologlint
+            --timeout=3m
           
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/amsclient/amsclient.go
+++ b/amsclient/amsclient.go
@@ -281,7 +281,7 @@ func (c *amsClientImpl) executeSubscriptionListRequest(
 
 			displayName, ok := item.GetDisplayName()
 			if !ok {
-				displayName = string(clusterIDstr)
+				displayName = clusterIDstr
 			}
 
 			managed, ok := item.GetManaged()

--- a/amsclient/utils.go
+++ b/amsclient/utils.go
@@ -34,5 +34,4 @@ func generateSearchParameter(orgID string, allowedStatuses, disallowedStatuses [
 	}
 
 	return searchQuery
-
 }

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -49,7 +49,7 @@ func removeFile(t *testing.T, filename string) {
 }
 
 // TestLoadConfiguration loads a configuration file for testing
-func TestLoadConfiguration(t *testing.T) {
+func TestLoadConfiguration() {
 	os.Clearenv()
 	mustLoadConfiguration("tests/config1")
 }
@@ -75,7 +75,7 @@ func TestLoadingConfigurationFailure(t *testing.T) {
 
 // TestLoadServerConfiguration tests loading the server configuration sub-tree
 func TestLoadServerConfiguration(t *testing.T) {
-	TestLoadConfiguration(t)
+	TestLoadConfiguration()
 	helpers.FailOnError(t, os.Chdir(".."))
 
 	serverCfg := conf.GetServerConfiguration()

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -49,7 +49,7 @@ func removeFile(t *testing.T, filename string) {
 }
 
 // TestLoadConfiguration loads a configuration file for testing
-func TestLoadConfiguration() {
+func TestLoadConfiguration(_ *testing.T) {
 	os.Clearenv()
 	mustLoadConfiguration("tests/config1")
 }
@@ -75,7 +75,7 @@ func TestLoadingConfigurationFailure(t *testing.T) {
 
 // TestLoadServerConfiguration tests loading the server configuration sub-tree
 func TestLoadServerConfiguration(t *testing.T) {
-	TestLoadConfiguration()
+	TestLoadConfiguration(t)
 	helpers.FailOnError(t, os.Chdir(".."))
 
 	serverCfg := conf.GetServerConfiguration()

--- a/content/content.go
+++ b/content/content.go
@@ -246,7 +246,6 @@ func GetRuleWithErrorKeyContent(
 func GetContentForRecommendation(
 	ruleID ctypes.RuleID,
 ) (*types.RuleWithContent, error) {
-
 	err := WaitForContentDirectoryToBeReady()
 
 	if err != nil {

--- a/content/content_test.go
+++ b/content/content_test.go
@@ -658,7 +658,7 @@ func TestGetExternalRuleSeverities2Unique(t *testing.T) {
 	assert.Equal(t, 2, len(uniqueSeverities))
 }
 
-func TestContentLoop(t *testing.T) {
+func TestContentLoop() {
 	go content.RunUpdateContentLoop(services.Configuration{
 		GroupsPollingTime: 1 * time.Second,
 	})

--- a/content/content_test.go
+++ b/content/content_test.go
@@ -84,11 +84,9 @@ func TestGetRuleContent(t *testing.T) {
 
 				content.UpdateContent(helpers.DefaultServicesConfig)
 				getRuleContentHelperFuncs[i](t)
-
 			}, testTimeout)
 		})
 	}
-
 }
 
 func TestGetRuleContent_CallMultipleTimes(t *testing.T) {
@@ -269,7 +267,6 @@ func TestFetchRuleContent_OSDEligibleNotRequiredAdmin(t *testing.T) {
 		}
 
 		assert.Equal(t, ruleWithContentResponse, ruleContent)
-
 	}, testTimeout)
 }
 
@@ -316,7 +313,6 @@ func TestFetchRuleContent_NotOSDEligible(t *testing.T) {
 		}
 
 		assert.Equal(t, ruleWithContentResponse, ruleContent)
-
 	}, testTimeout)
 }
 
@@ -348,7 +344,6 @@ func TestFetchRuleContent_DisabledRuleExist(t *testing.T) {
 		assert.False(t, osdFiltered)
 		assert.NotNil(t, ruleContent)
 		assert.Nil(t, err)
-
 	}, testTimeout)
 }
 
@@ -379,7 +374,6 @@ func TestFetchRuleContent_RuleDoesNotExist(t *testing.T) {
 		ruleContent, _, err := content.FetchRuleContent(&rule, false)
 		assert.Nil(t, ruleContent)
 		assert.NotNil(t, err)
-
 	}, testTimeout)
 }
 

--- a/content/content_test.go
+++ b/content/content_test.go
@@ -652,7 +652,7 @@ func TestGetExternalRuleSeverities2Unique(t *testing.T) {
 	assert.Equal(t, 2, len(uniqueSeverities))
 }
 
-func TestContentLoop() {
+func TestContentLoop(_ *testing.T) {
 	go content.RunUpdateContentLoop(services.Configuration{
 		GroupsPollingTime: 1 * time.Second,
 	})

--- a/content/parsing.go
+++ b/content/parsing.go
@@ -130,14 +130,13 @@ func timeParse(value string) (publishDate time.Time, missing bool, err error) {
 	for _, datetimeLayout := range timeParseFormats {
 		publishDate, err = time.Parse(datetimeLayout, value)
 
-		if err == nil {
-			return
+		if err != nil {
+			log.Info().Msgf(
+				`unable to parse time "%v" using layout "%v"`,
+				value, datetimeLayout,
+			)
 		}
-
-		log.Info().Msgf(
-			`unable to parse time "%v" using layout "%v"`,
-			value, datetimeLayout,
-		)
+		return
 	}
 
 	log.Error().Msgf("problem parsing publish_date: %v", err)

--- a/content/parsing.go
+++ b/content/parsing.go
@@ -135,12 +135,15 @@ func timeParse(value string) (publishDate time.Time, missing bool, err error) {
 				`unable to parse time "%v" using layout "%v"`,
 				value, datetimeLayout,
 			)
+			continue
 		}
-		return
+		break
 	}
 
-	log.Error().Msgf("problem parsing publish_date: %v", err)
-	err = errors.New("invalid format of publish_date")
+	if err != nil {
+		log.Error().Msgf("problem parsing publish_date: %v", err)
+		err = errors.New("invalid format of publish_date")
+	}
 
 	return
 }

--- a/server/acks_handlers.go
+++ b/server/acks_handlers.go
@@ -289,7 +289,7 @@ func (server *HTTPServer) updateAcknowledge(writer http.ResponseWriter, request 
 		return
 	}
 
-	parameters, err := readJustificationFromBody(writer, request)
+	parameters, err := readJustificationFromBody(request)
 	if err != nil {
 		handleServerError(writer, err)
 		return

--- a/server/acks_utils.go
+++ b/server/acks_utils.go
@@ -42,8 +42,8 @@ const aggregatorImproperCodeMessage = "Aggregator responded with improper HTTP c
 // structure types.AcknowledgemenJustification from response
 // payload (body)
 func readJustificationFromBody(request *http.Request) (
-	types.AcknowledgementJustification, error) {
-
+	types.AcknowledgementJustification, error,
+) {
 	// try to read request body
 	var parameters types.AcknowledgementJustification
 	err := json.NewDecoder(request.Body).Decode(&parameters)
@@ -63,8 +63,8 @@ func readJustificationFromBody(request *http.Request) (
 // structure types.AcknowledgementRuleSelectorJustification from response
 // payload (body)
 func readRuleSelectorAndJustificationFromBody(writer http.ResponseWriter, request *http.Request) (
-	types.AcknowledgementRuleSelectorJustification, error) {
-
+	types.AcknowledgementRuleSelectorJustification, error,
+) {
 	// try to read request body
 	var parameters types.AcknowledgementRuleSelectorJustification
 	err := json.NewDecoder(request.Body).Decode(&parameters)
@@ -190,7 +190,6 @@ func (server *HTTPServer) deleteAckRuleSystemWide(
 	ruleID types.Component, errorKey types.ErrorKey,
 	orgID types.OrgID,
 ) error {
-
 	// try to ack rule via Insights Aggregator REST API
 	aggregatorURL := httputils.MakeURLToEndpoint(
 		server.ServicesConfig.AggregatorBaseEndpoint,
@@ -226,7 +225,6 @@ func (server *HTTPServer) deleteAckRuleSystemWide(
 func (server *HTTPServer) readListOfAckedRules(
 	orgID types.OrgID,
 ) ([]types.SystemWideRuleDisable, error) {
-
 	// wont be used anywhere else
 	type responsePayload struct {
 		Status      string                        `json:"status"`
@@ -273,7 +271,6 @@ func (server *HTTPServer) readRuleDisableStatus(
 	ruleID types.Component, errorKey types.ErrorKey,
 	orgID types.OrgID,
 ) (types.Acknowledgement, bool, error) {
-
 	// wont be used anywhere else
 	type responsePayload struct {
 		Status      string                      `json:"status"`

--- a/server/acks_utils.go
+++ b/server/acks_utils.go
@@ -41,7 +41,7 @@ const aggregatorImproperCodeMessage = "Aggregator responded with improper HTTP c
 // readJustificationFromBody function tries to read data
 // structure types.AcknowledgemenJustification from response
 // payload (body)
-func readJustificationFromBody(writer http.ResponseWriter, request *http.Request) (
+func readJustificationFromBody(request *http.Request) (
 	types.AcknowledgementJustification, error) {
 
 	// try to read request body

--- a/server/auth.go
+++ b/server/auth.go
@@ -48,7 +48,6 @@ const (
 // Authentication middleware for checking auth rights
 func (server *HTTPServer) Authentication(next http.Handler, noAuthURLs []string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 		// for specific URLs it is ok to not use auth. mechanisms at all
 		// this is specific to OpenAPI JSON response and for all OPTION HTTP methods
 		if collections.StringInSlice(r.RequestURI, noAuthURLs) || r.Method == "OPTIONS" {

--- a/server/endpoints_dbg.go
+++ b/server/endpoints_dbg.go
@@ -15,9 +15,10 @@
 package server
 
 import (
+	"net/http"
+
 	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
 	"github.com/gorilla/mux"
-	"net/http"
 )
 
 const (

--- a/server/endpoints_v1.go
+++ b/server/endpoints_v1.go
@@ -104,7 +104,7 @@ func (server *HTTPServer) addV1EndpointsToRouter(router *mux.Router) {
 	router.HandleFunc(apiPrefix+InfoEndpoint, server.infoMap).Methods(http.MethodGet, http.MethodOptions)
 
 	// Reports endpoints
-	server.addV1ReportsEndpointsToRouter(router, apiPrefix, aggregatorBaseEndpoint)
+	server.addV1ReportsEndpointsToRouter(router, apiPrefix)
 
 	// Content related endpoints
 	server.addV1ContentEndpointsToRouter(router)
@@ -124,7 +124,7 @@ func (server *HTTPServer) addV1EndpointsToRouter(router *mux.Router) {
 
 // addV1ReportsEndpointsToRouter method registers handlers for endpoints that
 // return cluster report or reports to client
-func (server *HTTPServer) addV1ReportsEndpointsToRouter(router *mux.Router, apiPrefix, aggregatorBaseURL string) {
+func (server *HTTPServer) addV1ReportsEndpointsToRouter(router *mux.Router, apiPrefix string) {
 	router.HandleFunc(apiPrefix+OldReportEndpoint, server.reportEndpointV1).Methods(http.MethodGet, http.MethodOptions)
 	router.HandleFunc(apiPrefix+ReportEndpoint, server.reportEndpointV1).Methods(http.MethodGet, http.MethodOptions)
 	router.HandleFunc(apiPrefix+ReportMetainfoEndpoint, server.reportMetainfoEndpoint).Methods(http.MethodGet, http.MethodOptions)

--- a/server/endpoints_v2.go
+++ b/server/endpoints_v2.go
@@ -106,19 +106,18 @@ const (
 func (server *HTTPServer) addV2EndpointsToRouter(router *mux.Router) {
 	apiV2Prefix := server.Config.APIv2Prefix
 	openAPIv2URL := apiV2Prefix + filepath.Base(server.Config.APIv2SpecFile)
-	aggregatorBaseEndpoint := server.ServicesConfig.AggregatorBaseEndpoint
 
 	// Common REST API endpoints
 	router.HandleFunc(apiV2Prefix+MainEndpoint, server.mainEndpoint).Methods(http.MethodGet)
 
 	// Reports endpoints
-	server.addV2ReportsEndpointsToRouter(router, apiV2Prefix, aggregatorBaseEndpoint)
+	server.addV2ReportsEndpointsToRouter(router, apiV2Prefix)
 
 	// Content related endpoints
 	server.addV2ContentEndpointsToRouter(router, apiV2Prefix)
 
 	// Rules related endpoints
-	server.addV2RuleEndpointsToRouter(router, apiV2Prefix, aggregatorBaseEndpoint)
+	server.addV2RuleEndpointsToRouter(router, apiV2Prefix)
 
 	// Endpoints requiring Redis to work
 	server.addV2RedisEndpointsToRouter(router, apiV2Prefix)
@@ -147,7 +146,7 @@ func (server *HTTPServer) addV2RedisEndpointsToRouter(router *mux.Router, apiPre
 
 // addV2ReportsEndpointsToRouter method registers handlers for endpoints that
 // return cluster report or reports to client
-func (server *HTTPServer) addV2ReportsEndpointsToRouter(router *mux.Router, apiPrefix, aggregatorBaseURL string) {
+func (server *HTTPServer) addV2ReportsEndpointsToRouter(router *mux.Router, apiPrefix string) {
 	router.HandleFunc(apiPrefix+ReportEndpointV2, server.reportEndpointV2).Methods(http.MethodGet, http.MethodOptions)
 	router.HandleFunc(apiPrefix+ClusterInfoEndpoint, server.getSingleClusterInfo).Methods(http.MethodGet)
 	router.HandleFunc(apiPrefix+RecommendationsListEndpoint, server.getRecommendations).Methods(http.MethodGet)
@@ -156,7 +155,7 @@ func (server *HTTPServer) addV2ReportsEndpointsToRouter(router *mux.Router, apiP
 
 // addV2RuleEndpointsToRouter method registers handlers for endpoints that handle
 // rule-related operations (voting etc.)
-func (server *HTTPServer) addV2RuleEndpointsToRouter(router *mux.Router, apiPrefix, aggregatorBaseEndpoint string) {
+func (server *HTTPServer) addV2RuleEndpointsToRouter(router *mux.Router, apiPrefix string) {
 	// Acknowledgement-related endpoints. Please look into acks_handlers.go
 	// and acks_utils.go for more information about these endpoints
 	// prepared to be compatible with RHEL Insights Advisor.

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -26,6 +26,7 @@ import (
 	iou_helpers "github.com/RedHatInsights/insights-operator-utils/tests/helpers"
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
 	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
+
 	// "github.com/RedHatInsights/insights-results-smart-proxy/content"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -304,7 +304,7 @@ func expectNoRulesDisabledSystemWide(t *testing.TB, orgID types.OrgID) {
 	})
 }
 
-func expectNoRulesDisabledPerCluster(t *testing.TB, orgID types.OrgID, userID types.UserID) {
+func expectNoRulesDisabledPerCluster(t *testing.TB, orgID types.OrgID) {
 	helpers.GockExpectAPIRequest(*t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 		&helpers.APIRequest{
 			Method:       http.MethodGet,
@@ -1338,7 +1338,7 @@ func TestHTTPServer_OverviewEndpoint(t *testing.T) {
 
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, amsClientMock, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(
@@ -1419,7 +1419,7 @@ func TestHTTPServer_OverviewEndpointManagedClustersRules(t *testing.T) {
 
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		// managed cluster; 1 managed rule, 2 non-managed rules == only 1 rule must count
 		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, amsClientMock, nil, nil, nil, nil)
@@ -1498,7 +1498,7 @@ func TestHTTPServer_OverviewEndpoint_UnavailableContentService(t *testing.T) {
 
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, amsClientMock, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, helpers.DefaultServerConfig.APIv1Prefix, &helpers.APIRequest{
@@ -1571,7 +1571,7 @@ func TestHTTPServer_OverviewGetEndpointDisabledRule(t *testing.T) {
 			Body:       helpers.ToJSONString(ResponseRule2DisabledSystemWide),
 		})
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, amsClientMock, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(
@@ -1612,7 +1612,7 @@ func TestHTTPServer_OverviewGetEndpointDisabledRule(t *testing.T) {
 			Body:       helpers.ToJSONString(ResponseRule1DisabledSystemWide),
 		})
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -1687,7 +1687,7 @@ func TestHTTPServer_OverviewEndpointWithFallback(t *testing.T) {
 
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		config := helpers.DefaultServerConfigXRH
 		config.UseOrgClustersFallback = true
@@ -2999,7 +2999,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_NoClusters(t *testing.T) {
 
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfigXRH, nil, amsClientMock, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigJWT.APIv2Prefix, &helpers.APIRequest{
@@ -3051,7 +3051,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_ClustersFoundNoInsights(t *t
 
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		resp := GetClustersResponse2ClusterNoHits
 		for i := range clusterInfoList {
@@ -3124,7 +3124,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_NoRuleHits(t *testing.T) {
 
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		resp := GetClustersResponse2ClusterNoHits
 		for i := range clusterInfoList {
@@ -3184,7 +3184,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_NoReportInDB(t *testing.T) {
 
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		resp := GetClustersResponse2ClusterNoArchiveInDB
 		for i := range clusterInfoList {
@@ -3270,7 +3270,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_2ClustersFilled(t *testing.T
 
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		resp := GetClustersResponse2ClusterWithHits
 		for i := range clusterInfoList {
@@ -3353,7 +3353,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_2Clusters1Managed(t *testing
 
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		resp := GetClustersResponse2ClusterWithHitsCluster1Managed
 		for i := range clusterInfoList {
@@ -3440,7 +3440,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_2Clusters1WithVersion(t *tes
 
 		expectNoRulesDisabledSystemWide(&t, testdata.OrgID)
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		resp := GetClustersResponse2ClusterWithHitsCluster1WithVersion
 		for i := range clusterInfoList {
@@ -3545,7 +3545,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_AckedRule(t *testing.T) {
 			},
 		)
 
-		expectNoRulesDisabledPerCluster(&t, testdata.OrgID, types.UserID(userIDOnGoodJWTAuthBearer))
+		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		resp := GetClustersResponse2ClusterWithHits1Rule
 		for i := range clusterInfoList {

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -467,7 +467,6 @@ func TestHTTPServer_ReportEndpointV2NoContent(t *testing.T) {
 
 // TestHTTPServer_ReportEndpointV2TestAMSData tests that data from AMS API (mocked) is passed correctly to the response
 func TestHTTPServer_ReportEndpointV2TestAMSData(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -516,7 +515,6 @@ func TestHTTPServer_ReportEndpointV2TestAMSData(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpointV2TestManagedClustersRules(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -567,7 +565,6 @@ func TestHTTPServer_ReportEndpointV2TestManagedClustersRules(t *testing.T) {
 
 // Reproducer for Bug 1977858
 func TestHTTPServer_ReportEndpointNoContentFor2Rules(t *testing.T) {
-
 	err := loadMockRuleContentDir(&RuleContentDirectoryOnly1Rule)
 	assert.Nil(t, err)
 
@@ -601,7 +598,6 @@ func TestHTTPServer_ReportEndpointNoContentFor2Rules(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpoint_WithOnlyOSDEndpoint(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -634,7 +630,6 @@ func TestHTTPServer_ReportEndpoint_WithOnlyOSDEndpoint(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpoint_InsightsOperatorUserAgentManagedCluster(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -688,7 +683,6 @@ func TestHTTPServer_ReportEndpoint_InsightsOperatorUserAgentManagedCluster(t *te
 }
 
 func TestHTTPServer_ReportEndpoint_InsightsOperatorUserAgentNonManagedCluster(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -742,7 +736,6 @@ func TestHTTPServer_ReportEndpoint_InsightsOperatorUserAgentNonManagedCluster(t 
 }
 
 func TestHTTPServer_ReportEndpoint_WithDisabledRulesForCluster(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory5Rules)
 	assert.Nil(t, err)
 
@@ -803,7 +796,6 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRulesForCluster(t *testing.T) {
 }
 
 func TestHTTPServer_ReportEndpoint_WithDisabledRulesForClusterAndMissingContent(t *testing.T) {
-
 	err := loadMockRuleContentDir(&RuleContentDirectoryOnlyDisabledRule)
 	assert.Nil(t, err)
 
@@ -836,7 +828,6 @@ func TestHTTPServer_ReportEndpoint_WithDisabledRulesForClusterAndMissingContent(
 }
 
 func TestHTTPServer_ReportEndpoint_WithClusterAndSystemWideDisabledRules(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory5Rules)
 	assert.Nil(t, err)
 
@@ -992,7 +983,6 @@ func TestHTTPServer_ReportMetainfoEndpointTwoReports(t *testing.T) {
 // TestHTTPServer_ReportMetainfoEndpointForbidden checks how HTTP codes are
 // handled in report/info endpoint handler.
 func TestHTTPServer_ReportMetainfoEndpointForbidden(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1102,7 +1092,6 @@ func TestHTTPServer_ReportMetainfoEndpointWrongClusterName(t *testing.T) {
 
 // TODO: test more cases for rule endpoint
 func TestHTTPServer_RuleEndpoint(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1183,7 +1172,6 @@ func TestHTTPServer_RuleEndpoint_UnavailableContentService(t *testing.T) {
 }
 
 func TestHTTPServer_RuleEndpoint_WithOSD(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1221,7 +1209,6 @@ func TestHTTPServer_RuleEndpoint_WithOSD(t *testing.T) {
 }
 
 func TestHTTPServer_RuleEndpoint_WithNotOSDRule(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1260,7 +1247,6 @@ func TestHTTPServer_RuleEndpoint_WithNotOSDRule(t *testing.T) {
 
 // TestHTTPServer_GetContent
 func TestHTTPServer_GetContent(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1274,13 +1260,11 @@ func TestHTTPServer_GetContent(t *testing.T) {
 			Body:        helpers.ToJSONString(GetContentResponse3Rules),
 			BodyChecker: ruleInContentChecker,
 		})
-
 	}, testTimeout)
 }
 
 // TestHTTPServer_OverviewEndpoint
 func TestHTTPServer_OverviewEndpoint(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{
@@ -1360,7 +1344,6 @@ func TestHTTPServer_OverviewEndpoint(t *testing.T) {
 // TestHTTPServer_OverviewEndpointManagedClustersRules tests behaviour when a managed cluster is hitting non-managed rules
 // Scenario without managed clusters is tested in other test cases
 func TestHTTPServer_OverviewEndpointManagedClustersRules(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{
@@ -1513,7 +1496,6 @@ func TestHTTPServer_OverviewEndpoint_UnavailableContentService(t *testing.T) {
 }
 
 func TestHTTPServer_OverviewGetEndpointDisabledRule(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory5Rules)
 	assert.Nil(t, err)
 
@@ -1627,13 +1609,11 @@ func TestHTTPServer_OverviewGetEndpointDisabledRule(t *testing.T) {
 				Body:       helpers.ToJSONString(OverviewResponseRule1DisabledRule2Enabled),
 			},
 		)
-
 	}, testTimeout)
 }
 
 // TestHTTPServer_OverviewEndpointWithFallback
 func TestHTTPServer_OverviewEndpointWithFallback(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1710,7 +1690,6 @@ func TestHTTPServer_OverviewEndpointWithFallback(t *testing.T) {
 }
 
 func TestInternalOrganizations(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{RuleContentInternal1},
@@ -1814,7 +1793,6 @@ func TestRuleNames(t *testing.T) {
 
 // TestRuleNamesResponse checks the REST API status and response
 func TestRuleNamesResponse(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{RuleContentInternal1, testdata.RuleContent1},
@@ -1860,7 +1838,6 @@ func TestRuleNamesResponse(t *testing.T) {
 
 // TestHTTPServer_OverviewWithClusterIDsEndpoint
 func TestHTTPServer_OverviewWithClusterIDsEndpoint(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -1941,7 +1918,6 @@ func TestHTTPServer_OverviewWithClusterIDsEndpoint_UnavailableContentService(t *
 
 // TestHTTPServer_OverviewWithClusterIDsEndpoint
 func TestHTTPServer_OverviewWithClusterIDsEndpointDisabledRules(t *testing.T) {
-
 	err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 	assert.Nil(t, err)
 
@@ -2023,7 +1999,6 @@ func TestHTTPServer_OverviewWithClusterIDsEndpointDisabledRules(t *testing.T) {
 
 // TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing
 func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, testdata.RuleContent2},
@@ -2099,7 +2074,6 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing(t *testin
 
 // TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisabled1Acked
 func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisabled1Acked(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, testdata.RuleContent2},
@@ -2209,7 +2183,6 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisab
 
 // TestHTTPServer_RecommendationsListEndpoint2Rules1MissingContent
 func TestHTTPServer_RecommendationsListEndpoint2Rules1MissingContent(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1},
@@ -2353,7 +2326,6 @@ func TestHTTPServer_RecommendationsListEndpoint_NoRuleContent(t *testing.T) {
 
 // TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_ImpactingTrue
 func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_ImpactingTrue(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, testdata.RuleContent2, RuleContentInternal1},
@@ -2424,7 +2396,6 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 
 // TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_ImpactingFalse
 func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_ImpactingFalse(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, testdata.RuleContent2, RuleContentInternal1},
@@ -2496,7 +2467,6 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 
 // TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_ImpactingMissing
 func TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_ImpactingMissing(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, RuleContentInternal1},
@@ -2571,7 +2541,6 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_Impactin
 
 // TestHTTPServer_RecommendationsListEndpoint4Rules1Internal2Clusters_ImpactingMissing
 func TestHTTPServer_RecommendationsListEndpoint4Rules1Internal2Clusters_ImpactingMissing(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{
@@ -2680,7 +2649,6 @@ func TestHTTPServer_RecommendationsListEndpoint_BadImpactingParam(t *testing.T) 
 }
 
 func TestHTTPServer_RecommendationsListEndpointAMSManagedClusters(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, testdata.RuleContent2},
@@ -2757,7 +2725,6 @@ func TestHTTPServer_RecommendationsListEndpointAMSManagedClusters(t *testing.T) 
 
 // TestHTTPServer_GetRecommendationContent
 func TestHTTPServer_GetRecommendationContent(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, RuleContentInternal1},
@@ -2835,7 +2802,6 @@ func TestHTTPServer_GetRecommendationContent(t *testing.T) {
 
 // TestHTTPServer_GetRecommendationContentWithUserData
 func TestHTTPServer_GetRecommendationContentWithUserData(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, RuleContentInternal1},
@@ -3209,7 +3175,6 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_NoReportInDB(t *testing.T) {
 
 // TestHTTPServer_ClustersRecommendationsEndpoint_2ClustersFilled tests clusters received from AMS API with rule hits
 func TestHTTPServer_ClustersRecommendationsEndpoint_2ClustersFilled(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{

--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -79,7 +79,7 @@ func (server HTTPServer) getContentForRuleV1(writer http.ResponseWriter, request
 	if internal := content.IsRuleInternal(ruleID); internal {
 		err := server.checkInternalRulePermissions(request)
 		if err != nil {
-			log.Error().Err(err)
+			log.Error().Err(err).Send()
 			handleServerError(writer, err)
 			return
 		}
@@ -98,7 +98,7 @@ func (server HTTPServer) getContentV1(writer http.ResponseWriter, request *http.
 	allRules, err := content.GetAllContentV1()
 
 	if err != nil {
-		log.Error().Err(err)
+		log.Error().Err(err).Send()
 		handleServerError(writer, err)
 		return
 	}
@@ -139,7 +139,7 @@ func (server HTTPServer) getRuleIDs(writer http.ResponseWriter, request *http.Re
 	allRuleIDs, err := content.GetRuleIDs()
 
 	if err != nil {
-		log.Error().Err(err)
+		log.Error().Err(err).Send()
 		handleServerError(writer, err)
 		return
 	}
@@ -157,7 +157,7 @@ func (server HTTPServer) getRuleIDs(writer http.ResponseWriter, request *http.Re
 	}
 
 	if err := responses.SendOK(writer, responses.BuildOkResponseWithData("rules", ruleIDs)); err != nil {
-		log.Error().Err(err)
+		log.Error().Err(err).Send()
 		handleServerError(writer, err)
 		return
 	}
@@ -360,7 +360,7 @@ func (server *HTTPServer) infoMap(writer http.ResponseWriter, _ *http.Request) {
 	// try to send the response to client
 	err := responses.SendOK(writer, responses.BuildOkResponseWithData("info", response))
 	if err != nil {
-		log.Error().Err(err)
+		log.Error().Err(err).Send()
 		handleServerError(writer, err)
 		return
 	}
@@ -373,7 +373,7 @@ func (server *HTTPServer) fillInSmartProxyInfoParams() map[string]string {
 	if server.InfoParams == nil {
 		const msg = "InfoParams is empty"
 		err := errors.New(msg)
-		log.Error().Err(err)
+		log.Error().Err(err).Send()
 
 		// don't fail, just fill in the field
 		m := make(map[string]string)

--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -181,8 +181,8 @@ func (server HTTPServer) getOrganizationOverview(
 		clusterInfo := &clusterInfoList[i]
 
 		// check if there are any hitting recommendations
-		hittingRecommendations, any := clusterRecommendationsMap[clusterInfo.ID]
-		if !any {
+		hittingRecommendations, exist := clusterRecommendationsMap[clusterInfo.ID]
+		if !exist {
 			continue
 		}
 
@@ -350,7 +350,7 @@ func generateOrgOverview(
 
 // infoMap returns map of additional information about this service, Insights
 // Results Aggregator, and Smart Proxy
-func (server *HTTPServer) infoMap(writer http.ResponseWriter, request *http.Request) {
+func (server *HTTPServer) infoMap(writer http.ResponseWriter, _ *http.Request) {
 	// prepare response data structure
 	response := sptypes.InfoResponse{
 		SmartProxy:     server.fillInSmartProxyInfoParams(),

--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -338,7 +338,6 @@ func generateOrgOverview(
 				hitsByTags[tag]++
 			}
 		}
-
 	}
 
 	return sptypes.OrgOverviewResponse{

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -78,7 +78,7 @@ func (server HTTPServer) getContentCheckInternal(ruleID ctypes.RuleID, request *
 	if internal := content.IsRuleInternal(ruleID); internal {
 		err = server.checkInternalRulePermissions(request)
 		if err != nil {
-			log.Error().Err(err)
+			log.Error().Err(err).Send()
 			return
 		}
 	}

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -545,8 +545,9 @@ func filterOutDisabledRules(
 	clusterID ctypes.ClusterName,
 	systemWideDisabledRules map[ctypes.RuleID]bool,
 	disabledRulesPerCluster map[ctypes.ClusterName][]ctypes.RuleID,
-) (enabledOnlyRecommendations []ctypes.RuleID) {
-
+) (
+	enabledOnlyRecommendations []ctypes.RuleID,
+) {
 	for _, hittingRuleID := range hittingRecommendations {
 		// no need to continue, rule has been acked
 		if systemWideDisabledRules[hittingRuleID] {
@@ -724,8 +725,9 @@ func (server HTTPServer) getImpactingRecommendations(
 	orgID ctypes.OrgID,
 	userID ctypes.UserID,
 	clusterList []ctypes.ClusterName,
-) (ctypes.RecommendationImpactedClusters, error) {
-
+) (
+	ctypes.RecommendationImpactedClusters, error,
+) {
 	var aggregatorResponse struct {
 		Recommendations ctypes.RecommendationImpactedClusters `json:"recommendations"`
 		Status          string                                `json:"status"`
@@ -789,7 +791,6 @@ func (server HTTPServer) getClustersAndRecommendations(
 	userID ctypes.UserID,
 	clusterList []ctypes.ClusterName,
 ) (ctypes.ClusterRecommendationMap, error) {
-
 	var aggregatorResponse struct {
 		Clusters ctypes.ClusterRecommendationMap `json:"clusters"`
 		Status   string                          `json:"status"`
@@ -896,7 +897,6 @@ func getImpactedClustersFromAggregator(
 	url string,
 	activeClusters []ctypes.ClusterName,
 ) (resp *http.Response, err error) {
-
 	if len(activeClusters) < 1 {
 		// #nosec G107
 		resp, err = http.Get(url)
@@ -1099,7 +1099,6 @@ func (server *HTTPServer) processClustersDetailResponse(
 	clusterInfo []types.ClusterInfo,
 	writer http.ResponseWriter,
 ) error {
-
 	data := types.ClustersDetailData{
 		EnabledClusters:  make([]ctypes.HittingClustersData, 0),
 		DisabledClusters: make([]ctypes.DisabledClusterInfo, 0),
@@ -1407,7 +1406,6 @@ func filterRulesGetContent(
 	filteredRuleHits := []types.SimplifiedRuleHit{}
 
 	for _, ruleID := range ruleHits {
-
 		// skip acked rule
 		if _, found := ackedRules[ruleID]; found {
 			continue

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -440,7 +440,6 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_DisabledClusterNo
 }
 
 func TestHTTPServer_ClustersDetailEndpointAMSManagedClusters(t *testing.T) {
-
 	err := loadMockRuleContentDir(
 		createRuleContentDirectoryFromRuleContent(
 			[]ctypes.RuleContent{testdata.RuleContent1, testdata.RuleContent2},
@@ -910,7 +909,6 @@ func TestHTTPServer_GetRequestStatusForCluster_BadRequestClusterID(t *testing.T)
 				Body:       `{"status":"Error during parsing param 'cluster' with value 'aaaa'. Error: 'invalid UUID length: 4'"}`,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -938,7 +936,6 @@ func TestHTTPServer_GetRequestStatusForCluster_BadRequestID(t *testing.T) {
 				Body:       `{"status":"Error during parsing param 'request_id' with value '_'. Error: 'invalid request ID: '_''"}`,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -965,7 +962,6 @@ func TestHTTPServer_GetRequestStatusForCluster_BadAuthToken(t *testing.T) {
 				StatusCode: http.StatusForbidden,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -1194,7 +1190,6 @@ func TestHTTPServer_GetRequestsForCluster_BadRequestClusterID(t *testing.T) {
 				Body:       `{"status":"Error during parsing param 'cluster' with value 'aaaa'. Error: 'invalid UUID length: 4'"}`,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -1221,7 +1216,6 @@ func TestHTTPServer_GetRequestsForCluster_BadAuthToken(t *testing.T) {
 				StatusCode: http.StatusForbidden,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -1480,7 +1474,6 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_NoRedis(t *testing.T) {
 				StatusCode: http.StatusInternalServerError,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -1547,7 +1540,6 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_BadRequestClusterID(t *test
 				Body:       `{"status":"Error during parsing param 'cluster' with value 'aaaa'. Error: 'invalid UUID length: 4'"}`,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -1578,7 +1570,6 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_BadAuthToken(t *testing.T) 
 				StatusCode: http.StatusForbidden,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -1606,7 +1597,6 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_NoBody(t *testing.T) {
 				Body:       `{"status":"client didn't provide request body"}`,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -1635,7 +1625,6 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_BadBodyContent(t *testing.T
 				Body:       `{"status":"client didn't provide a valid request body"}`,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -1667,7 +1656,6 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_BadRequestID(t *testing.T) 
 				Body:       `{"status":"Error during parsing param 'request_id' with value '_'. Error: 'invalid request ID: '_''"}`,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -1871,7 +1859,6 @@ func TestHTTPServer_GetReportForRequest_BadAuthToken(t *testing.T) {
 				StatusCode: http.StatusForbidden,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -1899,7 +1886,6 @@ func TestHTTPServer_GetReportForRequest_BadRequestClusterID(t *testing.T) {
 				Body:       `{"status":"Error during parsing param 'cluster' with value 'aaaa'. Error: 'invalid UUID length: 4'"}`,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -1927,7 +1913,6 @@ func TestHTTPServer_GetReportForRequest_BadRequestID(t *testing.T) {
 				Body:       `{"status":"Error during parsing param 'request_id' with value '_'. Error: 'invalid request ID: '_''"}`,
 			},
 		)
-
 	}, testTimeout)
 }
 

--- a/server/rating.go
+++ b/server/rating.go
@@ -101,7 +101,6 @@ func (server HTTPServer) postRatingToAggregator(
 
 // getRatingForRecommendation retrieves user rating for recommendation from aggregator
 func (server HTTPServer) getRatingForRecommendation(
-	writer http.ResponseWriter,
 	orgID ctypes.OrgID,
 	ruleID ctypes.RuleID,
 ) (

--- a/server/rating.go
+++ b/server/rating.go
@@ -149,7 +149,7 @@ func (server HTTPServer) getRatingForRecommendation(
 			ruleID,
 			aggregatorResp.StatusCode,
 		)
-		log.Error().Err(err)
+		log.Error().Err(err).Send()
 		return
 	}
 

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -100,7 +100,6 @@ func (server *HTTPServer) readParamsGetRecommendations(writer http.ResponseWrite
 	impactingFlag types.ImpactingFlag,
 	err error,
 ) {
-
 	orgID, userID, err = server.GetCurrentOrgIDUserIDFromToken(request)
 	if err != nil {
 		log.Err(err).Msg(orgIDTokenError)

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -86,7 +86,7 @@ func readCompositeRuleID(request *http.Request) (
 			ParamValue: ruleIDParam,
 			ErrString:  msg.Error(),
 		}
-		log.Error().Err(err)
+		log.Error().Err(err).Send()
 		return
 	}
 

--- a/server/rule_toggle_handlers_test.go
+++ b/server/rule_toggle_handlers_test.go
@@ -68,7 +68,6 @@ func TestEnableEndpoint(t *testing.T) {
 				Body:       expectedBody,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -111,7 +110,6 @@ func TestDisableEndpoint(t *testing.T) {
 				Body:       expectedBody,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -142,7 +140,6 @@ func TestEnableEndpointBadErrorKey(t *testing.T) {
 				Body:       expectedBody,
 			},
 		)
-
 	}, testTimeout)
 }
 
@@ -173,6 +170,5 @@ func TestDisableEndpointBadErrorKey(t *testing.T) {
 				Body:       expectedBody,
 			},
 		)
-
 	}, testTimeout)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -1161,7 +1161,7 @@ func (server HTTPServer) singleRuleEndpoint(writer http.ResponseWriter, request 
 	if rule.Internal {
 		err = server.checkInternalRulePermissions(request)
 		if err != nil {
-			log.Error().Err(err)
+			log.Error().Err(err).Send()
 			handleServerError(writer, err)
 			return
 		}
@@ -1175,7 +1175,7 @@ func (server HTTPServer) singleRuleEndpoint(writer http.ResponseWriter, request 
 
 func handleFetchRuleContentError(writer http.ResponseWriter, err error) {
 	if _, ok := err.(*content.RuleContentDirectoryTimeoutError); ok {
-		log.Error().Err(err)
+		log.Error().Err(err).Send()
 		handleServerError(writer, err)
 		return
 	}
@@ -1238,7 +1238,7 @@ func (server HTTPServer) getGroupsConfig() (
 	if errorFound {
 		err = <-server.ErrorChannel
 		if _, ok := err.(*content.RuleContentDirectoryTimeoutError); ok {
-			log.Error().Err(err)
+			log.Error().Err(err).Send()
 		}
 		log.Error().Err(err).Msg("Error occurred during groups retrieval from content service")
 		return nil, err
@@ -1308,7 +1308,7 @@ func filterRulesInResponse(aggregatorReport []ctypes.RuleOnReport, filterOSD, ge
 			}
 			if _, ok := err.(*content.RuleContentDirectoryTimeoutError); ok {
 				// error occured during communication with Content Service
-				log.Error().Err(err)
+				log.Error().Err(err).Send()
 				contentError = err
 				return
 			}

--- a/server/server.go
+++ b/server/server.go
@@ -128,7 +128,6 @@ func New(config Configuration,
 	errorFoundChannel chan bool,
 	errorChannel chan error,
 ) *HTTPServer {
-
 	return &HTTPServer{
 		Config:            config,
 		InfoParams:        make(map[string]string),
@@ -986,7 +985,6 @@ func (server HTTPServer) reportEndpointV2(writer http.ResponseWriter, request *h
 
 	if report.Data, report.Meta.Count, err = server.buildReportEndpointResponse(
 		writer, request, aggregatorResponse, clusterID, report.Meta.Managed); err == nil {
-
 		// fill in timestamps
 		report.Meta.LastCheckedAt = aggregatorResponse.Meta.LastCheckedAt
 		report.Meta.GatheredAt = aggregatorResponse.Meta.GatheredAt
@@ -999,7 +997,6 @@ func (server HTTPServer) reportEndpointV2(writer http.ResponseWriter, request *h
 func fillImpacted(
 	rulesWithContent []types.RuleWithContentResponse,
 	aggregatorReports []ctypes.RuleOnReport) {
-
 	idReport := make(map[string]ctypes.RuleOnReport, len(aggregatorReports))
 
 	for _, v := range aggregatorReports {
@@ -1373,7 +1370,6 @@ func (server *HTTPServer) readListOfDisabledRulesForClusters(
 	orgID ctypes.OrgID,
 	clusterList []ctypes.ClusterName,
 ) ([]ctypes.DisabledRule, error) {
-
 	// wont be used anywhere else
 	var response struct {
 		Status        string                `json:"status"`

--- a/server/server.go
+++ b/server/server.go
@@ -311,7 +311,7 @@ func (server *HTTPServer) proxyTo(baseURL string, options *ProxyOptions) func(ht
 
 		copyHeader(request.Header, req.Header)
 
-		response, body, err := sendRequest(client, req, options, writer)
+		response, body, err := sendRequest(client, req, options)
 		if err != nil {
 			server.evaluateProxyError(writer, err, baseURL)
 			return
@@ -345,7 +345,7 @@ func (server *HTTPServer) evaluateProxyError(writer http.ResponseWriter, err err
 }
 
 func sendRequest(
-	client http.Client, req *http.Request, options *ProxyOptions, writer http.ResponseWriter,
+	client http.Client, req *http.Request, options *ProxyOptions,
 ) (*http.Response, []byte, error) {
 	log.Debug().Msgf("Connecting to %s", req.URL.RequestURI())
 	response, err := client.Do(req)
@@ -1157,7 +1157,7 @@ func (server HTTPServer) singleRuleEndpoint(writer http.ResponseWriter, request 
 	rule, filtered, err = content.FetchRuleContent(aggregatorResponse, osdFlag)
 
 	if err != nil || filtered {
-		handleFetchRuleContentError(writer, err, filtered)
+		handleFetchRuleContentError(writer, err)
 		return
 	}
 
@@ -1176,7 +1176,7 @@ func (server HTTPServer) singleRuleEndpoint(writer http.ResponseWriter, request 
 	}
 }
 
-func handleFetchRuleContentError(writer http.ResponseWriter, err error, filtered bool) {
+func handleFetchRuleContentError(writer http.ResponseWriter, err error) {
 	if _, ok := err.(*content.RuleContentDirectoryTimeoutError); ok {
 		log.Error().Err(err)
 		handleServerError(writer, err)

--- a/services/redis.go
+++ b/services/redis.go
@@ -186,7 +186,6 @@ func (redis *RedisClient) GetTimestampsForRequestIDs(
 			// therefore we can get the missing request ID from the original slice
 			report.RequestID = string(requestIDs[i])
 			report.Valid = false
-
 		} else {
 			report.Valid = true
 		}

--- a/services/redis.go
+++ b/services/redis.go
@@ -180,12 +180,13 @@ func (redis *RedisClient) GetTimestampsForRequestIDs(
 		if report.RequestID == "" {
 			if omitMissing {
 				continue
-			} else {
-				// commands in Redis pipeline are guaranteed to be executed in the order they were issued in,
-				// therefore we can get the missing request ID from the original slice
-				report.RequestID = string(requestIDs[i])
-				report.Valid = false
 			}
+
+			// commands in Redis pipeline are guaranteed to be executed in the order they were issued in,
+			// therefore we can get the missing request ID from the original slice
+			report.RequestID = string(requestIDs[i])
+			report.Valid = false
+
 		} else {
 			report.Valid = true
 		}

--- a/smart_proxy.go
+++ b/smart_proxy.go
@@ -86,7 +86,7 @@ func printConfig() ExitCode {
 	configBytes, err := json.MarshalIndent(conf.Config, "", "    ")
 
 	if err != nil {
-		log.Error().Err(err)
+		log.Error().Err(err).Send()
 		return 1
 	}
 

--- a/tests/helpers/amsclient.go
+++ b/tests/helpers/amsclient.go
@@ -29,7 +29,7 @@ type mockAMSClient struct {
 
 func (m *mockAMSClient) GetClustersForOrganization(
 	orgID types.OrgID,
-	unused1, unused2 []string,
+	_, _ []string,
 ) (
 	clusterInfoList []types.ClusterInfo,
 	err error,
@@ -60,7 +60,7 @@ func (m *mockAMSClient) GetClusterDetailsFromExternalClusterID(
 }
 
 func (m *mockAMSClient) GetSingleClusterInfoForOrganization(
-	orgID types.OrgID, clusterID types.ClusterName,
+	_ types.OrgID, clusterID types.ClusterName,
 ) (
 	clusterInfo types.ClusterInfo, err error,
 ) {

--- a/tests/helpers/amsclient.go
+++ b/tests/helpers/amsclient.go
@@ -34,7 +34,6 @@ func (m *mockAMSClient) GetClustersForOrganization(
 	clusterInfoList []types.ClusterInfo,
 	err error,
 ) {
-
 	clusterInfoList, ok := m.clustersPerOrg[orgID]
 	if !ok {
 		return nil, fmt.Errorf("No clusters")
@@ -50,7 +49,6 @@ func (m *mockAMSClient) GetClusterDetailsFromExternalClusterID(
 ) (
 	clusterInfo types.ClusterInfo,
 ) {
-
 	for _, info := range m.clustersPerOrg[testdata.OrgID] {
 		if info.ID == id {
 			return info
@@ -64,7 +62,6 @@ func (m *mockAMSClient) GetSingleClusterInfoForOrganization(
 ) (
 	clusterInfo types.ClusterInfo, err error,
 ) {
-
 	for _, info := range m.clustersPerOrg[testdata.OrgID] {
 		if info.ID == clusterID {
 			return info, nil

--- a/types/operations.go
+++ b/types/operations.go
@@ -25,10 +25,10 @@ import (
 
 // GetClusterNames extract the ClusterName from an array of ClusterInfo
 func GetClusterNames(clustersInfo []ClusterInfo) []ClusterName {
-	var retval []ClusterName = make([]ClusterName, 0)
+	retval := make([]ClusterName, len(clustersInfo))
 
-	for _, info := range clustersInfo {
-		retval = append(retval, info.ID)
+	for i, info := range clustersInfo {
+		retval[i] = info.ID
 	}
 
 	return retval

--- a/types/operations.go
+++ b/types/operations.go
@@ -52,7 +52,7 @@ func RuleIDWithErrorKeyFromCompositeRuleID(compositeRuleID ctypes.RuleID) (ctype
 
 	if len(splitedRuleID) != 2 {
 		err := fmt.Errorf("invalid rule ID, it must contain only rule ID and error key separated by |")
-		log.Error().Err(err)
+		log.Error().Err(err).Send()
 		return ctypes.RuleID(""), ctypes.ErrorKey(""), err
 	}
 
@@ -63,7 +63,7 @@ func RuleIDWithErrorKeyFromCompositeRuleID(compositeRuleID ctypes.RuleID) (ctype
 
 	if !isRuleIDValid || !isErrorKeyValid {
 		err := fmt.Errorf("invalid rule ID, each part of ID must contain only latin characters, number, underscores or dots")
-		log.Error().Err(err)
+		log.Error().Err(err).Send()
 		return ctypes.RuleID(""), ctypes.ErrorKey(""), err
 	}
 


### PR DESCRIPTION
# Description
- run more linters for golangci-lint
- removed some linters which were enabled by default that we're running explicitly (gofmt, golint, gosev, govet, ineffasign, gocyclo)
- fix existing linting issues (if you want to review, I split the individual linters into commits)


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Refactor (refactoring code, removing useless files)
- Configuration update

## Testing steps
`golangci-lint run` with all the linters

## Checklist
* [ ] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
