### PR TITLE
[CCXDEV-13097] Exit if redis cannot be initialized/pinged

### DIFF
--- a/smart_proxy.go
+++ b/smart_proxy.go
@@ -131,16 +131,14 @@ func startServer() ExitCode {
 
 	redisClient, err := services.NewRedisClient(redisConf)
 	if err != nil {
-		redisClient = nil
-	} else {
-		// PING Redis server
-		if err = redisClient.HealthCheck(); err != nil {
-			log.Error().Err(err).Msg("failed to ping Redis server")
-			redisClient = nil
-		} else {
-			log.Info().Msg("Redis client created, Redis server is responding")
-		}
+		log.Error().Err(err).Msg("failed to initialize Redis server")
+		return ExitStatusServerError
 	}
+	if err = redisClient.HealthCheck(); err != nil {
+		log.Error().Err(err).Msg("failed to ping Redis server")
+		return ExitStatusServerError
+	}
+	log.Info().Msg("Redis client created, Redis server is responding")
 
 	serverInstance = server.New(serverCfg, servicesCfg, amsClient, redisClient, groupsChannel, errorFoundChannel, errorChannel)
 


### PR DESCRIPTION
# Description

On ephemeral, the Redis client wasn't initialized because smart-proxy was faster than Redis to start up and it was configured to not init the Redis client at all if it failed the first time. With this change it should enter a CrashLoopBackOff state until it can connect.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

CI + manually on ephemeral. If redis is not started (`oc scale statefulset --replicas 0 ccx-redis`) it starts looping with this error:
```
❯ oc logs ccx-smart-proxy-service-6668f59494-pvxs2
Defaulted container "ccx-smart-proxy-service" out of: ccx-smart-proxy-service, crcauth
Clowder is enabled
{"level":"info","Enabled":false,"time":"2024-08-29T07:27:55Z","message":"Caching for cluster list"}
{"level":"info","time":"2024-08-29T07:27:55Z","message":"Creating amsclient..."}
{"level":"info","time":"2024-08-29T07:27:55Z","message":"AMSClient successfully created"}
{"level":"info","time":"2024-08-29T07:27:55Z","message":"creating redis client. endpoint ccx-redis:6379, selected DB 0, timeout seconds 30"}
{"level":"error","error":"dial tcp 172.30.70.165:6379: connect: connection refused","time":"2024-08-29T07:27:55Z","message":"Redis PING command failed"}
{"level":"error","error":"unexpected response from Redis server","time":"2024-08-29T07:27:55Z","message":"failed to ping Redis server"} 
❯ 
```
Until Redis is up again (`oc scale statefulset --replicas 1 ccx-redis`)
```
{"level":"info","time":"2024-08-29T07:30:30Z","message":"Redis client created, Redis server is responding"} 
```


## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
