### PR TITLE
remove AMS API page size limit

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -287,6 +287,6 @@ parameters:
 - name: AMS_API_URL
   value: "https://api.stage.openshift.com"
 - name: AMS_API_PAGESIZE
-  value: "10000"
+  value: "-1"
 - name: ORG_CLUSTERS_FALLBACK
   value: "false"


### PR DESCRIPTION
# Description
- remove AMS API request page size limit completely 
- tested with organization with 29k clusters:
  - with current 10k limit, it has to make 3 request to get the full data set
  - page size 10k takes 4-5sec (so 12-14sec to get the full data)
  - page size -1 (get all 29k clusters at once) takes 9-10sec 


Fixes # (issue)

## Type of change

Please delete options that are not relevant.
- Configuration update

## Testing steps
via `ocm-cli`, making the same query as smart-proxy does, with token from 29k clusters org

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
