### PR TITLE
Unit test for function to retrieve KafkaZerolog configuration struct

### DIFF
--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -296,3 +296,28 @@ func TestGetSetupConfiguration(t *testing.T) {
 	// check returned structure
 	assert.Equal(t, "tests/internal_organizations_test.csv", setupConfiguration.InternalRulesOrganizationsCSVFile)
 }
+
+// TestKafkaZerologConfiguration tests loading the KafkaZerolog configuration sub-tree
+func TestKafkaZerologConfiguration(t *testing.T) {
+	/* Load following configuration:
+
+	[kafka_zerolog]
+	broker = "-kafka-zerolog-broker-"
+	topic = "-kafka-zerolog-topic-"
+	cert_path = "-kafka-zerolog-cert-path-"
+	level = "-kafka-zerolog-level-"
+
+	*/
+
+	TestLoadConfiguration(t)
+	helpers.FailOnError(t, os.Chdir(".."))
+
+	// call the tested function
+	configuration := conf.GetKafkaZerologConfiguration()
+
+	// check returned structure
+	assert.Equal(t, "-kafka-zerolog-broker-", configuration.Broker)
+	assert.Equal(t, "-kafka-zerolog-topic-", configuration.Topic)
+	assert.Equal(t, "-kafka-zerolog-cert-path-", configuration.CertPath)
+	assert.Equal(t, "-kafka-zerolog-level-", configuration.Level)
+}

--- a/tests/config1.toml
+++ b/tests/config1.toml
@@ -37,3 +37,9 @@ url = "https://api.openshift.com"
 client_id = "-client-id-"
 client_secret = "-top-secret-"
 page_size = 6000
+
+[kafka_zerolog]
+broker = "-kafka-zerolog-broker-"
+topic = "-kafka-zerolog-topic-"
+cert_path = "-kafka-zerolog-cert-path-"
+level = "-kafka-zerolog-level-"


### PR DESCRIPTION
# Description

Unit test for function to retrieve KafkaZerolog configuration struct

Fixes #750 

## Type of change

- Unit tests (no changes in the code)

## Testing steps

To be checked on CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
