### PR TITLE
update v1 OpenAPI spec with extra info for unused endpoint

### DIFF
--- a/server/api/v1/openapi.json
+++ b/server/api/v1/openapi.json
@@ -210,7 +210,7 @@
         },
         "operationId": "getClustersForOrganization",
         "summary": "Returns a list of clusters associated with the specified organization ID.",
-        "description": "Returns a list of clusters, ie. cluster IDs, that are associated with the specified organization ID. Please note that there is 1:N organization to cluster mapping, ie. one cluster belongs exactly to one organization."
+        "description": "Returns a list of clusters, ie. cluster IDs, that are associated with the specified organization ID from the last 3 hours. For a complete list of clusters, please use API v2. Please note that there is 1:N organization to cluster mapping, ie. one cluster belongs exactly to one organization."
       }
     },
     "/clusters/{clusterList}/reports": {


### PR DESCRIPTION
# Description
- https://github.com/RedHatInsights/insights-results-aggregator/pull/1825
- reducing the limit to 3h, this endpoint is unusued as far as we know, there are v2 alternatives which are much better

Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- Documentation update

## Testing steps
n/a

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
