### PR TITLE
[CCXDEV-12251] Fix retrieval of request IDs for the given cluster

### DIFF
--- a/services/redis.go
+++ b/services/redis.go
@@ -47,9 +47,8 @@ const (
 
 var (
 	// RequestIDsScanPattern is a glob-style pattern to find all matching keys. Uses ?* instead of * to avoid
-	// matching "organization:%v:cluster:%v:request:". [^:reports] is an exclude pattern to not match the
-	// simplified report keys
-	RequestIDsScanPattern = "organization:%v:cluster:%v:request:?*[^:reports]"
+	// matching "organization:%v:cluster:%v:request:".
+	RequestIDsScanPattern = "organization:%v:cluster:%v:request:?*"
 
 	// SimplifiedReportKey is a key under which the information about specific requests is stored
 	SimplifiedReportKey = "organization:%v:cluster:%v:request:%v:reports"
@@ -122,6 +121,10 @@ func (redisClient *RedisClient) GetRequestIDsForClusterID(
 
 		// get last part of key == request_id
 		for _, key := range keys {
+			// exclude simplified report keys that are ending with ":reports" suffix
+			if strings.HasSuffix(key, ":reports") {
+				continue
+			}
 			keySliced := strings.Split(key, ":")
 			requestID := keySliced[len(keySliced)-1]
 			requestIDs = append(requestIDs, types.RequestID(requestID))


### PR DESCRIPTION
# Description

The glob-style pattern used for filtering request IDs in Redis cache wasn't correct. The fix simplifies the pattern and adds additional filtering on the service side.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps

Run the filtering against some samples in the locally run Redis cache, run the unit tests.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
