### PR TITLE
Fix missing status in data engineering response

### DIFF
--- a/server/upgrade_risks_prediction.go
+++ b/server/upgrade_risks_prediction.go
@@ -163,15 +163,10 @@ func (server *HTTPServer) upgradeRisksPredictionMultiCluster(writer http.Respons
 	// prepare and send response
 	response := make(map[string]interface{})
 
-	if predictionResponse.Status != "" {
-		// RHOBS has data for at least one of the clusters
-		response["status"] = predictionResponse.Status
-		response["predictions"] = predictionResponse.Predictions
-	} else {
-		// RHOBS has no data for any of the given clusters
-		response["status"] = "ok"
-		response["predictions"] = []types.UpgradeRisksPrediction{}
-	}
+	// RHOBS has data for at least one of the clusters
+	response["status"] = "ok"
+	response["predictions"] = predictionResponse.Predictions
+
 	err = responses.SendOK(
 		writer,
 		response,


### PR DESCRIPTION
# Description

Data Engineering service doesn't include an "status" key in its JSON responses, so the value will be always missing. This PR will take that into account and avoid returning empty list of predictions on success.

Fixes #CCXDEV-11669

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

Tested locally

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
