### PR TITLE
Reduce scan batch count to 100 to improve SCAN perfomance

### DIFF
--- a/services/redis.go
+++ b/services/redis.go
@@ -40,7 +40,7 @@ const (
 	// RuleHitsFieldName represent the name of hte field in Redis hash containing simplified rule hits
 	RuleHitsFieldName = "rule_hits"
 	// ScanBatchCount is the number of records to go through in a single SCAN operation
-	ScanBatchCount = 1000
+	ScanBatchCount = 100
 
 	redisCmdExecutionFailedMsg = "failed to execute command against Redis server"
 )


### PR DESCRIPTION
# Description

Attempt to improve the SCAN operation performance, [after some testing](https://gist.github.com/epapbak/da15fe0feb9aef615f9c44e32f2d6064#file-results-md) was done that seems to indicate that a smaller batch size will have a great impact on the performance.

Part of CCXDEV-13117

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Configuration update

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
