### PR TITLE
Fix wrong format in 404 response

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -1502,7 +1502,7 @@ func (server *HTTPServer) getWorkloadsForCluster(
 
 	if resp.StatusCode == http.StatusNotFound {
 		return workloads, &utypes.ItemNotFoundError{
-			ItemID: fmt.Sprintf("cluster=%s;namespace=%s", clusterID, namespace)}
+			ItemID: fmt.Sprintf("cluster=%s;namespace=%s", clusterID, namespace.UUID)}
 	}
 
 	// check the aggregator response


### PR DESCRIPTION
# Description

In https://github.com/RedHatInsights/insights-results-smart-proxy/pull/1251 I was printing the whole struct, not the UUID.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
