### PR TITLE
reduce log pollution (zerolog issues)

### DIFF
--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -250,7 +250,7 @@ func getInternalRulesOrganizations() []types.OrgID {
 		log.Fatal().Err(err).Msg("Internal organizations CSV could not be processed")
 	}
 
-	log.Info().Msgf("Internal rules request filtering enabled. Organizations allowed: %v", internalOrganizations)
+	log.Debug().Msgf("Internal rules request filtering enabled. Organizations allowed: %v", internalOrganizations)
 	return internalOrganizations
 }
 

--- a/server/acks_handlers.go
+++ b/server/acks_handlers.go
@@ -137,7 +137,7 @@ func (server *HTTPServer) getAcknowledge(writer http.ResponseWriter, request *ht
 	// rule was not acked -> nothing to return
 	if !found {
 		writer.WriteHeader(http.StatusNotFound)
-		log.Info().Msg("Rule has not been disabled previously -> nothing to return!")
+		log.Debug().Msg("Rule has not been disabled previously -> nothing to return!")
 		return
 	}
 
@@ -312,7 +312,7 @@ func (server *HTTPServer) updateAcknowledge(writer http.ResponseWriter, request 
 
 	// if acknowledgement has NOT been found -> return 404 NotFound
 	if !found {
-		log.Info().Msg("Rule ack can not be found")
+		log.Debug().Msg("Rule ack can not be found")
 		err := &utypes.ItemNotFoundError{ItemID: (ruleID + "|" + types.RuleID(errorKey))}
 		handleServerError(writer, err)
 		return
@@ -374,7 +374,7 @@ func (server *HTTPServer) deleteAcknowledge(writer http.ResponseWriter, request 
 
 	if !found {
 		writer.WriteHeader(http.StatusNotFound)
-		log.Info().Msg("Rule has not been disabled previously -> ACK won't be deleted")
+		log.Debug().Msg("Rule has not been disabled previously -> ACK won't be deleted")
 		return
 	}
 

--- a/server/rating.go
+++ b/server/rating.go
@@ -40,7 +40,7 @@ func (server *HTTPServer) postRating(writer http.ResponseWriter, request *http.R
 		return
 	}
 
-	log.Info().Int32("org_id", int32(orgID)).Msg("Extracted user and org")
+	log.Debug().Int32("org_id", int32(orgID)).Msg("Extracted user and org")
 
 	rating, successful := server.postRatingToAggregator(orgID, request, writer)
 	if !successful {
@@ -139,7 +139,7 @@ func (server HTTPServer) getRatingForRecommendation(
 	}
 
 	if aggregatorResp.StatusCode == http.StatusNotFound {
-		log.Info().Msgf("rule rating for rule %v not found", ruleID)
+		log.Debug().Msgf("rule rating for rule %v not found", ruleID)
 		return ruleRating, &utypes.ItemNotFoundError{}
 	}
 

--- a/services/services.go
+++ b/services/services.go
@@ -81,7 +81,7 @@ func GetGroups(conf Configuration) ([]groups.Group, error) {
 		return nil, err
 	}
 
-	log.Info().Msgf("Received %d groups", len(receivedMsg.Groups))
+	log.Debug().Msgf("Received %d groups", len(receivedMsg.Groups))
 	return receivedMsg.Groups, nil
 }
 
@@ -108,7 +108,7 @@ func GetContent(conf Configuration) (*types.RuleContentDirectory, error) {
 		return nil, err
 	}
 
-	log.Info().Msgf("Got %d rules from content-service", len(receivedContent.Rules))
+	log.Debug().Msgf("Got %d rules from content-service", len(receivedContent.Rules))
 
 	return &receivedContent, nil
 }


### PR DESCRIPTION
# Description
Reducing a lot of log pollution.

once again, we're seeing these errors in production:
```
zerolog: could not write event: InvalidParameterException: Log events in a single PutLogEvents request must be in chronological order.
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Refactor (refactoring code, removing useless files)

## Testing steps
n/a

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
