### PR TITLE
extend DVO workload related endpoints to latest version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/BurntSushi/toml v1.3.2
 	github.com/RedHatInsights/insights-content-service v1.0.0
 	github.com/RedHatInsights/insights-operator-utils v1.25.3
-	github.com/RedHatInsights/insights-results-aggregator v1.3.4
+	github.com/RedHatInsights/insights-results-aggregator v1.4.0
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.9
 	github.com/RedHatInsights/insights-results-types v1.3.23
 	github.com/go-redis/redismock/v9 v9.2.0
@@ -77,7 +77,6 @@ require (
 	github.com/magiconair/properties v1.8.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
-	github.com/mattn/go-sqlite3 v2.0.3+incompatible // indirect
 	github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0 // indirect
 	github.com/microcosm-cc/bluemonday v1.0.23 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -44,8 +44,9 @@ github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EFZQ978U7x8IRnstaskI3IysnWY5Ao3QgZUKOXlsAdw=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
-github.com/DATA-DOG/go-sqlmock v1.4.1 h1:ThlnYciV1iM/V0OSF/dtkqWb6xo5qITT1TJBG1MRDJM=
 github.com/DATA-DOG/go-sqlmock v1.4.1/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+github.com/DATA-DOG/go-sqlmock v1.5.2 h1:OcvFkGmslmlZibjAjaHm3L//6LiuBgolP7OputlJIzU=
+github.com/DATA-DOG/go-sqlmock v1.5.2/go.mod h1:88MAG/4G7SMwSE3CeA0ZKzrT5CiOU3OJ+JlNzwDqpNU=
 github.com/DataDog/datadog-go v2.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKzY=
 github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4KhCrqr6GRJjdC/gNfTdxkIXvuGZZda2VM=
@@ -59,7 +60,6 @@ github.com/RedHatInsights/cloudwatch v0.0.0-20200512151223-b0b55757a24b/go.mod h
 github.com/RedHatInsights/cloudwatch v0.0.0-20210111105023-1df2bdfe3291 h1:f2RIq2LvG0Nz7TrPYr8clzUPXIEf+Q3oDoCfAHym4/I=
 github.com/RedHatInsights/cloudwatch v0.0.0-20210111105023-1df2bdfe3291/go.mod h1:8l+HqU8iWM6hA9kSAHgY3ItSlpEsPr8fb2R0GBp9S0U=
 github.com/RedHatInsights/insights-content-service v0.0.0-20200619153839-23a428468a08/go.mod h1:CSzDwoJXMIPnRNOZfYn68YbXejRqSr0i4uqtB6oLYt4=
-github.com/RedHatInsights/insights-content-service v0.0.0-20221024073309-fabee4bcb06e/go.mod h1:9bnb8zbE7ocCmrvVpmIRgCOcb2ew7ovEcReMB953Pbo=
 github.com/RedHatInsights/insights-content-service v1.0.0 h1:rwxz1rCbZbjoR9isTcDlDUE9vNzgKvl5agxlxS2L18g=
 github.com/RedHatInsights/insights-content-service v1.0.0/go.mod h1:6nihzwhfwTZHM8ClPwISTntuYPf6W2UzcI+yPeUPMRk=
 github.com/RedHatInsights/insights-operator-utils v1.0.1/go.mod h1:gRzYBMY4csuOXgrxUuC10WUkz6STOm3mqVsQCb+AGOQ=
@@ -72,13 +72,12 @@ github.com/RedHatInsights/insights-operator-utils v1.12.0/go.mod h1:mN5jURLpSG+j
 github.com/RedHatInsights/insights-operator-utils v1.21.0/go.mod h1:B2hizFGwXCc8MT34QqVJ1A8ANTyGQZQWXQw/gSCEsaU=
 github.com/RedHatInsights/insights-operator-utils v1.21.2/go.mod h1:3Pfsgsi7GCu2wgIqQlt1llpyQyyxsDWEGdgnPvadM40=
 github.com/RedHatInsights/insights-operator-utils v1.21.8/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
-github.com/RedHatInsights/insights-operator-utils v1.22.0/go.mod h1:4G1aWUV3SBc5tRflpAZX2BjoWB8afxXtSutg+5/sLE8=
 github.com/RedHatInsights/insights-operator-utils v1.24.5/go.mod h1:7qR/8rlMdiqoXAkZyQ5JhVrVNCa6SBwNUt4KMq/17j4=
 github.com/RedHatInsights/insights-operator-utils v1.25.3 h1:68+ppwkm8gGLELBwI6gNmkvyRAD0aJt1Ja1iSggqJcA=
 github.com/RedHatInsights/insights-operator-utils v1.25.3/go.mod h1:/kKpnF+K0J3xPSujVGiE4NtsEbOa2ttJDmSqzZOVnko=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
-github.com/RedHatInsights/insights-results-aggregator v1.3.4 h1:co58Suun8+6G8gLm41Ws1K+pifwXs6/LAiRbB/Zir1c=
-github.com/RedHatInsights/insights-results-aggregator v1.3.4/go.mod h1:mceJE31e1pofOjY9Wkrrxqvw6l1hQCRDNwnkLdnfY1M=
+github.com/RedHatInsights/insights-results-aggregator v1.4.0 h1:ZaEcgPh9eycVGq0ORdsNat3mayLLCCOUjiMoYaP4HFk=
+github.com/RedHatInsights/insights-results-aggregator v1.4.0/go.mod h1:hAVwcog5dsSFYIp8E+D4cD8uYKYISIziKpDvNxKD0TM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20200825113234-e84e924194bc/go.mod h1:DcDgoCCmBuUSKQOGrTi0BfFLdSjAp/KxIwyqKUd46sM=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201014142608-de97c4b07d5c/go.mod h1:x8IvreR2g24veCKVMXDPOR6a0D86QK9UCBfi5Xm5Gnc=
 github.com/RedHatInsights/insights-results-aggregator-data v0.0.0-20201109115720-126bd0348556/go.mod h1:+j10GLCbx42McRJE7uU+aVayf5Elwx4nKULFiPkki6U=
@@ -87,11 +86,9 @@ github.com/RedHatInsights/insights-results-aggregator-data v1.1.2/go.mod h1:rbic
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.1/go.mod h1:Ylo2cWFmraBzkwKLew54kZSsUTgeVvFJdIi/oRkdxtc=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.2/go.mod h1:E1UaB+IjJ/muxvMstVoqJrB82zVKNykjTtCiM3tMHoM=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.3/go.mod h1:udHNC7lBxYnu9AqMahABqvuclCzWUWSkbacQbUaehfI=
-github.com/RedHatInsights/insights-results-aggregator-data v1.3.6/go.mod h1:tOwmlIB5irSv1mTLgONuLrsbTp4vokl4ClJFClrrXX0=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.9 h1:D6JtouoQs606xOIQaQVmAFi+tgw/UEv/POarE46VdEY=
 github.com/RedHatInsights/insights-results-aggregator-data v1.3.9/go.mod h1:sL0aXaqEq/EzjMEj8QHv13RjfnSXvv2f2q/7OHSOVCQ=
 github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
-github.com/RedHatInsights/insights-results-types v1.3.7/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.20/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.21/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.22/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
@@ -150,7 +147,9 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4Yn
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
 github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/ginkgo/v2 v2.12.0/go.mod h1:SwYbGRRDovPVboqFv0tPTcG1sN61LM1Z4ARdbAV9g4c=
 github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
+github.com/bsm/gomega v1.27.10/go.mod h1:JyEr/xRbxbtgWNi8tIEVPUYZ5Dzef52k01W3YH0H+O0=
 github.com/bsm/sarama-cluster v2.1.10+incompatible/go.mod h1:r7ao+4tTNXvWm+VRpRJchr2kQhqxgmAp2iEX5W96gMM=
 github.com/buger/jsonparser v1.0.0/go.mod h1:tgcrVJ81GPSF0mz+0nu1Xaz0fazGPrmmJfJtxjbHhUQ=
 github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
@@ -200,8 +199,9 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckarep/golang-set v1.7.1 h1:SCQV0S6gTtp6itiFrTqI+pfmJ4LN85S1YzhDf9rTHJQ=
 github.com/deckarep/golang-set v1.7.1/go.mod h1:93vsz/8Wt4joVM7c2AVqh+YRMiUSc14yDtF28KmMOgQ=
+github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=
+github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/dgraph-io/badger v1.6.0/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
@@ -242,6 +242,7 @@ github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2
 github.com/frankban/quicktest v1.4.1/go.mod h1:36zfPVQyHxymz4cH7wlDmVwDrJuljRB60qkgn7rorfQ=
 github.com/frankban/quicktest v1.10.2/go.mod h1:K+q6oSqb0W0Ininfk863uOk1lMy69l/P6txr3mVT54s=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.6.0 h1:n+5WquG0fcWoWp6xPWfHdbskMCQaFnG6PfBrh1Ky4HY=
@@ -263,6 +264,7 @@ github.com/gin-gonic/gin v1.4.0/go.mod h1:OW2EZn3DO8Ln9oIKOvM++LBO+5UPHJJDH72/q/
 github.com/go-check/check v0.0.0-20180628173108-788fd7840127/go.mod h1:9ES+weclKsC9YodN5RgxqK/VD9HM9JsCSh7rNhMZE98=
 github.com/go-errors/errors v1.0.1/go.mod h1:f4zRHt4oKfwPJE5k8C9vpYG+aDHdBFUsgrm6/TyX73Q=
 github.com/go-errors/errors v1.4.2 h1:J6MZopCL4uSllY1OfXM374weqZFFItUbrImctkmUxIA=
+github.com/go-errors/errors v1.4.2/go.mod h1:sIVyrIiJhuEF+Pj9Ebtd6P/rEYROXFi3BopGUQ5a5Og=
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
@@ -557,6 +559,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/pty v1.1.8/go.mod h1:O1sed60cT9XZ5uDucP5qwvh+TE3NnUj51EiZO/lmSfw=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
@@ -569,7 +572,6 @@ github.com/lib/pq v1.1.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.3.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 github.com/lib/pq v1.7.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
-github.com/lib/pq v1.8.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.2/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
@@ -613,7 +615,6 @@ github.com/matttproud/golang_protobuf_extensions/v2 v2.0.0/go.mod h1:QUyp042oQth
 github.com/mediocregopher/mediocre-go-lib v0.0.0-20181029021733-cb65787f37ed/go.mod h1:dSsfyI2zABAdhcbvkXqgxOxrCsbYeHCPgrZkku60dSg=
 github.com/mediocregopher/radix/v3 v3.3.0/go.mod h1:EmfVyvspXz1uZEyPBMyGK+kjWiKQGvsUt6O3Pj+LDCQ=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
-github.com/microcosm-cc/bluemonday v1.0.21/go.mod h1:ytNkv4RrDrLJ2pqlsSI46O6IVXmZOBBD4SaJyDwwTkM=
 github.com/microcosm-cc/bluemonday v1.0.23 h1:SMZe2IGa0NuHvnVNAZ+6B38gsTbi5e4sViiWJyDDqFY=
 github.com/microcosm-cc/bluemonday v1.0.23/go.mod h1:mN70sk7UkkF8TUr2IGBpNN0jAgStuPzlK76QuruE/z4=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -655,6 +656,7 @@ github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy
 github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
+github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
@@ -664,6 +666,7 @@ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/ginkgo v1.10.3/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/ginkgo/v2 v2.7.0 h1:/XxtEV3I3Eif/HobnVx9YmJgk8ENdRsuUmM+fLCFNow=
 github.com/onsi/ginkgo/v2 v2.7.0/go.mod h1:yjiuMwPokqY1XauOgju45q3sJt6VzQ/Fict1LFVcsAo=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -762,7 +765,6 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0 h1:MkV+77GLUNo5oJ0jf870itWm3D0Sjh7+Za9gazKc5LQ=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/redhatinsights/app-common-go v1.5.1/go.mod h1:SqgG5JkX/RNlk2d+sXamIFxhOIvWLgCBr8uK6q70ESk=
-github.com/redhatinsights/app-common-go v1.6.3/go.mod h1:6gzRyg8ZyejwMCksukeAhh2ZXOB3uHSmBsbP06fG2PQ=
 github.com/redhatinsights/app-common-go v1.6.7 h1:cXWW0F6ZW53RLRr54gn7Azo9CLTysYOmFDR0D0Qd0Fs=
 github.com/redhatinsights/app-common-go v1.6.7/go.mod h1:6gzRyg8ZyejwMCksukeAhh2ZXOB3uHSmBsbP06fG2PQ=
 github.com/redis/go-redis/v9 v9.4.0 h1:Yzoz33UZw9I/mFhx4MNrB6Fk+XHO1VukNcCa1+lwyKk=
@@ -770,6 +772,7 @@ github.com/redis/go-redis/v9 v9.4.0/go.mod h1:hdY0cQFCN4fnSYT6TkisLufl/4W5UIXyv0
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
@@ -878,6 +881,7 @@ github.com/verdverm/frisby v0.0.0-20170604211311-b16556248a9a h1:Mt+KWT4h97wIDQa
 github.com/verdverm/frisby v0.0.0-20170604211311-b16556248a9a/go.mod h1:Z+jvFzFlZ6eHAKMfi8PZZphUtg4S0gc2EZYOL9UnWgA=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/scram v1.0.5 h1:TuS0RFmt5Is5qm9Tm2SoD89OPqe4IRiFtyFY4iwWXsw=
+github.com/xdg/scram v1.0.5/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
 github.com/xdg/stringprep v1.0.0 h1:d9X0esnoa3dFsV0FG35rAT0RIhYFlPq7MiP+DW89La0=
 github.com/xdg/stringprep v1.0.0/go.mod h1:Jhud4/sHMO4oL310DaZAKk9ZaJ08SJfe+sJh0HrGL1Y=
 github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
@@ -1030,7 +1034,6 @@ golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20220127200216-cd36cc0744dd/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
-golang.org/x/net v0.0.0-20221002022538-bcab6841153b/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/net v0.19.0 h1:zTwKpTd2XuCqf8huc7Fo2iSy+4RHPd10s4KzeTnVr1c=
 golang.org/x/net v0.19.0/go.mod h1:CfAk/cbD4CthTvqiEl8NpboMuiuOYsAr/7NOjZJtv1U=
@@ -1131,7 +1134,6 @@ golang.org/x/sys v0.0.0-20220114195835-da31bd327af9/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220227234510-4e6760a101f9/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220908164124-27713097b956/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -1333,6 +1335,7 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -2769,7 +2769,7 @@ func TestHTTPServer_DVONamespaceListEndpoint_NoWorkloads(t *testing.T) {
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "organization/{organization}/workloads", // TODO: use real ira_server endpoint
+				Endpoint:     ira_server.DVOWorkloadRecommendations,
 				EndpointArgs: []interface{}{testdata.OrgID},
 			},
 			&helpers.APIResponse{
@@ -2844,7 +2844,7 @@ func TestHTTPServer_DVONamespaceListEndpoint_OK(t *testing.T) {
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "organization/{organization}/workloads", // TODO: use real ira_server endpoint
+				Endpoint:     ira_server.DVOWorkloadRecommendations,
 				EndpointArgs: []interface{}{testdata.OrgID},
 			},
 			&helpers.APIResponse{
@@ -2961,7 +2961,7 @@ func TestHTTPServer_DVONamespaceListEndpoint_AggregatorError(t *testing.T) {
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "organization/{organization}/workloads", // TODO: use real ira_server endpoint
+				Endpoint:     ira_server.DVOWorkloadRecommendations,
 				EndpointArgs: []interface{}{testdata.OrgID},
 			},
 			&helpers.APIResponse{
@@ -3033,7 +3033,7 @@ func TestHTTPServer_DVONamespaceListEndpoint_RecommendationDoesNotExist(t *testi
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "organization/{organization}/workloads", // TODO: use real ira_server endpoint
+				Endpoint:     ira_server.DVOWorkloadRecommendations,
 				EndpointArgs: []interface{}{testdata.OrgID},
 			},
 			&helpers.APIResponse{
@@ -3124,7 +3124,7 @@ func TestHTTPServer_DVONamespaceListEndpoint_FilterOutInactiveClusters(t *testin
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "organization/{organization}/workloads", // TODO: use real ira_server endpoint
+				Endpoint:     ira_server.DVOWorkloadRecommendations,
 				EndpointArgs: []interface{}{testdata.OrgID},
 			},
 			&helpers.APIResponse{
@@ -3188,7 +3188,7 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterNotFound(t *testing.T) {
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "organization/{organization}/namespace/{namespace}/cluster/{cluster}/workloads", // TODO: use real ira_server endpoint
+				Endpoint:     ira_server.DVOWorkloadRecommendationsSingleNamespace,
 				EndpointArgs: []interface{}{testdata.OrgID, data.NamespaceUUID1, testdata.ClusterName},
 			},
 			&helpers.APIResponse{
@@ -3255,7 +3255,7 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterFoundNoWorkloads(t *testing.T
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "organization/{organization}/namespace/{namespace}/cluster/{cluster}/workloads", // TODO: use real ira_server endpoint
+				Endpoint:     ira_server.DVOWorkloadRecommendationsSingleNamespace,
 				EndpointArgs: []interface{}{testdata.OrgID, data.NamespaceUUID1, testdata.ClusterName},
 			},
 			&helpers.APIResponse{
@@ -3372,7 +3372,7 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterFoundWithWorkloads(t *testing
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "organization/{organization}/namespace/{namespace}/cluster/{cluster}/workloads", // TODO: use real ira_server endpoint
+				Endpoint:     ira_server.DVOWorkloadRecommendationsSingleNamespace,
 				EndpointArgs: []interface{}{testdata.OrgID, data.NamespaceUUID1, testdata.ClusterName},
 			},
 			&helpers.APIResponse{
@@ -3592,7 +3592,7 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterFoundWithWorkloads_RuleConten
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "organization/{organization}/namespace/{namespace}/cluster/{cluster}/workloads", // TODO: use real ira_server endpoint
+				Endpoint:     ira_server.DVOWorkloadRecommendationsSingleNamespace,
 				EndpointArgs: []interface{}{testdata.OrgID, data.NamespaceUUID1, testdata.ClusterName},
 			},
 			&helpers.APIResponse{
@@ -3667,7 +3667,7 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterFoundWithWorkloads_NotFoundIn
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "organization/{organization}/namespace/{namespace}/cluster/{cluster}/workloads", // TODO: use real ira_server endpoint
+				Endpoint:     ira_server.DVOWorkloadRecommendationsSingleNamespace,
 				EndpointArgs: []interface{}{testdata.OrgID, data.NamespaceUUID1, testdata.ClusterName},
 			},
 			&helpers.APIResponse{
@@ -3712,7 +3712,7 @@ func TestHTTPServer_DVONamespaceForCluster1_AggregatorError(t *testing.T) {
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "organization/{organization}/namespace/{namespace}/cluster/{cluster}/workloads", // TODO: use real ira_server endpoint
+				Endpoint:     ira_server.DVOWorkloadRecommendationsSingleNamespace,
 				EndpointArgs: []interface{}{testdata.OrgID, data.NamespaceUUID1, testdata.ClusterName},
 			},
 			&helpers.APIResponse{
@@ -3756,7 +3756,7 @@ func TestHTTPServer_DVONamespaceForCluster1_AggregatorBadResponse(t *testing.T) 
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
-				Endpoint:     "organization/{organization}/namespace/{namespace}/cluster/{cluster}/workloads", // TODO: use real ira_server endpoint
+				Endpoint:     ira_server.DVOWorkloadRecommendationsSingleNamespace,
 				EndpointArgs: []interface{}{testdata.OrgID, data.NamespaceUUID1, testdata.ClusterName},
 			},
 			&helpers.APIResponse{

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -2812,11 +2812,11 @@ func TestHTTPServer_DVONamespaceListEndpoint_OK(t *testing.T) {
 
 		now := time.Now().UTC().Format(time.RFC3339)
 		aggrResponse := struct {
-			Status    string                      `json:"status"`
-			Workloads []types.WorkloadsForCluster `json:"workloads"`
+			Status    string                        `json:"status"`
+			Workloads []types.WorkloadsForNamespace `json:"workloads"`
 		}{
 			Status: "ok",
-			Workloads: []types.WorkloadsForCluster{
+			Workloads: []types.WorkloadsForNamespace{
 				{
 					Cluster: types.Cluster{
 						UUID: string(data.ClusterInfoResult2Clusters[0].ID),
@@ -2831,13 +2831,9 @@ func TestHTTPServer_DVONamespaceListEndpoint_OK(t *testing.T) {
 						ReportedAt:      now,
 						LastCheckedAt:   now,
 					},
-					Recommendations: []types.DVORecommendation{
-						{
-							Check: string(testdata.Rule1CompositeID),
-						},
-						{
-							Check: string(testdata.Rule2CompositeID),
-						},
+					RecommendationsHitCount: map[string]int{
+						string(testdata.Rule1CompositeID): 1,
+						string(testdata.Rule2CompositeID): 1,
 					},
 				},
 			},
@@ -3005,11 +3001,11 @@ func TestHTTPServer_DVONamespaceListEndpoint_RecommendationDoesNotExist(t *testi
 
 		now := time.Now().UTC().Format(time.RFC3339)
 		aggrResponse := struct {
-			Status    string                      `json:"status"`
-			Workloads []types.WorkloadsForCluster `json:"workloads"`
+			Status    string                        `json:"status"`
+			Workloads []types.WorkloadsForNamespace `json:"workloads"`
 		}{
 			Status: "ok",
-			Workloads: []types.WorkloadsForCluster{
+			Workloads: []types.WorkloadsForNamespace{
 				{
 					Cluster: types.Cluster{
 						UUID: string(data.ClusterInfoResult2Clusters[0].ID),
@@ -3024,13 +3020,9 @@ func TestHTTPServer_DVONamespaceListEndpoint_RecommendationDoesNotExist(t *testi
 						ReportedAt:      now,
 						LastCheckedAt:   now,
 					},
-					Recommendations: []types.DVORecommendation{
-						{
-							Check: string("non-existent recommendation ID"),
-						},
-						{
-							Check: string(testdata.Rule2CompositeID),
-						},
+					RecommendationsHitCount: map[string]int{
+						string("non-existent rule ID"):    1,
+						string(testdata.Rule2CompositeID): 1,
 					},
 				},
 			},
@@ -3082,11 +3074,11 @@ func TestHTTPServer_DVONamespaceListEndpoint_FilterOutInactiveClusters(t *testin
 
 		now := time.Now().UTC().Format(time.RFC3339)
 		aggrResponse := struct {
-			Status    string                      `json:"status"`
-			Workloads []types.WorkloadsForCluster `json:"workloads"`
+			Status    string                        `json:"status"`
+			Workloads []types.WorkloadsForNamespace `json:"workloads"`
 		}{
 			Status: "ok",
-			Workloads: []types.WorkloadsForCluster{
+			Workloads: []types.WorkloadsForNamespace{
 				{
 					Cluster: types.Cluster{
 						UUID: string(testdata.ClusterName), // <-- cluster is not in the list of active clusters from AMS API
@@ -3101,10 +3093,8 @@ func TestHTTPServer_DVONamespaceListEndpoint_FilterOutInactiveClusters(t *testin
 						ReportedAt:      now,
 						LastCheckedAt:   now,
 					},
-					Recommendations: []types.DVORecommendation{
-						{
-							Check: string(testdata.Rule1CompositeID),
-						},
+					RecommendationsHitCount: map[string]int{
+						string(testdata.Rule1CompositeID): 1,
 					},
 				},
 				{
@@ -3121,13 +3111,9 @@ func TestHTTPServer_DVONamespaceListEndpoint_FilterOutInactiveClusters(t *testin
 						ReportedAt:      now,
 						LastCheckedAt:   now,
 					},
-					Recommendations: []types.DVORecommendation{
-						{
-							Check: string(testdata.Rule1CompositeID),
-						},
-						{
-							Check: string(testdata.Rule2CompositeID),
-						},
+					RecommendationsHitCount: map[string]int{
+						string(testdata.Rule1CompositeID): 1,
+						string(testdata.Rule2CompositeID): 1,
 					},
 				},
 			},
@@ -3345,9 +3331,37 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterFoundWithWorkloads(t *testing
 				Recommendations: []types.DVORecommendation{
 					{
 						Check: string(testdata.Rule1CompositeID),
+						TemplateData: map[string]interface{}{
+							"samples": []map[string]interface{}{
+								{"name": "displayname"},
+							},
+						},
+						Objects: []types.DVOObject{
+							{
+								Kind: "pod",
+								UID:  uuid.NewString(),
+							},
+						},
 					},
 					{
 						Check: string(testdata.Rule2CompositeID),
+						TemplateData: map[string]interface{}{
+							"samples": []map[string]interface{}{
+								{
+									"name": "displayname",
+								},
+							},
+						},
+						Objects: []types.DVOObject{
+							{
+								Kind: "pod",
+								UID:  uuid.NewString(),
+							},
+							{
+								Kind: "pod",
+								UID:  uuid.NewString(),
+							},
+						},
 					},
 				},
 			},
@@ -3378,12 +3392,21 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterFoundWithWorkloads(t *testing
 		expectedResponse.Metadata.HighestSeverity = 2
 		expectedResponse.Metadata.HitsBySeverity = map[int]int{
 			1: 1,
-			2: 1,
+			2: 2,
 		}
-		expectedResponse.Recommendations[0].Description = testdata.RuleErrorKey1.Description
-		expectedResponse.Recommendations[0].Remediation = testdata.RuleErrorKey1.Resolution
-		expectedResponse.Recommendations[1].Description = testdata.RuleErrorKey2.Description
-		expectedResponse.Recommendations[1].Remediation = testdata.RuleErrorKey2.Resolution
+		expectedResponse.Recommendations[0].Details = testdata.RuleErrorKey1.Description
+		expectedResponse.Recommendations[0].Resolution = testdata.RuleErrorKey1.Resolution
+		expectedResponse.Recommendations[0].MoreInfo = testdata.RuleErrorKey1.MoreInfo
+		expectedResponse.Recommendations[0].Modified = testdata.RuleErrorKey1.PublishDate.UTC().Format(time.RFC3339)
+		expectedResponse.Recommendations[0].TemplateData = aggrResp.Workloads.Recommendations[0].TemplateData
+		expectedResponse.Recommendations[0].Objects = aggrResp.Workloads.Recommendations[0].Objects
+
+		expectedResponse.Recommendations[1].Details = testdata.RuleErrorKey2.Description
+		expectedResponse.Recommendations[1].Resolution = testdata.RuleErrorKey2.Resolution
+		expectedResponse.Recommendations[1].MoreInfo = testdata.RuleErrorKey2.MoreInfo
+		expectedResponse.Recommendations[1].Modified = testdata.RuleErrorKey2.PublishDate.UTC().Format(time.RFC3339)
+		expectedResponse.Recommendations[1].TemplateData = aggrResp.Workloads.Recommendations[1].TemplateData
+		expectedResponse.Recommendations[1].Objects = aggrResp.Workloads.Recommendations[1].Objects
 
 		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
 

--- a/server/server.go
+++ b/server/server.go
@@ -1526,11 +1526,11 @@ func (server *HTTPServer) getWorkloadsForCluster(
 // getWorkloadsForOrganization returns a list of workloads for given organization ID.
 // Empty slice is returned when aggregator responds with 404 Not Found.
 // Nil is returned when any other unexpected error occurs.
-func (server *HTTPServer) getWorkloadsForOrganization(orgID types.OrgID) ([]types.WorkloadsForCluster, error) {
+func (server *HTTPServer) getWorkloadsForOrganization(orgID types.OrgID) ([]types.WorkloadsForNamespace, error) {
 	// wont be used anywhere else
 	var response struct {
-		Status    string                      `json:"status"`
-		Workloads []types.WorkloadsForCluster `json:"workloads"`
+		Status    string                        `json:"status"`
+		Workloads []types.WorkloadsForNamespace `json:"workloads"`
 	}
 
 	aggregatorURL := httputils.MakeURLToEndpoint(
@@ -1546,7 +1546,7 @@ func (server *HTTPServer) getWorkloadsForOrganization(orgID types.OrgID) ([]type
 	}
 
 	if resp.StatusCode == http.StatusNotFound {
-		return []types.WorkloadsForCluster{}, nil
+		return []types.WorkloadsForNamespace{}, nil
 	}
 
 	// check the aggregator response

--- a/server/server.go
+++ b/server/server.go
@@ -1493,7 +1493,7 @@ func (server *HTTPServer) getWorkloadsForCluster(
 
 	aggregatorURL := httputils.MakeURLToEndpoint(
 		server.ServicesConfig.AggregatorBaseEndpoint,
-		"organization/{organization}/namespace/{namespace}/cluster/{cluster}/workloads", // TODO: use real ira_server endpoint
+		ira_server.DVOWorkloadRecommendationsSingleNamespace,
 		orgID, namespace.UUID, clusterID,
 	)
 
@@ -1535,7 +1535,7 @@ func (server *HTTPServer) getWorkloadsForOrganization(orgID types.OrgID) ([]type
 
 	aggregatorURL := httputils.MakeURLToEndpoint(
 		server.ServicesConfig.AggregatorBaseEndpoint,
-		"organization/{organization}/workloads", // TODO: use real ira_server endpoint
+		ira_server.DVOWorkloadRecommendations,
 		orgID,
 	)
 

--- a/types/dvo_types.go
+++ b/types/dvo_types.go
@@ -59,12 +59,23 @@ type WorkloadsForCluster struct {
 	Recommendations []DVORecommendation `json:"recommendations"`
 }
 
+// WorkloadsForNamespace structure represents a single entry of the namespace list with some aggregations
+type WorkloadsForNamespace struct {
+	Cluster                 Cluster        `json:"cluster"`
+	Namespace               Namespace      `json:"namespace"`
+	Metadata                Metadata       `json:"metadata"`
+	RecommendationsHitCount map[string]int `json:"recommendations_hit_count"`
+}
+
 // DVORecommendation structure represents one DVO-related recommendation
 type DVORecommendation struct {
-	Check       string      `json:"check"`
-	Description string      `json:"description"`
-	Remediation string      `json:"remediation"`
-	Objects     []DVOObject `json:"objects"`
+	Check        string                 `json:"check"`
+	Details      string                 `json:"details"`
+	Resolution   string                 `json:"resolution"`
+	Modified     string                 `json:"modified"`
+	MoreInfo     string                 `json:"more_info"`
+	TemplateData map[string]interface{} `json:"extra_data"`
+	Objects      []DVOObject            `json:"objects"`
 }
 
 // DVOObject structure


### PR DESCRIPTION
# Description
- this PR fixes the two DVO related API endpoints to match the mock service structure.
- tested locally with new aggregator changes, requires more testing on ephemeral/stage
- there's some UT coverage of the endpoints already

TODO:
- fix links to real aggregator API
- update OpenAPI spec
- move types to shared repo

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update
- Unit tests (no changes in the code)
- REST API tests

## Testing steps
locally with https://github.com/RedHatInsights/insights-results-aggregator/pull/1969 

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
