### PR TITLE
Update io-utils version to handle out-of-range errors properly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 require (
 	github.com/BurntSushi/toml v1.4.0
 	github.com/RedHatInsights/insights-content-service v1.0.0
-	github.com/RedHatInsights/insights-operator-utils v1.25.11
+	github.com/RedHatInsights/insights-operator-utils v1.25.12
 	github.com/RedHatInsights/insights-results-aggregator v1.4.1
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.9
 	github.com/RedHatInsights/insights-results-types v1.23.4

--- a/go.sum
+++ b/go.sum
@@ -68,8 +68,8 @@ github.com/RedHatInsights/insights-operator-utils v1.21.0/go.mod h1:B2hizFGwXCc8
 github.com/RedHatInsights/insights-operator-utils v1.21.2/go.mod h1:3Pfsgsi7GCu2wgIqQlt1llpyQyyxsDWEGdgnPvadM40=
 github.com/RedHatInsights/insights-operator-utils v1.21.8/go.mod h1:qa1a8NdarIzcZkr5mu9fBw4OarOfg1qZFZC1vNGbyas=
 github.com/RedHatInsights/insights-operator-utils v1.24.5/go.mod h1:7qR/8rlMdiqoXAkZyQ5JhVrVNCa6SBwNUt4KMq/17j4=
-github.com/RedHatInsights/insights-operator-utils v1.25.11 h1:BcD9ISCkzDFnhor3d4So6nmjVjILQATS8GJhoRVqOak=
-github.com/RedHatInsights/insights-operator-utils v1.25.11/go.mod h1:zC4Wok6rNTMSQU8ey8ulPby2IB1wcujgFteB866vo1A=
+github.com/RedHatInsights/insights-operator-utils v1.25.12 h1:2hxQUdHCG7wLbHEikEtIi5R/dbiXvuAddD/HJtgVXDw=
+github.com/RedHatInsights/insights-operator-utils v1.25.12/go.mod h1:zC4Wok6rNTMSQU8ey8ulPby2IB1wcujgFteB866vo1A=
 github.com/RedHatInsights/insights-results-aggregator v0.0.0-20200604090056-3534f6dd9c1c/go.mod h1:7Pc15NYXErx7BMJ4rF1Hacm+29G6atzjhwBpXNFMt+0=
 github.com/RedHatInsights/insights-results-aggregator v1.4.1 h1:GBqHrT+LzkBAk4fYDWdvF04XdOdC3EXov9z9lEBFeN4=
 github.com/RedHatInsights/insights-results-aggregator v1.4.1/go.mod h1:hAVwcog5dsSFYIp8E+D4cD8uYKYISIziKpDvNxKD0TM=


### PR DESCRIPTION
# Description

New insights-operator-utils version

## Type of change

- Bump-up dependent library (no changes in the code)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
