### PR TITLE
[CCXDEV-12791] Rename insights-results-smart-proxy to ccx-smart-proxy

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -21,10 +21,10 @@ set -exv
 # --------------------------------------------
 APP_NAME="ccx-data-pipeline"  # name of app-sre "application" folder this component lives in
 REF_ENV="insights-production"
-COMPONENT_NAME="insights-results-smart-proxy"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
+COMPONENT_NAME="ccx-smart-proxy"  # name of app-sre "resourceTemplate" in deploy.yaml for this component
 IMAGE="quay.io/cloudservices/ccx-smart-proxy"
-COMPONENTS="ccx-data-pipeline ccx-insights-results dvo-extractor dvo-writer insights-content-service insights-results-smart-proxy ocp-advisor-frontend ccx-mock-ams ccx-redis" # space-separated list of components to laod
-COMPONENTS_W_RESOURCES="insights-results-smart-proxy"  # component to keep
+COMPONENTS="ccx-data-pipeline ccx-insights-results dvo-extractor dvo-writer insights-content-service ccx-smart-proxy ocp-advisor-frontend ccx-mock-ams ccx-redis" # space-separated list of components to laod
+COMPONENTS_W_RESOURCES="ccx-smart-proxy"  # component to keep
 CACHE_FROM_LATEST_IMAGE="true"
 DEPLOY_FRONTENDS="true"   # enable for front-end/UI tests
 


### PR DESCRIPTION
# Description

This rename is needed in order to use the smart-proxy endpoint internally from other AppSRE namespaces. We used to have different app-sre component ID and clowdapp name which made it impossible.

## Type of change

- Configuration update

## Testing steps

CI.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
