### PR TITLE
Using newer version of base image to fix CVE-2023-28484 and CVE-2023-29469

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ USER 0
 RUN make build && \
     chmod a+x insights-results-smart-proxy
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1014
+FROM registry.access.redhat.com/ubi8/ubi-minimal:8.8-1037
 
 COPY --from=builder /opt/app-root/src/insights-results-smart-proxy .
 COPY --from=builder /opt/app-root/src/server/api/v1/openapi.json /openapi/v1/openapi.json


### PR DESCRIPTION
# Description

Upgrade base image in order to use the newer version of libxml2 that is free of the mentioned CVEs

#CCXDEV-10603

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Bump-up dependent library (no changes in the code)

## Testing steps

N/A

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
