### PR TITLE
send active cluster list in POST body to aggregator's `DVOWorkloadRecommendations` endpoint

### DIFF
--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -294,11 +294,6 @@ func (server HTTPServer) getRecommendations(writer http.ResponseWriter, request 
 
 	// retrieve user disabled rules for given list of active clusters
 	disabledClustersForRules := server.getRuleDisabledClusters(writer, orgID, clusterIDList)
-	if err != nil {
-		log.Error().Err(err).Msg("problem getting user disabled rules for list of clusters")
-		// server error has been handled already
-		return
-	}
 
 	recommendationList, err = getFilteredRecommendationsList(
 		activeClustersInfo, impactingRecommendations, impactingFlag, ackedRulesMap, disabledClustersForRules,

--- a/server/handlers_v2.go
+++ b/server/handlers_v2.go
@@ -1552,7 +1552,7 @@ func (server *HTTPServer) getDVONamespaceList(writer http.ResponseWriter, reques
 	log.Info().Int(orgIDTag, int(orgID)).Msgf("getDVONamespaceList took %v to get %d clusters from AMS API", time.Since(tStart), len(activeClustersInfo))
 
 	// get workloads for clusters
-	workloads, err := server.getWorkloadsForOrganization(orgID)
+	workloads, err := server.getWorkloadsForOrganization(orgID, writer, activeClustersInfo)
 	if err != nil {
 		handleServerError(writer, err)
 		return

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -2764,13 +2764,15 @@ func TestHTTPServer_DVONamespaceListEndpoint_NoWorkloads(t *testing.T) {
 			data.ClusterInfoResult,
 		)
 
+		reqBody, _ := json.Marshal(data.ClusterList1Cluster)
 		helpers.GockExpectAPIRequest(
 			t,
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method:       http.MethodGet,
+				Method:       http.MethodPost,
 				Endpoint:     ira_server.DVOWorkloadRecommendations,
 				EndpointArgs: []interface{}{testdata.OrgID},
+				Body:         reqBody,
 			},
 			&helpers.APIResponse{
 				StatusCode: http.StatusNotFound,
@@ -2839,13 +2841,15 @@ func TestHTTPServer_DVONamespaceListEndpoint_OK(t *testing.T) {
 			},
 		}
 
+		reqBody, _ := json.Marshal(data.ClusterList2Clusters)
 		helpers.GockExpectAPIRequest(
 			t,
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method:       http.MethodGet,
+				Method:       http.MethodPost,
 				Endpoint:     ira_server.DVOWorkloadRecommendations,
 				EndpointArgs: []interface{}{testdata.OrgID},
+				Body:         reqBody,
 			},
 			&helpers.APIResponse{
 				StatusCode: http.StatusOK,
@@ -2956,13 +2960,15 @@ func TestHTTPServer_DVONamespaceListEndpoint_AggregatorError(t *testing.T) {
 			data.ClusterInfoResult,
 		)
 
+		reqBody, _ := json.Marshal(data.ClusterList1Cluster)
 		helpers.GockExpectAPIRequest(
 			t,
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method:       http.MethodGet,
+				Method:       http.MethodPost,
 				Endpoint:     ira_server.DVOWorkloadRecommendations,
 				EndpointArgs: []interface{}{testdata.OrgID},
+				Body:         reqBody,
 			},
 			&helpers.APIResponse{
 				StatusCode: http.StatusInternalServerError,
@@ -3028,13 +3034,15 @@ func TestHTTPServer_DVONamespaceListEndpoint_RecommendationDoesNotExist(t *testi
 			},
 		}
 
+		reqBody, _ := json.Marshal(data.ClusterList2Clusters)
 		helpers.GockExpectAPIRequest(
 			t,
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method:       http.MethodGet,
+				Method:       http.MethodPost,
 				Endpoint:     ira_server.DVOWorkloadRecommendations,
 				EndpointArgs: []interface{}{testdata.OrgID},
+				Body:         reqBody,
 			},
 			&helpers.APIResponse{
 				StatusCode: http.StatusOK,
@@ -3139,13 +3147,15 @@ func TestHTTPServer_DVONamespaceListEndpoint_FilterOutInactiveClusters(t *testin
 			},
 		}
 
+		reqBody, _ := json.Marshal(data.ClusterList2Clusters)
 		helpers.GockExpectAPIRequest(
 			t,
 			helpers.DefaultServicesConfig.AggregatorBaseEndpoint,
 			&helpers.APIRequest{
-				Method:       http.MethodGet,
+				Method:       http.MethodPost,
 				Endpoint:     ira_server.DVOWorkloadRecommendations,
 				EndpointArgs: []interface{}{testdata.OrgID},
+				Body:         reqBody,
 			},
 			&helpers.APIResponse{
 				StatusCode: http.StatusOK,

--- a/server/server.go
+++ b/server/server.go
@@ -1551,6 +1551,7 @@ func (server *HTTPServer) getWorkloadsForOrganization(
 		return nil, err
 	}
 
+	// #nosec G107
 	resp, err := http.Post(aggregatorURL, JSONContentType, bytes.NewBuffer(body))
 	if err != nil {
 		if _, ok := err.(*url.Error); ok {

--- a/tests/testdata/testdata.go
+++ b/tests/testdata/testdata.go
@@ -92,6 +92,8 @@ var (
 		},
 	}
 
+	ClusterList1Cluster = []types.ClusterName{testdata.ClusterName}
+
 	ClusterInfoResult2Clusters = []types.ClusterInfo{
 		{
 			ID:          testdata.GetRandomClusterID(),
@@ -102,6 +104,8 @@ var (
 			DisplayName: ClusterDisplayName2,
 		},
 	}
+
+	ClusterList2Clusters = []types.ClusterName{ClusterInfoResult2Clusters[0].ID, ClusterInfoResult2Clusters[1].ID}
 )
 
 // GetRandomClusterInfo function returns a ClusterInfo with random ID


### PR DESCRIPTION
# Description
In order to improve the performance of aggregator's `DVOWorkloadRecommendations` endpoint (we have a lot of data for clusters that aren't active in OCM, and in the case of the largest organizations, aggregator was sending >20-30MB of data to smart-proxy), a filtering mechanism based on `cluster_id` was implemented here https://github.com/RedHatInsights/insights-results-aggregator/pull/2031.

Aggregator's endpoint now accepts POST requests containing a list of cluster_ids in the request body, this PR accommodates those changes. The behavior of smart-proxy is unchanged.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Refactor (refactoring code, removing useless files)
- Unit tests (no changes in the code)

## Testing steps

Please describe how the change was tested locally. If, for some reason, the testing was not done or not done fully, please describe what are the testing steps.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
