### PR TITLE
Reenable tests to check race condition in CI

### DIFF
--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -22,12 +22,14 @@ import (
 	"time"
 
 	// "github.com/RedHatInsights/insights-content-service/groups"
+	"github.com/RedHatInsights/insights-content-service/groups"
 	"github.com/RedHatInsights/insights-operator-utils/responses"
 	iou_helpers "github.com/RedHatInsights/insights-operator-utils/tests/helpers"
 	"github.com/RedHatInsights/insights-results-aggregator-data/testdata"
 	ira_server "github.com/RedHatInsights/insights-results-aggregator/server"
 
 	// "github.com/RedHatInsights/insights-results-smart-proxy/content"
+	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
 	data "github.com/RedHatInsights/insights-results-smart-proxy/tests/testdata"
@@ -3770,7 +3772,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_DisabledAndAcked(t *testing.
 }
 
 // TODO: fix race condition/deadlock, then this test can be enabled again
-/*
+// If this test fails again, please refer to CCXDEV-11314 and attach the CI run
 func TestHTTPServer_GroupsEndpoint(t *testing.T) {
 	groupsChannel := make(chan []groups.Group)
 	errorFoundChannel := make(chan bool)
@@ -3803,10 +3805,9 @@ func TestHTTPServer_GroupsEndpoint(t *testing.T) {
 		})
 	}, 30*time.Second)
 }
-*/
 
 // TODO: fix race condition/deadlock, then this test can be enabled again
-/*
+// If this test fails again, please refer to CCXDEV-11314 and attach the CI run
 func TestHTTPServer_GroupsEndpoint_UnavailableContentService(t *testing.T) {
 	groupsChannel := make(chan []groups.Group)
 	errorFoundChannel := make(chan bool)
@@ -3832,7 +3833,6 @@ func TestHTTPServer_GroupsEndpoint_UnavailableContentService(t *testing.T) {
 		})
 	}, 30*time.Second)
 }
-*/
 
 // TestServeInfoMap checks the REST API server behaviour for info endpoint
 func TestServeInfoMap(t *testing.T) {


### PR DESCRIPTION
# Description

Enabling tests that were disabled because they caused a race condition.

I'm not able to reproduce the problem locally, so I'm trying to see the problem running it on CI

## Type of change

- Unit tests (no changes in the code)

## Testing steps

Tested locally

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
