### PR TITLE
Copy certificate authorities in final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,10 @@ COPY --from=builder /opt/app-root/src/insights-results-smart-proxy .
 COPY --from=builder /opt/app-root/src/server/api/v1/openapi.json /openapi/v1/openapi.json
 COPY --from=builder /opt/app-root/src/server/api/v2/openapi.json /openapi/v2/openapi.json
 
+# copy the certificates from builder image
+COPY --from=builder /etc/ssl /etc/ssl
+COPY --from=builder /etc/pki /etc/pki
+
 USER 1001
 
 CMD ["/insights-results-smart-proxy"]


### PR DESCRIPTION
# Description

ubi-micro, used as base image, doesn't contain the needed certificate files to be able to connect to external services, causing problems when connecting to logstash (for example).

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Manual tests locally

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
