### PR TITLE
[CCXDEV-10937] Update Travis BDD step to use run_in_container.sh script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,11 +46,10 @@ jobs:
         - docker
       before_script:
         - ./build.sh
-        - cid=$(docker run -itd quay.io/cloudservices/insights-behavioral-spec:latest sh -c "sleep infinity")
-        - docker cp insights-results-smart-proxy $cid:`docker exec $cid bash -c 'echo "$VIRTUAL_ENV_BIN/."'`
-        - docker exec -u root $cid /bin/bash -c 'chmod +x $VIRTUAL_ENV_BIN/insights-results-smart-proxy'
+        - wget -O docker-compose.yml https://raw.githubusercontent.com/RedHatInsights/insights-behavioral-spec/main/docker-compose.yml
+        - wget -O bdd_runner.sh https://raw.githubusercontent.com/RedHatInsights/insights-behavioral-spec/main/run_in_docker.sh && chmod +x bdd_runner.sh
       script:
-        - docker exec -it $cid /bin/bash -c 'env && make smart-proxy-tests'
+        - ./bdd_runner.sh smart-proxy-tests .
     - stage: integration tests
       script:
         - make integration_tests


### PR DESCRIPTION
# Description

Simplify BDD stage in Travis by using the [run_in_container.sh script](https://github.com/RedHatInsights/insights-behavioral-spec/blob/main/run_in_docker.sh).

Fixes CCXDEV-10937

## Type of change

- Refactor (refactoring code, removing useless files)
- Behavioral tests (no changes in the code)

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
