### PR TITLE
Add types and config for RBAC support

### DIFF
--- a/auth/configuration.go
+++ b/auth/configuration.go
@@ -1,0 +1,70 @@
+/*
+Copyright © 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/rs/zerolog/log"
+)
+
+type RBACConfig struct {
+	Host        string `mapstructure:"host" toml:"host"`
+	Port        uint16 `mapstructure:"port" toml:"port,omitempty"`
+	Enabled     bool   `mapstructure:"enabled" toml:"enabled"`
+	EnforceAuth bool   `mapstructure:"enforce" toml:"enforce"`
+}
+
+// IsEnabled returns true if RBAC is enabled in the configuration
+func IsEnabled(config *RBACConfig) bool {
+	return config.Enabled
+}
+
+// constructRBACURL constructs the RBAC URL with the query parameters for
+// checking access to Advisor OCP resources
+func constructRBACURL(config *RBACConfig) (string, string, error) {
+	if !strings.HasPrefix(config.Host, "http://") && !strings.HasPrefix(config.Host, "https://") {
+		config.Host = "https://" + config.Host // Default to HTTPS if no scheme is provided
+	}
+
+	// Parse the URL to handle both the Host and the Endpoint correctly
+	baseURL, err := url.Parse(config.Host)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid host format: %v", err)
+	}
+
+	// Check if a port is provided and append it to the host
+	if config.Port != 0 {
+		baseURL.Host = fmt.Sprintf("%s:%d", baseURL.Hostname(), config.Port)
+	}
+
+	// Add the /access/ endpoint and ocp-advisor parameter. This could be configured via env-var,
+	// but I don't think there's a need for complicating things further
+
+	baseURL.Path = "/access/"
+
+	params := url.Values{}
+	params.Add("application", "ocp-advisor")
+	params.Add("limit", "100") // We don't know what customers might have configured, so let's limit responses' size
+
+	uri := fmt.Sprintf("%s?%s", baseURL, params.Encode())
+	log.Info().Str("RBAC URL:", uri).Send()
+
+	return uri, baseURL.Host, nil
+}

--- a/auth/configuration_test.go
+++ b/auth/configuration_test.go
@@ -1,0 +1,54 @@
+package auth_test
+
+import (
+	"testing"
+
+	"github.com/RedHatInsights/insights-results-smart-proxy/auth"
+)
+
+func TestConstructRBACURL(t *testing.T) {
+	tests := []struct {
+		config       *auth.RBACConfig
+		expectedURL  string
+		expectedHost string
+		expectError  bool
+	}{
+		{
+			config:       &auth.RBACConfig{Host: "example.com", Port: 443},
+			expectedURL:  "https://example.com:443/access/?application=ocp-advisor&limit=100",
+			expectedHost: "example.com:443",
+			expectError:  false,
+		},
+		{
+			config:       &auth.RBACConfig{Host: "http://example.com", Port: 0},
+			expectedURL:  "http://example.com/access/?application=ocp-advisor&limit=100",
+			expectedHost: "example.com",
+			expectError:  false,
+		},
+		{
+			config:       &auth.RBACConfig{Host: "invalid", Port: 0},
+			expectedURL:  "https://invalid/access/?application=ocp-advisor&limit=100",
+			expectedHost: "invalid",
+			expectError:  false, //url.Parse and url.ParseURI can't catch bad URLs, careful!
+		},
+	}
+
+	for _, tt := range tests {
+		base, host, err := auth.ConstructRBACURL(tt.config)
+
+		// Check for expected error
+		if (err != nil) != tt.expectError {
+			t.Errorf("expected error: %v, got: %v", tt.expectError, err)
+		}
+
+		// If no error is expected, check the returned values
+		if !tt.expectError {
+			if base != tt.expectedURL {
+				t.Errorf("expected base URL: %s, got: %s", tt.expectedURL, base)
+			}
+			if host != tt.expectedHost {
+				t.Errorf("expected host: %s, got: %s", tt.expectedHost, host)
+			}
+		}
+	}
+}

--- a/auth/export_test.go
+++ b/auth/export_test.go
@@ -1,0 +1,21 @@
+/*
+Copyright © 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+var (
+	ConstructRBACURL = constructRBACURL
+)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -45,6 +45,7 @@ import (
 	"github.com/BurntSushi/toml"
 	"github.com/RedHatInsights/insights-operator-utils/logger"
 	"github.com/RedHatInsights/insights-results-smart-proxy/amsclient"
+	"github.com/RedHatInsights/insights-results-smart-proxy/auth"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/services"
 	types "github.com/RedHatInsights/insights-results-types"
@@ -84,6 +85,7 @@ var Config struct {
 	SentryLoggingConf logger.SentryLoggingConfiguration `mapstructure:"sentry" toml:"sentry"`
 	KafkaZerologConf  logger.KafkaZerologConfiguration  `mapstructure:"kafka_zerolog" toml:"kafka_zerolog"`
 	AMSClientConf     amsclient.Configuration           `mapstructure:"amsclient" toml:"amsclient"`
+	RBACConf          auth.RBACConfig                   `mapstructure:"rbac" toml:"rbac"`
 }
 
 // LoadConfiguration loads configuration from defaultConfigFile, file set in
@@ -208,6 +210,10 @@ func GetAMSClientConfiguration() amsclient.Configuration {
 // GetRedisConfiguration returns Redis configuration
 func GetRedisConfiguration() services.RedisConfiguration {
 	return Config.RedisConf
+}
+
+func GetRBACConfiguration() auth.RBACConfig {
+	return Config.RBACConf
 }
 
 // checkIfFileExists returns nil if path doesn't exist or isn't a file,

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -432,3 +432,16 @@ func TestGetLoggingConfiguration(t *testing.T) {
 		LoggingToCloudWatchEnabled: false,
 	}, loggingConfiguration)
 }
+
+// TestLoadRBACConfiguration tests loading the RBAC configuration sub-tree
+func TestLoadRBACConfiguration(t *testing.T) {
+	TestLoadConfiguration(t)
+	helpers.FailOnError(t, os.Chdir(".."))
+
+	cfg := conf.GetRBACConfiguration()
+
+	assert.Equal(t, "https://api.openshift.com", cfg.Host)
+	assert.Equal(t, false, cfg.Enabled)
+	assert.Equal(t, false, cfg.EnforceAuth)
+	assert.Equal(t, uint16(0), cfg.Port)
+}

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/RedHatInsights/insights-operator-utils v1.25.12
 	github.com/RedHatInsights/insights-results-aggregator v1.4.1
 	github.com/RedHatInsights/insights-results-aggregator-data v1.3.9
-	github.com/RedHatInsights/insights-results-types v1.23.4
+	github.com/RedHatInsights/insights-results-types v1.23.5
 	github.com/go-redis/redismock/v9 v9.2.0
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/google/uuid v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/RedHatInsights/insights-results-types v1.2.0/go.mod h1:6VVdMTGU/BAS2c
 github.com/RedHatInsights/insights-results-types v1.3.20/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.21/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
 github.com/RedHatInsights/insights-results-types v1.3.22/go.mod h1:6VVdMTGU/BAS2cW0KrHAUiDyocpyKqpPpEyp6AJ1tk8=
-github.com/RedHatInsights/insights-results-types v1.23.4 h1:BWFxaaDRaNozhXmf1W25WnGI4qsulVACLD5PoUdWUE8=
-github.com/RedHatInsights/insights-results-types v1.23.4/go.mod h1:Cz4DzWtf860oCPtdjIRa26ZbDP++rMhCSPZvgXEuSHQ=
+github.com/RedHatInsights/insights-results-types v1.23.5 h1:Cy280q62m1DG6nvy+HHXyfj3U/GgR6su9qkYc2+sz1M=
+github.com/RedHatInsights/insights-results-types v1.23.5/go.mod h1:Cz4DzWtf860oCPtdjIRa26ZbDP++rMhCSPZvgXEuSHQ=
 github.com/RedHatInsights/kafka-zerolog v0.0.0-20210304172207-928f026dc7ec/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=
 github.com/RedHatInsights/kafka-zerolog v1.0.0 h1:4zPrLcwnfFl07qv9/ximlm1E/rWs93TkYnHrgNiU73A=
 github.com/RedHatInsights/kafka-zerolog v1.0.0/go.mod h1:HJul5oCsCRNiRlh/ayJDGdW3PzGlid/5aaQwJBn7was=

--- a/tests/config1.toml
+++ b/tests/config1.toml
@@ -60,3 +60,8 @@ environment = "test_env"
 
 [logging]
 debug = true
+
+[rbac]
+host = "https://api.openshift.com"
+enabled = false
+enforce = false

--- a/types/rbac.go
+++ b/types/rbac.go
@@ -1,0 +1,49 @@
+// Copyright 2024 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+type RbacResponse struct {
+	Meta  RbacMetadata `json:"meta"`
+	Links rbacLinks    `json:"links"`
+	Data  []RbacData   `json:"data"`
+}
+
+type RbacMetadata struct {
+	Count  int `json:"count"`
+	Limit  int `json:"limit,omitempty"`
+	Offset int `json:"offset,omitempty"`
+}
+
+type RbacData struct {
+	ResourceDefinitions []rbacResourceDefinitions `json:"resourceDefinitions,omitempty"`
+	Permission          string                    `json:"permission,omitempty"`
+}
+
+type rbacResourceDefinitions struct {
+	AttributeFilter attributeFilter `json:"attributeFilter,omitempty"`
+}
+
+type attributeFilter struct {
+	Key       string
+	Value     interface{}
+	Operation string
+}
+
+type rbacLinks struct {
+	First    string
+	Next     string `json:"next,omitempty"`
+	Previous string `json:"previous,omitempty"`
+	Last     string
+}


### PR DESCRIPTION
# Description

- Update insights-results-type version to include changes in Identity structure
- Add new types for RBAC response handling, based on the `/access/` endpoint (see https://developers.redhat.com/api-catalog/api/rbac)
- Add support for RBAC configuration and corresponding unit tests

First part of CCXDEV-12884 

## Type of change
- New feature (non-breaking change which adds functionality)
- Configuration update

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
