### PR TITLE
DVO latest API fixes + OpenAPI 

### DIFF
--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -760,44 +760,7 @@
                       }
                     },
                     "metadata": {
-                      "type": "object",
-                      "properties": {
-                        "recommendations": {
-                          "type": "integer",
-                          "description": "Total number of DVO recommendations affecting this namespace and cluster"
-                        },
-                        "objects": {
-                          "type": "integer",
-                          "description": "Total number of objects affecting this namespace and cluster"
-                        },
-                        "reported_at": {
-                          "format": "date-time",
-                          "type": "string",
-                          "description": "Timestamp of the first analysis"
-                        },
-                        "last_checked_at": {
-                          "format": "date-time",
-                          "type": "string",
-                          "description": "Timestamp of the last analysis"
-                        },
-                        "highest_severity": {
-                          "type": "integer",
-                          "description": "Highest recommendation severity affecting this namespace + cluster"
-                        },
-                        "hits_by_severity": {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "integer"
-                          },
-                          "description": "A dictionary with the number of DVO recommendation hits grouped by their severity. Always provides the severity keys even if there are no recommendations currently hitting.",
-                          "example": {
-                            "1": 2,
-                            "2": 3,
-                            "3": 0,
-                            "4": 1
-                          }
-                        }
-                      }
+                        "$ref": "#/components/schemas/dvoReportMeta"
                     },
                     "recommendations": {
                       "type": "array",
@@ -816,6 +779,30 @@
                           "remediation": {
                             "type": "string",
                             "description": "Resolution steps of the issue, possibly linking to a resolution article in the knowledge base."
+                          },
+                          "modified": {
+                            "description": "The date the recommendation was last updated.",
+                            "format": "date-time",
+                            "type": "string"
+                          },
+                          "reason": {
+                            "type": "string",
+                            "description": "Reason for the issue, giving the user more accurate description of the cause."
+                          },
+                          "total_risk": {
+                            "description": "Total risk - calculated from rule impact and likelihood.",
+                            "enum": [
+                              0,
+                              1,
+                              2,
+                              3,
+                              4
+                            ],
+                            "type": "integer"
+                          },
+                          "extra_data": {
+                            "description": "Used as templating/interpolation data for other content (details, resolution, etc.), has varying structure depending on the rules in the report, but should always be a valid JSON object.",
+                            "type": "object"
                           },
                           "objects": {
                             "type": "array",
@@ -912,44 +899,7 @@
                             }
                           },
                           "metadata": {
-                            "type": "object",
-                            "properties": {
-                              "recommendations": {
-                                "type": "integer",
-                                "description": "Total number of DVO recommendations affecting an organization affecting this namespace"
-                              },
-                              "objects": {
-                                "type": "integer",
-                                "description": "Total number of objects affecting this namespace"
-                              },
-                              "reported_at": {
-                                "format": "date-time",
-                                "type": "string",
-                                "description": "Timestamp of the first analysis"
-                              },
-                              "last_checked_at": {
-                                "format": "date-time",
-                                "type": "string",
-                                "description": "Timestamp of the last analysis"
-                              },
-                              "highest_severity": {
-                                "type": "integer",
-                                "description": "Highest recommendation severity affecting this namespace"
-                              },
-                              "hits_by_severity": {
-                                "type": "object",
-                                "additionalProperties": {
-                                  "type": "integer"
-                                },
-                                "description": "A dictionary with the number of DVO recommendation hits grouped by their severity. Always provides the severity keys even if there are no recommendations currently hitting.",
-                                "example": {
-                                  "1": 2,
-                                  "2": 3,
-                                  "3": 0,
-                                  "4": 1
-                                }
-                              }
-                            }
+                            "$ref": "#/components/schemas/dvoReportMeta"
                           }
                         }
                       }
@@ -1944,6 +1894,46 @@
           "managed": false,
           "count": 9,
           "last_checked_at": "2020-12-08T09:45:23Z"
+        }
+      },
+      "dvoReportMeta": {
+        "type": "object",
+        "properties": {
+          "recommendations": {
+            "type": "integer",
+            "description": "Total number of DVO recommendations affecting this namespace"
+          },
+          "objects": {
+            "type": "integer",
+            "description": "Total number of unique objects (workloads) being affected by DVO recommendations in this namespace. When a workload is being affected by several recommendations at once, it still counts as one affected object/workload in the context of a namespace."
+          },
+          "reported_at": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Timestamp of the first analysis"
+          },
+          "last_checked_at": {
+            "format": "date-time",
+            "type": "string",
+            "description": "Timestamp of the last analysis"
+          },
+          "highest_severity": {
+            "type": "integer",
+            "description": "Highest recommendation severity affecting this namespace + cluster"
+          },
+          "hits_by_severity": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "description": "A dictionary with the number of DVO recommendation hits grouped by their severity. Always provides the severity keys even if there are no recommendations currently hitting.",
+            "example": {
+              "1": 2,
+              "2": 3,
+              "3": 0,
+              "4": 1
+            }
+          }
         }
       },
       "reportResponse": {

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -1751,17 +1751,11 @@ func fillInWorkloadsData(
 			}
 		}
 
-		ruleContent, err := content.GetContentForRecommendation(ctypes.RuleID(recommendation.Check))
+		err = fillDVORecommendationRuleContent(&recommendation)
 		if err != nil {
-			log.Error().Err(err).Msgf(ruleContentError, recommendation.Check)
 			return workloads, err
 		}
 
-		// fill rest of data from content service
-		recommendation.Details = ruleContent.Description
-		recommendation.Resolution = ruleContent.Resolution
-		recommendation.MoreInfo = ruleContent.MoreInfo
-		recommendation.Modified = ruleContent.PublishDate.UTC().Format(time.RFC3339)
 		recommendations = append(recommendations, recommendation)
 	}
 
@@ -1773,4 +1767,22 @@ func fillInWorkloadsData(
 	}
 
 	return
+}
+
+func fillDVORecommendationRuleContent(recommendation *types.DVORecommendation) error {
+	ruleContent, err := content.GetContentForRecommendation(ctypes.RuleID(recommendation.Check))
+	if err != nil {
+		log.Error().Err(err).Msgf(ruleContentError, recommendation.Check)
+		return err
+	}
+
+	// fill DVORecommendation with data from content service
+	recommendation.Details = ruleContent.Description
+	recommendation.Resolution = ruleContent.Resolution
+	recommendation.MoreInfo = ruleContent.MoreInfo
+	recommendation.Reason = ruleContent.Reason
+	recommendation.TotalRisk = ruleContent.TotalRisk
+	recommendation.Modified = ruleContent.PublishDate.UTC().Format(time.RFC3339)
+
+	return nil
 }

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -1742,7 +1742,8 @@ func fillInWorkloadsData(
 	recommendations := []types.DVORecommendation{}
 
 	// fill in severities and other data from rule content
-	for _, recommendation := range workloadsForCluster.Recommendations {
+	for i := range workloadsForCluster.Recommendations {
+		recommendation := &workloadsForCluster.Recommendations[i]
 		if severity, found := recommendationSeverities[ctypes.RuleID(recommendation.Check)]; found {
 			workloadsForCluster.Metadata.HitsBySeverity[severity] += len(recommendation.Objects)
 
@@ -1751,12 +1752,12 @@ func fillInWorkloadsData(
 			}
 		}
 
-		err = fillDVORecommendationRuleContent(&recommendation)
+		err = fillDVORecommendationRuleContent(recommendation)
 		if err != nil {
 			return workloads, err
 		}
 
-		recommendations = append(recommendations, recommendation)
+		recommendations = append(recommendations, *recommendation)
 	}
 
 	workloads = types.WorkloadsForCluster{

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -3397,6 +3397,8 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterFoundWithWorkloads(t *testing
 		expectedResponse.Recommendations[0].Details = testdata.RuleErrorKey1.Description
 		expectedResponse.Recommendations[0].Resolution = testdata.RuleErrorKey1.Resolution
 		expectedResponse.Recommendations[0].MoreInfo = testdata.RuleErrorKey1.MoreInfo
+		expectedResponse.Recommendations[0].Reason = testdata.RuleErrorKey1.Reason
+		expectedResponse.Recommendations[0].TotalRisk = testdata.RuleWithContent1.TotalRisk
 		expectedResponse.Recommendations[0].Modified = testdata.RuleErrorKey1.PublishDate.UTC().Format(time.RFC3339)
 		expectedResponse.Recommendations[0].TemplateData = aggrResp.Workloads.Recommendations[0].TemplateData
 		expectedResponse.Recommendations[0].Objects = aggrResp.Workloads.Recommendations[0].Objects
@@ -3404,6 +3406,8 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterFoundWithWorkloads(t *testing
 		expectedResponse.Recommendations[1].Details = testdata.RuleErrorKey2.Description
 		expectedResponse.Recommendations[1].Resolution = testdata.RuleErrorKey2.Resolution
 		expectedResponse.Recommendations[1].MoreInfo = testdata.RuleErrorKey2.MoreInfo
+		expectedResponse.Recommendations[1].Reason = testdata.RuleErrorKey2.Reason
+		expectedResponse.Recommendations[1].TotalRisk = testdata.RuleWithContent2.TotalRisk
 		expectedResponse.Recommendations[1].Modified = testdata.RuleErrorKey2.PublishDate.UTC().Format(time.RFC3339)
 		expectedResponse.Recommendations[1].TemplateData = aggrResp.Workloads.Recommendations[1].TemplateData
 		expectedResponse.Recommendations[1].Objects = aggrResp.Workloads.Recommendations[1].Objects

--- a/types/dvo_types.go
+++ b/types/dvo_types.go
@@ -74,6 +74,8 @@ type DVORecommendation struct {
 	Resolution   string                 `json:"resolution"`
 	Modified     string                 `json:"modified"`
 	MoreInfo     string                 `json:"more_info"`
+	Reason       string                 `json:"reason"`
+	TotalRisk    int                    `json:"total_risk"`
 	TemplateData map[string]interface{} `json:"extra_data"`
 	Objects      []DVOObject            `json:"objects"`
 }


### PR DESCRIPTION
# Description
- add `reason` and `total_risk` to `"namespaces/dvo/{namespace}/cluster/{cluster}"` endpoint
- update DVO endpoints in the OpenAPI spec (missing fields, better wording,..)
- increase UT coverage of both DVO endpoints functionality. Everything is now covered except for usual cases we're not covering anywhere like `err = responses.SendOK()` etc.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)
- REST API tests
- Documentation update

## Testing steps
locally w/ content-service

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
