### PR TITLE
allow any (<256 chars) namespace_id as URL param

### DIFF
--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -3488,7 +3488,9 @@ func TestHTTPServer_DVONamespaceForCluster1_BadClusterID(t *testing.T) {
 	}, testTimeout)
 }
 
-func TestHTTPServer_DVONamespaceForCluster1_BadNamespaceID(t *testing.T) {
+// TestHTTPServer_DVONamespaceForCluster1_NonUUIDNamespaceID non-UUID namespace_ids are produced by test rules/molodec,
+// we need to allow anything
+func TestHTTPServer_DVONamespaceForCluster1_NonUUIDNamespaceID(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
@@ -3501,6 +3503,19 @@ func TestHTTPServer_DVONamespaceForCluster1_BadNamespaceID(t *testing.T) {
 			data.ClusterInfoResult,
 		)
 
+		helpers.GockExpectAPIRequest(
+			t,
+			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
+			&helpers.APIRequest{
+				Method:       http.MethodGet,
+				Endpoint:     ira_server.DVOWorkloadRecommendationsSingleNamespace,
+				EndpointArgs: []interface{}{testdata.OrgID, "namespace ID", testdata.ClusterName},
+			},
+			&helpers.APIResponse{
+				StatusCode: http.StatusNotFound,
+			},
+		)
+
 		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
@@ -3510,10 +3525,10 @@ func TestHTTPServer_DVONamespaceForCluster1_BadNamespaceID(t *testing.T) {
 			&helpers.APIRequest{
 				Method:       http.MethodGet,
 				Endpoint:     server.DVONamespaceForClusterEndpoint,
-				EndpointArgs: []interface{}{"bad namespace ID", testdata.ClusterName},
+				EndpointArgs: []interface{}{"namespace ID", testdata.ClusterName},
 				XRHIdentity:  goodXRHAuthToken,
 			}, &helpers.APIResponse{
-				StatusCode: http.StatusBadRequest,
+				StatusCode: http.StatusNotFound,
 			},
 		)
 	}, testTimeout)

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -282,7 +282,22 @@ func readNamespace(writer http.ResponseWriter, request *http.Request) (
 	return
 }
 
+// rule tests used by molodec use non-UUID namespace IDs, we must allow any garbage
+// until that's resolved
 func validateNamespaceID(namespace string) (string, error) {
+	IDValidator := regexp.MustCompile(`^.{1,256}$`)
+
+	if !IDValidator.MatchString(namespace) {
+		message := fmt.Sprintf("invalid namespace ID: '%s'", namespace)
+		err := errors.New(message)
+		log.Error().Err(err).Msg(message)
+		return "", err
+	}
+
+	return namespace, nil
+}
+
+func validateNamespaceUUID(namespace string) (string, error) {
 	if _, err := uuid.Parse(namespace); err != nil {
 		message := fmt.Sprintf("invalid namespace ID: '%s'. Error: %s", namespace, err.Error())
 

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -25,7 +25,6 @@ import (
 
 	httputils "github.com/RedHatInsights/insights-operator-utils/http"
 	ctypes "github.com/RedHatInsights/insights-results-types"
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 
 	"github.com/RedHatInsights/insights-results-smart-proxy/types"
@@ -292,22 +291,6 @@ func validateNamespaceID(namespace string) (string, error) {
 		err := errors.New(message)
 		log.Error().Err(err).Msg(message)
 		return "", err
-	}
-
-	return namespace, nil
-}
-
-func validateNamespaceUUID(namespace string) (string, error) {
-	if _, err := uuid.Parse(namespace); err != nil {
-		message := fmt.Sprintf("invalid namespace ID: '%s'. Error: %s", namespace, err.Error())
-
-		log.Error().Err(err).Msg(message)
-
-		return "", &RouterParsingError{
-			ParamName:  NamespaceIDParam,
-			ParamValue: namespace,
-			ErrString:  err.Error(),
-		}
 	}
 
 	return namespace, nil


### PR DESCRIPTION
# Description
we have `namespace_id`s in the DB in improper UUID format due to test rules/archives (it can be basically anything).

relaxing the URL param validation until we resolve the test data problem.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)

## Testing steps
locally

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
