### PR TITLE
sync clowdapp name with app-interface

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -16,7 +16,7 @@
 apiVersion: v1
 kind: Template
 metadata:
-  name: ccx-smart-proxy
+  name: insights-results-smart-proxy
 
 objects:
 - kind: HorizontalPodAutoscaler
@@ -24,20 +24,20 @@ objects:
   metadata:
     labels:
       app: ccx-data-pipeline
-    name: ccx-smart-proxy-service
+    name: insights-results-smart-proxy-service
   spec:
     minReplicas: ${{MIN_REPLICAS}}
     maxReplicas: ${{MAX_REPLICAS}}
     scaleTargetRef:
       apiVersion: apps/v1
       kind: Deployment
-      name: ccx-smart-proxy-service
+      name: insights-results-smart-proxy-service
     targetCPUUtilizationPercentage: 80
 
 - apiVersion: cloud.redhat.com/v1alpha1
   kind: ClowdApp
   metadata:
-    name: ccx-smart-proxy
+    name: insights-results-smart-proxy
   spec:
     envName: ${ENV_NAME}
     testing:
@@ -203,9 +203,9 @@ objects:
       prometheus.io/port: "8080"
       prometheus.io/scheme: http
       prometheus.io/scrape: "true"
-    name: ccx-smart-proxy
+    name: insights-results-smart-proxy
     labels:
-      app: ccx-smart-proxy
+      app: insights-results-smart-proxy
   spec:
     ports:
     - name: web
@@ -213,7 +213,7 @@ objects:
       protocol: TCP
       targetPort: 8000
     selector:
-      app: ccx-smart-proxy
+      app: insights-results-smart-proxy
     sessionAffinity: None
     type: ClusterIP
     


### PR DESCRIPTION
# Description

Attempt to sync component name from app-interface and deploy/clowdapp.yaml file. app-interface uses `insights-results-smart-proxy` - try to use this too. Changing clowdapp.yaml seems cause less issues since it is used mostly for pod names not in clowder config files.

## Type of change

- Configuration update