### PR TITLE
`v1/organizations/{organization}/clusters` now uses AMS API functionality to get cluster list

### DIFF
--- a/server/endpoints_v1.go
+++ b/server/endpoints_v1.go
@@ -70,9 +70,9 @@ const (
 	DisableRuleFeedbackEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/disable_feedback"
 	// OverviewEndpoint returns some overview data for the clusters belonging to the org id
 	OverviewEndpoint = "org_overview"
-
 	// ClustersForOrganizationEndpoint returns all clusters for {organization}
-	ClustersForOrganizationEndpoint = ira_server.ClustersForOrganizationEndpoint
+	ClustersForOrganizationEndpoint = "organizations/{organization}/clusters"
+
 	// OrganizationsEndpoint returns all organizations
 	OrganizationsEndpoint = ira_server.OrganizationsEndpoint
 	// DeleteOrganizationsEndpoint deletes all {organizations}(comma separated array). DEBUG only

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -3937,7 +3937,6 @@ func TestHTTPServer_GetClustersForOrganizationOk(t *testing.T) {
 }
 
 func TestHTTPServer_GetClustersForOrganizationAggregatorFallback(t *testing.T) {
-
 	clusterInfoList := make([]types.ClusterInfo, 2)
 	for i := range clusterInfoList {
 		clusterInfoList[i] = data.GetRandomClusterInfo()

--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -133,7 +133,7 @@ func (server HTTPServer) getClustersForOrg(writer http.ResponseWriter, request *
 	// try to get cluster list from AMS API because the aggregator way is unusable for large orgs
 	activeClustersInfo, err := server.readClusterInfoForOrgID(orgID)
 	if err != nil {
-		log.Error().Err(err).Int(orgIDTag, int(orgID)).Msg("problem reading cluster list for org")
+		log.Error().Err(err).Int(orgIDTag, int(orgID)).Msg(clusterListError)
 		handleServerError(writer, err)
 		return
 	}

--- a/server/handlers_v1.go
+++ b/server/handlers_v1.go
@@ -124,14 +124,25 @@ func (server HTTPServer) getContentV1(writer http.ResponseWriter, request *http.
 
 // getClustersForOrg retrieves the list of clusters belonging to this organization
 func (server HTTPServer) getClustersForOrg(writer http.ResponseWriter, request *http.Request) {
-	// readOrganizationID is done only for checking the authentication
-	_, successful := httputils.ReadOrganizationID(writer, request, server.Config.Auth)
+	orgID, successful := httputils.ReadOrganizationID(writer, request, server.Config.Auth)
 	if !successful {
-		// already handled in readOrganizationID ?
+		// server error already handled in readOrganizationID
 		return
 	}
 
-	server.proxyTo(server.ServicesConfig.AggregatorBaseEndpoint, nil)(writer, request)
+	// try to get cluster list from AMS API because the aggregator way is unusable for large orgs
+	activeClustersInfo, err := server.readClusterInfoForOrgID(orgID)
+	if err != nil {
+		log.Error().Err(err).Int(orgIDTag, int(orgID)).Msg("problem reading cluster list for org")
+		handleServerError(writer, err)
+		return
+	}
+	clusterList := sptypes.GetClusterNames(activeClustersInfo)
+
+	err = responses.SendOK(writer, responses.BuildOkResponseWithData("clusters", clusterList))
+	if err != nil {
+		log.Error().Err(err).Msg(responseDataError)
+	}
 }
 
 // getRuleIDs returns a list of the names of the rules

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -262,7 +262,7 @@ func (server HTTPServer) getRecommendations(writer http.ResponseWriter, request 
 
 	activeClustersInfo, err := server.readClusterInfoForOrgID(orgID)
 	if err != nil {
-		log.Error().Err(err).Int(orgIDTag, int(orgID)).Msg("problem reading cluster list for org")
+		log.Error().Err(err).Int(orgIDTag, int(orgID)).Msg(clusterListError)
 		handleServerError(writer, err)
 		return
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -85,12 +85,12 @@ const (
 	// clusterIDTag is used for printing cluster IDs
 	clusterIDTag = "clusterID"
 
-	ackedRulesError = "Unable to retrieve list of acked rules"
-
-	compositeRuleIDError = "Error generating composite rule ID for [%v] and [%v]"
-
 	// dotReport ".report" string present in the ruleID in most tables
 	dotReport = ".report"
+
+	ackedRulesError      = "Unable to retrieve list of acked rules"
+	compositeRuleIDError = "Error generating composite rule ID for [%v] and [%v]"
+	clusterListError     = "problem reading cluster list for org"
 )
 
 // HTTPServer is an implementation of Server interface
@@ -1439,7 +1439,7 @@ func (server *HTTPServer) getClusterListAndUserData(
 	// get list of clusters from AMS API or aggregator
 	clusterInfoList, err := server.readClusterInfoForOrgID(orgID)
 	if err != nil {
-		log.Error().Err(err).Int(orgIDTag, int(orgID)).Msg("problem reading cluster list for org")
+		log.Error().Err(err).Int(orgIDTag, int(orgID)).Msg(clusterListError)
 		handleServerError(writer, err)
 		return
 	}


### PR DESCRIPTION
# Description
`v1/organizations/{organization}/clusters` was practically unusable for very large orgs (>20k clusters) because it was retrieving clusters by string (date) comparison. Combined with the large number of rows in the table, it took a very long time to retrieve the results and triggered a gateway timeout.

- endpoint is not utilized by any real consumer, only tests (visible in metrics)
  - removing the endpoint is still not a good idea
- already mentioned in OpenAPI spec that v2/clusters should be used instead
- historically this endpoint was used before we introduced the AMS API
- aggregator fallback functionality is kept

Fixes CCXDEV-11657

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Unit tests (no changes in the code)
- REST API tests

## Testing steps
`make before_commit`

## Checklist
* [x] `make before_commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [x] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
