### PR TITLE
[CCXDEV-14499] GH actions: add GoLang 1.21 validation - lint/tests

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         go-version:
           - "1.20"
+          - "1.21"
     name: Tests for Go ${{ matrix.go-version}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,6 +26,7 @@ jobs:
       matrix:
         go-version:
           - "1.20"
+          - "1.21"
     name: Linters for Go ${{ matrix.go-version}}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
# Description
[CCXDEV-14499] GH actions: add GoLang 1.21 validation - lint/tests. Konflux wants to migrate to golang 1.21 base image.
https://github.com/RedHatInsights/insights-results-smart-proxy/pull/1321

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Configuration update
