### PR TITLE
Minor improvement in the schema definition for multi cluster URP

### DIFF
--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -2373,6 +2373,7 @@
           },
           "last_checked_at": {
             "type": "string",
+            "format": "date-time",
             "example": "2011-15-04T00:05:23Z"
           }
         }


### PR DESCRIPTION
# Description

Adding the string format for `"last_checked_at"` field in one of the URP responses

Fixes #CCXDEV-12500

## Type of change

- Refactor (refactoring code, removing useless files)

## Testing steps

Just openapi check

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
