### PR TITLE
fix possible duplicate records returned from AMS API. cluster UUID is unique for us.

### DIFF
--- a/amsclient/amsclient.go
+++ b/amsclient/amsclient.go
@@ -242,6 +242,8 @@ func (c *amsClientImpl) executeSubscriptionListRequest(
 	clusterInfoList []types.ClusterInfo,
 	err error,
 ) {
+	uniqueClusterMap := make(map[string]bool)
+
 	for pageNum := 1; ; pageNum++ {
 		var err error
 		subscriptionListRequest = subscriptionListRequest.
@@ -278,6 +280,12 @@ func (c *amsClientImpl) executeSubscriptionListRequest(
 				log.Error().Str(clusterIDTag, clusterIDstr).Msg("Invalid cluster UUID")
 				continue
 			}
+
+			// check for duplicates; add to unique struct
+			if _, exists := uniqueClusterMap[clusterIDstr]; exists {
+				continue
+			}
+			uniqueClusterMap[clusterIDstr] = true
 
 			displayName, ok := item.GetDisplayName()
 			if !ok {

--- a/amsclient/amsclient.go
+++ b/amsclient/amsclient.go
@@ -242,7 +242,7 @@ func (c *amsClientImpl) executeSubscriptionListRequest(
 	clusterInfoList []types.ClusterInfo,
 	err error,
 ) {
-	uniqueClusterMap := make(map[string]bool)
+	uniqueClusterMap := make(map[string]struct{})
 
 	for pageNum := 1; ; pageNum++ {
 		var err error
@@ -285,7 +285,7 @@ func (c *amsClientImpl) executeSubscriptionListRequest(
 			if _, exists := uniqueClusterMap[clusterIDstr]; exists {
 				continue
 			}
-			uniqueClusterMap[clusterIDstr] = true
+			uniqueClusterMap[clusterIDstr] = struct{}{}
 
 			displayName, ok := item.GetDisplayName()
 			if !ok {

--- a/tests/testdata/amstestdata.go
+++ b/tests/testdata/amstestdata.go
@@ -153,6 +153,45 @@ var (
 		},
 	}
 
+	// SubscriptionsResponseDuplicateRecords contains a valid response for subscription from AMS, as AMS API
+	// can sometimes send duplicate records. Cluster UUID (external_cluster_id) is unique for us, so we must
+	// exclude those records.
+	SubscriptionsResponseDuplicateRecords map[string]interface{} = map[string]interface{}{
+		"kind":  "SubscriptionList",
+		"page":  1,
+		"size":  4,
+		"total": 4,
+		"items": []map[string]interface{}{
+			{
+				"display_name":        ClusterDisplayName1,
+				"external_cluster_id": ClusterName1,
+				"id":                  "1YfQ9bR7LTDz24YzfFmaCdeB0sS",
+				"managed":             true,
+				"status":              ActiveStatus,
+			},
+			{
+				"display_name":        ClusterDisplayName2,
+				"external_cluster_id": ClusterName2,
+				"id":                  "1YfQLCOCZZOEXgOp8uIbqe5i5z2",
+				"managed":             false,
+				"status":              ActiveStatus,
+			}, {
+				"display_name":        ClusterDisplayName1,
+				"external_cluster_id": ClusterName1,
+				"id":                  "1YfQ9bR7LTDz24YzfFmaCdeB0sS",
+				"managed":             true,
+				"status":              ActiveStatus,
+			},
+			{
+				"display_name":        ClusterDisplayName2,
+				"external_cluster_id": ClusterName2,
+				"id":                  "1YfQLCOCZZOEXgOp8uIbqe5i5z2",
+				"managed":             false,
+				"status":              ActiveStatus,
+			},
+		},
+	}
+
 	// SubscriptionEmptyResponse contains a valid response for subscription from AMS, 0 clusters
 	SubscriptionEmptyResponse map[string]interface{} = map[string]interface{}{
 		"kind":  "SubscriptionList",


### PR DESCRIPTION
# Description
AMS API can sometimes return duplicate records even though `page_size=-1` (unlimited page size). Possibly due to some internal paging mechanism inside AMS API. Because we didn't modify the cluster list returned from AMS, these duplicated clusters have been showing in the Insights Advisor for OpenShift application (noticed by tdosek in his org). 

this fix included:
- unlinking my c.r.c account from my organization
- linking my account to known problematic organization (tdosek's org)
- testing behaviour on prod to check if it's backend/frontend issue
- retrieving access token for said organization
- modifying `amsclient` auth locally to accept access tokens instead of client ID and secret
- fix in this PR
- re-test with modified amsclient
- re-link my proper org to my account

Fixes https://issues.redhat.com/browse/CCXDEV-11659

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
mentioned in description

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
