### PR TITLE
fix missing rule content causing 500 in DVO namespace list endpoint

### DIFF
--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -1614,10 +1614,7 @@ func processWorkloadsRecommendations(
 					w.Metadata.HighestSeverity = severity
 				}
 			} else {
-				msg := "recommendation ID not found in content"
-				err := errors.New(msg)
-				log.Error().Err(err).Send()
-				return workloads, err
+				log.Info().Msgf("recommendation ID [%v] not found in content. Skipping.", recommendation)
 			}
 		}
 


### PR DESCRIPTION
# Description
- missing rule content is causing a 500, instead it should simply omit the problematic rule IDs from the calculation and return the rest of the data.

Fixes [CCXDEV-12893](https://issues.redhat.com/browse/CCXDEV-12893)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Unit tests (no changes in the code)

## Testing steps
locally

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
