### PR TITLE
[CCXDEV-14488] Fix pr_check: use old image for pull requests

### DIFF
--- a/pr_check.sh
+++ b/pr_check.sh
@@ -27,6 +27,9 @@ COMPONENTS="ccx-data-pipeline ccx-insights-results dvo-extractor dvo-writer insi
 COMPONENTS_W_RESOURCES="ccx-smart-proxy"  # component to keep
 CACHE_FROM_LATEST_IMAGE="true"
 DEPLOY_FRONTENDS="true"   # enable for front-end/UI tests
+# Set the correct images for pull requests.
+# pr_check in pull requests still uses the old cloudservices images
+EXTRA_DEPLOY_ARGS="--set-parameter ccx-smart-proxy/IMAGE=quay.io/cloudservices/ccx-smart-proxy"
 
 export IQE_PLUGINS="ccx"
 # Run all pipeline and ui tests


### PR DESCRIPTION
# Description
[CCXDEV-14488] Fix pr_check: use old image for pull requests

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- Configuration update