### PR TITLE
[CCXDEV-12792] Add /groups to v2 API

### DIFF
--- a/server/api/v1/openapi.json
+++ b/server/api/v1/openapi.json
@@ -163,7 +163,7 @@
         },
         "operationId": "getRuleGroups",
         "summary": "Get all rule groups and their relevant information",
-        "description": "This simply redirects to an endpoint of the same name of a service called insights-operator-service"
+        "description": "This simply redirects to an endpoint of the same name of a service called insights-content-service"
       }
     },
     "/organizations/{orgId}/clusters": {

--- a/server/api/v2/openapi.json
+++ b/server/api/v2/openapi.json
@@ -114,6 +114,60 @@
         }
       }
     },
+    "/groups": {
+      "get": {
+        "tags": [
+          "prod"
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "groups": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "title": {
+                            "type": "string"
+                          },
+                          "description": {
+                            "type": "string"
+                          },
+                          "tags": {
+                            "type": "array",
+                            "items": {
+                              "type": "string"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    }
+                  }
+                }
+              }
+            },
+            "description": "A JSON array of groups."
+          },
+          "503": {
+            "content": {
+              "text/plain": {}
+            },
+            "description": "Content service is unavailable"
+          }
+        },
+        "operationId": "getRuleGroups",
+        "summary": "Get all rule groups and their relevant information",
+        "description": "This simply redirects to an endpoint of the same name of a service called insights-content-service"
+      }
+    },
     "/cluster/{clusterId}/reports": {
       "get": {
         "tags": [

--- a/server/endpoints_v2.go
+++ b/server/endpoints_v2.go
@@ -134,6 +134,7 @@ func (server *HTTPServer) addV2EndpointsToRouter(router *mux.Router) {
 
 	// Common REST API endpoints
 	router.HandleFunc(apiV2Prefix+MainEndpoint, server.mainEndpoint).Methods(http.MethodGet)
+	router.HandleFunc(apiV2Prefix+RuleGroupsEndpoint, server.getGroups).Methods(http.MethodGet, http.MethodOptions)
 
 	// Reports endpoints
 	server.addV2ReportsEndpointsToRouter(router, apiV2Prefix)


### PR DESCRIPTION
# Description

Just adding the same `/groups` endpoint we had for v1 but on v2. Requested by an external team.

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

CI

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
