### PR TITLE
Add RBAC client

### DIFF
--- a/auth/configuration.go
+++ b/auth/configuration.go
@@ -26,8 +26,7 @@ import (
 
 // RBACConfig holds the configuration for RBAC settings.
 type RBACConfig struct {
-	Host        string `mapstructure:"host" toml:"host"`
-	Port        uint16 `mapstructure:"port" toml:"port,omitempty"`
+	URL         string `mapstructure:"url" toml:"url"`
 	Enabled     bool   `mapstructure:"enabled" toml:"enabled"`
 	EnforceAuth bool   `mapstructure:"enforce" toml:"enforce"`
 }
@@ -41,19 +40,14 @@ func IsEnabled(config *RBACConfig) bool {
 // access to Advisor OCP resources. It takes an RBACConfig and returns the
 // constructed base URL, host, and any error encountered.
 func constructRBACURL(config *RBACConfig) (string, string, error) {
-	if !strings.HasPrefix(config.Host, "http://") && !strings.HasPrefix(config.Host, "https://") {
-		config.Host = "https://" + config.Host // Default to HTTPS if no scheme is provided
+	if !strings.HasPrefix(config.URL, "http://") && !strings.HasPrefix(config.URL, "https://") {
+		config.URL = "https://" + config.URL // Default to HTTPS if no scheme is provided
 	}
 
 	// Parse the URL to handle both the Host and the Endpoint correctly
-	baseURL, err := url.Parse(config.Host)
+	baseURL, err := url.Parse(config.URL)
 	if err != nil {
 		return "", "", fmt.Errorf("invalid host format: %v", err)
-	}
-
-	// Check if a port is provided and append it to the host
-	if config.Port != 0 {
-		baseURL.Host = fmt.Sprintf("%s:%d", baseURL.Hostname(), config.Port)
 	}
 
 	// Add the /access/ endpoint and ocp-advisor parameter

--- a/auth/configuration_test.go
+++ b/auth/configuration_test.go
@@ -30,19 +30,19 @@ func TestConstructRBACURL(t *testing.T) {
 		expectError  bool
 	}{
 		{
-			config:       &auth.RBACConfig{Host: "example.com", Port: 443},
-			expectedURL:  "https://example.com:443/access/?application=ocp-advisor&limit=100",
-			expectedHost: "example.com:443",
+			config:       &auth.RBACConfig{URL: "example.com"},
+			expectedURL:  "https://example.com/access/?application=ocp-advisor&limit=100",
+			expectedHost: "example.com",
 			expectError:  false,
 		},
 		{
-			config:       &auth.RBACConfig{Host: "http://example.com", Port: 0},
+			config:       &auth.RBACConfig{URL: "http://example.com"},
 			expectedURL:  "http://example.com/access/?application=ocp-advisor&limit=100",
 			expectedHost: "example.com",
 			expectError:  false,
 		},
 		{
-			config:       &auth.RBACConfig{Host: "wrong-schema:/invalid", Port: 0},
+			config:       &auth.RBACConfig{URL: "wrong-schema:/invalid"},
 			expectedURL:  "https://wrong-schema:/access/?application=ocp-advisor&limit=100",
 			expectedHost: "wrong-schema:",
 			expectError:  false, //url.Parse and url.ParseURI can't catch bad URLs, careful!

--- a/auth/rbac.go
+++ b/auth/rbac.go
@@ -62,11 +62,6 @@ func (rc *rbacClientImpl) IsEnforcing() bool {
 
 // IsAuthorized checks if an account has the correct permissions to access our resources
 func (rc *rbacClientImpl) IsAuthorized(token string) bool {
-	// baseURL := "https://console.redhat.com/api/rbac/v1" // TODO: env var, separate URL from endpoint like this: https://console.redhat.com and /api/rbac/v1/access so we can include port if needed. use helper func to create url
-	// baseURL := "https://console.stage.redhat.com/api/rbac/v1"
-
-	// Here you can add additional logic to parse the response body if needed
-	// For now, we assume that a 200 response means permissions are valid
 	permissions := rc.getPermissions(token)
 	return permissions != nil
 }
@@ -138,7 +133,6 @@ func (rc *rbacClientImpl) requestAccess(url, identityToken string) []types.RbacD
 // from RBAC and creates and return the map of permissions where key is
 // resourceType (openshift.cluster, openshift.node, openshift.project) and the values are the
 // slice of resources (cluster names, node names, project names).
-// We might not need it, but since it's part of the response, this might be useful.
 func aggregatePermissions(acls []types.RbacData) map[string][]string {
 	permissions := map[string][]string{}
 	for _, acl := range acls {

--- a/auth/rbac.go
+++ b/auth/rbac.go
@@ -1,0 +1,169 @@
+/*
+Copyright © 2024 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/RedHatInsights/insights-results-smart-proxy/types"
+	"github.com/rs/zerolog/log"
+)
+
+type RBACClient interface {
+	IsAuthorized(token string) bool
+	IsEnforcing() bool
+}
+
+type rbacClientImpl struct {
+	uri         string
+	host        string
+	client      *http.Client
+	enforceAuth bool
+}
+
+// NewRBACClient create an RBACClient from the configuration
+func NewRBACClient(conf *RBACConfig) (RBACClient, error) {
+	url, host, err := constructRBACURL(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{}
+
+	return &rbacClientImpl{
+		url,
+		host,
+		client,
+		conf.EnforceAuth,
+	}, nil
+}
+
+func (rc *rbacClientImpl) IsEnforcing() bool {
+	return rc.enforceAuth
+}
+
+// IsAuthorized checks if an account has the correct permissions to access our resources
+func (rc *rbacClientImpl) IsAuthorized(token string) bool {
+	// baseURL := "https://console.redhat.com/api/rbac/v1" // TODO: env var, separate URL from endpoint like this: https://console.redhat.com and /api/rbac/v1/access so we can include port if needed. use helper func to create url
+	// baseURL := "https://console.stage.redhat.com/api/rbac/v1"
+
+	// Here you can add additional logic to parse the response body if needed
+	// For now, we assume that a 200 response means permissions are valid
+	permissions := rc.getPermissions(token)
+	return permissions != nil
+}
+
+func (rc *rbacClientImpl) getPermissions(identityToken string) map[string][]string {
+	acls := rc.requestAccess(rc.uri, identityToken)
+	if len(acls) > 0 {
+		permissions := aggregatePermissions(acls)
+		if len(permissions) > 0 {
+			return permissions
+		}
+		return nil
+	}
+	return nil
+}
+
+// requestAccess handles the call(s) to RBAC taking into account that the response
+// is paginated
+func (rc *rbacClientImpl) requestAccess(url, identityToken string) []types.RbacData {
+	//TODO Change return to (rbacData, err) and forward error?
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to create RBAC request")
+		return nil
+	}
+
+	// Forward the x-rh-identity header directly
+	req.Header.Set(XRHAuthTokenHeader, identityToken)
+
+	resp, err := rc.client.Do(req)
+	if err != nil {
+		log.Error().Err(err).Msg("Failed to call RBAC API")
+		return nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		log.Error().Msgf("RBAC API returned non-200 status: %d", resp.StatusCode)
+		return nil
+	}
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Error().Err(err).Msg("Error closing response body")
+		}
+	}()
+
+	body, _ := io.ReadAll(resp.Body)
+	response := types.RbacResponse{}
+	if err := json.Unmarshal(body, &response); err != nil {
+		log.Err(err).Str("URL", url).Msg("Unable to unmarshal response from RBAC server")
+	}
+
+	if response.Meta.Count == 0 {
+		//TODO: Debug level, not info, but for now we need it
+		log.Info().Msg("No RBAC data for this user")
+		return nil
+	}
+	access := []types.RbacData{}
+
+	access = append(access, response.Data...)
+	if response.Links.Next != "" {
+		next_url := fmt.Sprintf("%s%s", rc.host, response.Links.Next)
+		access = append(access, rc.requestAccess(next_url, identityToken)...)
+	}
+	return access
+}
+
+// aggregatePermissions loop over all the permissions/roles/alcs of the user returned
+// from RBAC and creates and return the map of permissions where key is
+// resourceType (openshift.cluster, openshift.node, openshift.project) and the values are the
+// slice of resources (cluster names, node names, project names).
+// We might not need it, but since it's part of the response, this might be useful.
+func aggregatePermissions(acls []types.RbacData) map[string][]string {
+	permissions := map[string][]string{}
+	for _, acl := range acls {
+		resourceType := strings.Split(acl.Permission, ":")[1]
+		if strings.Contains(resourceType, "openshift") {
+			if _, ok := permissions[resourceType]; !ok {
+				permissions[resourceType] = []string{}
+			}
+			if len(acl.ResourceDefinitions) == 0 {
+				permissions[resourceType] = append(permissions[resourceType], "*")
+			} else {
+				for _, resourceDefinition := range acl.ResourceDefinitions {
+					switch t := resourceDefinition.AttributeFilter.Value.(type) {
+					case []interface{}:
+						for _, v := range t {
+							permissions[resourceType] = append(permissions[resourceType], fmt.Sprint(v))
+						}
+					case string:
+						permissions[resourceType] = append(permissions[resourceType], t)
+					}
+				}
+			}
+		} else if resourceType == "*" {
+			permissions["*"] = []string{}
+		}
+	}
+	return permissions
+}

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -440,8 +440,7 @@ func TestLoadRBACConfiguration(t *testing.T) {
 
 	cfg := conf.GetRBACConfiguration()
 
-	assert.Equal(t, "https://api.openshift.com", cfg.Host)
+	assert.Equal(t, "https://api.openshift.com", cfg.URL)
 	assert.Equal(t, false, cfg.Enabled)
 	assert.Equal(t, false, cfg.EnforceAuth)
-	assert.Equal(t, uint16(0), cfg.Port)
 }

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -52,3 +52,8 @@ database = 0
 endpoint = "localhost:6379"
 password = ""
 timeout_seconds = 30
+
+[rbac]
+host = https://console.redhat.com/api/rbac/v1
+enabled = false
+enforce = false

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -54,6 +54,6 @@ password = ""
 timeout_seconds = 30
 
 [rbac]
-host = https://console.redhat.com/api/rbac/v1
+url = "https://console.redhat.com/api/rbac/v1"
 enabled = false
 enforce = false

--- a/config.toml
+++ b/config.toml
@@ -69,6 +69,6 @@ password = ""
 timeout_seconds = 30
 
 [rbac]
-host = https://console.redhat.com/api/rbac/v1
+url = "https://console.redhat.com/api/rbac/v1"
 enabled = false
 enforce = false

--- a/config.toml
+++ b/config.toml
@@ -67,3 +67,8 @@ database = 0
 endpoint = "localhost:6379"
 password = ""
 timeout_seconds = 30
+
+[rbac]
+host = https://console.redhat.com/api/rbac/v1
+enabled = false
+enforce = false

--- a/server/handlers_test.go
+++ b/server/handlers_test.go
@@ -438,7 +438,7 @@ func TestHTTPServer_ReportEndpointV2NoContent(t *testing.T) {
 			clusterInfoList,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
 			Method:       http.MethodGet,
@@ -483,7 +483,7 @@ func TestHTTPServer_ReportEndpointV2TestAMSData(t *testing.T) {
 			clusterInfoList,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
 			Method:       http.MethodGet,
@@ -531,7 +531,7 @@ func TestHTTPServer_ReportEndpointV2TestManagedClustersRules(t *testing.T) {
 			clusterInfoList,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		// 3 rules, only 1 of which is managed
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
@@ -651,7 +651,7 @@ func TestHTTPServer_ReportEndpoint_InsightsOperatorUserAgentManagedCluster(t *te
 			clusterInfoList,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
 			Method:       http.MethodGet,
@@ -704,7 +704,7 @@ func TestHTTPServer_ReportEndpoint_InsightsOperatorUserAgentNonManagedCluster(t 
 			clusterInfoList,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		helpers.GockExpectAPIRequest(t, helpers.DefaultServicesConfig.AggregatorBaseEndpoint, &helpers.APIRequest{
 			Method:       http.MethodGet,
@@ -1326,7 +1326,7 @@ func TestHTTPServer_OverviewEndpoint(t *testing.T) {
 
 		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(
 			t,
 			testServer,
@@ -1407,7 +1407,7 @@ func TestHTTPServer_OverviewEndpointManagedClustersRules(t *testing.T) {
 		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
 		// managed cluster; 1 managed rule, 2 non-managed rules == only 1 rule must count
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(
 			t,
 			testServer,
@@ -1485,7 +1485,7 @@ func TestHTTPServer_OverviewEndpoint_UnavailableContentService(t *testing.T) {
 
 		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, helpers.DefaultServerConfig.APIv1Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.OverviewEndpoint,
@@ -1557,7 +1557,7 @@ func TestHTTPServer_OverviewGetEndpointDisabledRule(t *testing.T) {
 
 		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(
 			t,
 			testServer,
@@ -1673,7 +1673,7 @@ func TestHTTPServer_OverviewEndpointWithFallback(t *testing.T) {
 
 		config := helpers.DefaultServerConfig
 		config.UseOrgClustersFallback = true
-		testServer := helpers.CreateHTTPServer(&config, nil, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&config, nil, nil, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(
 			t,
 			testServer,
@@ -2061,7 +2061,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing(t *testin
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.RecommendationsListEndpoint,
@@ -2170,7 +2170,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules_ImpactingMissing1RuleDisab
 		)
 
 		// one rule acked; one rule user disabled (not counted as impacting)
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.RecommendationsListEndpoint,
@@ -2245,7 +2245,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1MissingContent(t *testing.
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.RecommendationsListEndpoint,
@@ -2314,7 +2314,7 @@ func TestHTTPServer_RecommendationsListEndpoint_NoRuleContent(t *testing.T) {
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.RecommendationsListEndpoint,
@@ -2384,7 +2384,7 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.RecommendationsListEndpoint + "?" + server.ImpactingParam + "=true",
@@ -2454,7 +2454,7 @@ func TestHTTPServer_RecommendationsListEndpoint3Rules1Internal0Clusters_Impactin
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.RecommendationsListEndpoint + "?" + server.ImpactingParam + "=false",
@@ -2528,7 +2528,7 @@ func TestHTTPServer_RecommendationsListEndpoint2Rules1Internal2Clusters_Impactin
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.RecommendationsListEndpoint,
@@ -2607,7 +2607,7 @@ func TestHTTPServer_RecommendationsListEndpoint4Rules1Internal2Clusters_Impactin
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.RecommendationsListEndpoint,
@@ -2712,7 +2712,7 @@ func TestHTTPServer_RecommendationsListEndpointAMSManagedClusters(t *testing.T) 
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.RecommendationsListEndpoint,
@@ -2969,7 +2969,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_NoClusters(t *testing.T) {
 
 		expectNoRulesDisabledPerCluster(&t, testdata.OrgID)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.ClustersRecommendationsEndpoint,
@@ -3029,7 +3029,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_ClustersFoundNoInsights(t *t
 			resp.Clusters[i].LastCheckedAt = "" // will be empty because we don't have the cluster in our DB
 		}
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.ClustersRecommendationsEndpoint,
@@ -3102,7 +3102,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_NoRuleHits(t *testing.T) {
 			resp.Clusters[i].LastCheckedAt = testTimestamp
 		}
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.ClustersRecommendationsEndpoint,
@@ -3162,7 +3162,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_NoReportInDB(t *testing.T) {
 			resp.Clusters[i].Managed = clusterInfoList[i].Managed
 		}
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.ClustersRecommendationsEndpoint,
@@ -3246,7 +3246,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_2ClustersFilled(t *testing.T
 			resp.Clusters[i].Managed = clusterInfoList[i].Managed
 		}
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.ClustersRecommendationsEndpoint,
@@ -3330,7 +3330,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_2Clusters1Managed(t *testing
 		}
 
 		// cluster 1 is managed, so must only show 1 rule. cluster 2 will show both rules.
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.ClustersRecommendationsEndpoint,
@@ -3417,7 +3417,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_2Clusters1WithVersion(t *tes
 		}
 
 		// cluster 1 is managed, so must only show 1 rule. cluster 2 will show both rules.
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.ClustersRecommendationsEndpoint,
@@ -3521,7 +3521,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_AckedRule(t *testing.T) {
 			resp.Clusters[i].Managed = clusterInfoList[i].Managed
 		}
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.ClustersRecommendationsEndpoint,
@@ -3629,7 +3629,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_DisabledRuleSingleCluster(t 
 			resp.Clusters[i].Managed = clusterInfoList[i].Managed
 		}
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.ClustersRecommendationsEndpoint,
@@ -3758,7 +3758,7 @@ func TestHTTPServer_ClustersRecommendationsEndpoint_DisabledAndAcked(t *testing.
 			resp.Clusters[i].Managed = clusterInfoList[i].Managed
 		}
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(t, testServer, serverConfigXRH.APIv2Prefix, &helpers.APIRequest{
 			Method:      http.MethodGet,
 			Endpoint:    server.ClustersRecommendationsEndpoint,
@@ -3803,6 +3803,7 @@ func TestHTTPServer_GroupsEndpoint(t *testing.T) {
 				groupsChannel,
 				errorFoundChannel,
 				errorChannel,
+				nil,
 			)
 
 			req := &helpers.APIRequest{
@@ -3933,7 +3934,7 @@ func TestHTTPServer_GetClustersForOrganizationOk(t *testing.T) {
 				test.amsMockClusterList,
 			)
 
-			testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+			testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 			iou_helpers.AssertAPIRequest(
 				t,
@@ -3973,7 +3974,7 @@ func TestHTTPServer_GetClustersForOrganizationAggregatorFallback(t *testing.T) {
 	config := helpers.DefaultServerConfig
 	config.UseOrgClustersFallback = true
 	// no AMS client
-	testServer := helpers.CreateHTTPServer(&config, nil, nil, nil, nil, nil, nil)
+	testServer := helpers.CreateHTTPServer(&config, nil, nil, nil, nil, nil, nil, nil)
 
 	iou_helpers.AssertAPIRequest(
 		t,

--- a/server/handlers_v2_test.go
+++ b/server/handlers_v2_test.go
@@ -219,7 +219,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk(t *testing.T) {
 		clusters[1], data.ClusterDisplayName2, disabledAt, justificationNote,
 	)
 
-	testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+	testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 	iou_helpers.AssertAPIRequest(
 		t,
@@ -350,7 +350,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_ImpactedClusterDi
 
 	expectedResponse = fmt.Sprintf(expectedResponse, clusters[0], data.ClusterDisplayName1, disabledAt, justificationNote)
 
-	testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+	testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 	iou_helpers.AssertAPIRequest(
 		t,
@@ -485,7 +485,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_DisabledClusterNo
 	// 2nd cluster is there
 	expectedResponse = fmt.Sprintf(expectedResponse, clusters[1], data.ClusterDisplayName2)
 
-	testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+	testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 	iou_helpers.AssertAPIRequest(
 		t,
@@ -637,7 +637,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_AckedRule_CCXDEV_
 		clusters[1], data.ClusterDisplayName2, disabledAt, justificationNote,
 	)
 
-	testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+	testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 	// rule acked == all rules must be marked as disabled
 	iou_helpers.AssertAPIRequest(
@@ -803,7 +803,7 @@ func TestHTTPServer_ClustersDetailEndpointAggregatorResponseOk_AckedRule_Disable
 		clusters[1], data.ClusterDisplayName2, disabledAt, justificationNote,
 	)
 
-	testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+	testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 	// rule acked == all rules must be marked as disabled
 	iou_helpers.AssertAPIRequest(
@@ -894,7 +894,7 @@ func TestHTTPServer_ClustersDetailEndpointAMSManagedClusters(t *testing.T) {
 				"status":"ok"
 			}
 			`
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		// cluster is managed, but rule is not == must not show as hitting
 		iou_helpers.AssertAPIRequest(
@@ -1185,7 +1185,7 @@ func TestHTTPServer_GetSingleClusterInfo(t *testing.T) {
 		expectedResponse = fmt.Sprintf(expectedResponse, clusterInfoList[0].ID, clusterInfoList[0].DisplayName,
 			clusterInfoList[0].Managed, clusterInfoList[0].Status,
 		)
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -1214,7 +1214,7 @@ func TestHTTPServer_GetSingleClusterInfoClusterNotFound(t *testing.T) {
 			[]types.ClusterInfo{},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -1236,7 +1236,7 @@ func TestHTTPServer_GetRequestStatusForCluster_RedisNil(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -1260,7 +1260,7 @@ func TestHTTPServer_GetRequestStatusForCluster_RedisError500(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		expectedKey := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
 		redisServer.ExpectScan(0, expectedKey, services.ScanBatchCount).SetErr(errors.New("Redis server failure"))
@@ -1289,7 +1289,7 @@ func TestHTTPServer_GetRequestStatusForCluster_NoRequestsForCluster(t *testing.T
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		expectedKey := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
 		redisServer.ExpectScan(0, expectedKey, services.ScanBatchCount).SetVal([]string{}, 0)
@@ -1320,7 +1320,7 @@ func TestHTTPServer_GetRequestStatusForCluster_RequestNotFound(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		expectedKey := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
 		redisServer.ExpectScan(0, expectedKey, services.ScanBatchCount).SetVal([]string{"requestIDNotTheOne", "requestIDAlsoNotTheOne"}, 0)
@@ -1352,7 +1352,7 @@ func TestHTTPServer_GetRequestStatusForCluster_BadRequestClusterID(t *testing.T)
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// invalid clusterID
 		iou_helpers.AssertAPIRequest(
@@ -1379,7 +1379,7 @@ func TestHTTPServer_GetRequestStatusForCluster_BadRequestID(t *testing.T) {
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// invalid requestID in endpoint arg
 		iou_helpers.AssertAPIRequest(
@@ -1406,7 +1406,7 @@ func TestHTTPServer_GetRequestStatusForCluster_BadAuthToken(t *testing.T) {
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// bad token
 		iou_helpers.AssertAPIRequest(
@@ -1431,7 +1431,7 @@ func TestHTTPServer_GetRequestStatusForCluster_SingleRequestID(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		expectedKey := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
 		redisServer.ExpectScan(0, expectedKey, services.ScanBatchCount).SetVal([]string{"requestID1"}, 0)
@@ -1464,7 +1464,7 @@ func TestHTTPServer_GetRequestStatusForCluster_RequestIDOnSecondPage(t *testing.
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		expectedKey := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
 		redisServer.ExpectScan(0, expectedKey, services.ScanBatchCount).SetVal([]string{"requestID1"}, 42)
@@ -1499,7 +1499,7 @@ func TestHTTPServer_GetRequestsForCluster_OK1Request(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		expectedKey1stCommand := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
 		redisServer.ExpectScan(0, expectedKey1stCommand, services.ScanBatchCount).SetVal([]string{"requestID1"}, 0)
@@ -1542,7 +1542,7 @@ func TestHTTPServer_GetRequestsForCluster_OK3Requests(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		requestIDs := make([]string, 3)
 		for i := range requestIDs {
@@ -1599,7 +1599,7 @@ func TestHTTPServer_GetRequestsForCluster_RequestsNotFound(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		expectedKey := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
 		redisServer.ExpectScan(0, expectedKey, services.ScanBatchCount).SetVal([]string{}, 0)
@@ -1633,7 +1633,7 @@ func TestHTTPServer_GetRequestsForCluster_BadRequestClusterID(t *testing.T) {
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// invalid clusterID
 		iou_helpers.AssertAPIRequest(
@@ -1660,7 +1660,7 @@ func TestHTTPServer_GetRequestsForCluster_BadAuthToken(t *testing.T) {
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// invalid clusterID
 		iou_helpers.AssertAPIRequest(
@@ -1683,7 +1683,7 @@ func TestHTTPServer_GetRequestsForCluster_NoRedis(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -1707,7 +1707,7 @@ func TestHTTPServer_GetRequestsForCluster_RedisError500(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		expectedKey1stCommand := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
 		redisServer.ExpectScan(0, expectedKey1stCommand, services.ScanBatchCount).SetErr(errors.New("Redis server failure"))
@@ -1736,7 +1736,7 @@ func TestHTTPServer_GetRequestsForCluster_RedisError500_2ndCmd(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		expectedKey1stCommand := fmt.Sprintf(services.RequestIDsScanPattern, testdata.OrgID, testdata.ClusterName)
 		redisServer.ExpectScan(0, expectedKey1stCommand, services.ScanBatchCount).SetVal([]string{"requestID1"}, 0)
@@ -1770,7 +1770,7 @@ func TestHTTPServer_GetReportForRequest_OK1Request(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		expectedKey := fmt.Sprintf(services.SimplifiedReportKey, testdata.OrgID, testdata.ClusterName, "requestID1")
 		redisServer.ExpectHMGet(
@@ -1814,7 +1814,7 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_OK3Request1Found(t *testing
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		requestIDs := make([]string, 3)
 		for i := range requestIDs {
@@ -1873,7 +1873,7 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_OK1RequestNotFound(t *testi
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		expectedKey := fmt.Sprintf(services.SimplifiedReportKey, testdata.OrgID, testdata.ClusterName, "requestID1")
 		redisServer.ExpectHMGet(
@@ -1915,7 +1915,7 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_NoRedis(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil, nil)
 
 		requestIDList := []types.RequestID{"requestID1"}
 		reqBody, _ := json.Marshal(requestIDList)
@@ -1943,7 +1943,7 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_RedisError500(t *testing.T)
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		expectedKey := fmt.Sprintf(services.SimplifiedReportKey, testdata.OrgID, testdata.ClusterName, "requestID1")
 		redisServer.ExpectHMGet(
@@ -1979,7 +1979,7 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_BadRequestClusterID(t *test
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		requestIDList := []types.RequestID{"requestID1"}
 		reqBody, _ := json.Marshal(requestIDList)
@@ -2010,7 +2010,7 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_BadAuthToken(t *testing.T) 
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		requestIDList := []types.RequestID{"requestID1"}
 		reqBody, _ := json.Marshal(requestIDList)
@@ -2040,7 +2040,7 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_NoBody(t *testing.T) {
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// invalid clusterID
 		iou_helpers.AssertAPIRequest(
@@ -2067,7 +2067,7 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_BadBodyContent(t *testing.T
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// invalid clusterID
 		iou_helpers.AssertAPIRequest(
@@ -2095,7 +2095,7 @@ func TestHTTPServer_GetRequestsForClusterPostVariant_BadRequestID(t *testing.T) 
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		requestIDList := []types.RequestID{"_"}
 		reqBody, _ := json.Marshal(requestIDList)
@@ -2128,7 +2128,7 @@ func TestHTTPServer_GetReportForRequest_OK_RequestNotFound(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// redis expects
 		expectedKey := fmt.Sprintf(services.SimplifiedReportKey, testdata.OrgID, testdata.ClusterName, "requestID1")
@@ -2164,7 +2164,7 @@ func TestHTTPServer_GetReportForRequest_OK_NoRuleHits(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// redis expects
 		expectedKey := fmt.Sprintf(services.SimplifiedReportKey, testdata.OrgID, testdata.ClusterName, "requestID1")
@@ -2233,7 +2233,7 @@ func TestHTTPServer_GetReportForRequest_OK_1RuleHit(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// redis expects
 		expectedRuleHits := fmt.Sprintf("%v|%v", testdata.Rule1ID, testdata.ErrorKey1)
@@ -2303,7 +2303,7 @@ func TestHTTPServer_GetReportForRequest_BadAuthToken(t *testing.T) {
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// invalid clusterID
 		iou_helpers.AssertAPIRequest(
@@ -2329,7 +2329,7 @@ func TestHTTPServer_GetReportForRequest_BadRequestClusterID(t *testing.T) {
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// invalid clusterID
 		iou_helpers.AssertAPIRequest(
@@ -2356,7 +2356,7 @@ func TestHTTPServer_GetReportForRequest_BadRequestID(t *testing.T) {
 		// mock server not needed because the request will not get to part requiring Redis
 		redisClient, _ := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// invalid requestID in endpoint arg
 		iou_helpers.AssertAPIRequest(
@@ -2389,7 +2389,7 @@ func TestHTTPServer_GetReportForRequest_NoRuleContent(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// redis expects
 		expectedRuleHits := fmt.Sprintf("%v|%v", testdata.Rule1ID, testdata.ErrorKey1)
@@ -2459,7 +2459,7 @@ func TestHTTPServer_GetReportForRequest_OK_2RuleHits1Acked(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// redis expects
 		expectedRuleHits := fmt.Sprintf("%v|%v,%v|%v", testdata.Rule1ID, testdata.ErrorKey1, testdata.Rule2ID, testdata.ErrorKey2)
@@ -2533,7 +2533,7 @@ func TestHTTPServer_GetReportForRequest_OK_3RuleHits1Acked1Disabled(t *testing.T
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// redis expects
 
@@ -2625,7 +2625,7 @@ func TestHTTPServer_GetReportForRequest_AggregatorError(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// redis expects
 		expectedRuleHits := fmt.Sprintf("%v|%v", testdata.Rule1ID, testdata.ErrorKey1)
@@ -2670,7 +2670,7 @@ func TestHTTPServer_GetReportForRequest_AggregatorError_2ndCall(t *testing.T) {
 
 		redisClient, redisServer := helpers.GetMockRedis()
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, &redisClient, nil, nil, nil, nil)
 
 		// redis expects
 		expectedRuleHits := fmt.Sprintf("%v|%v", testdata.Rule1ID, testdata.ErrorKey1)
@@ -2726,7 +2726,7 @@ func TestHTTPServer_GetReportForRequest_NoRedis(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(tt testing.TB) {
 		defer helpers.CleanAfterGock(t)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil, nil)
 
 		requestIDList := []types.RequestID{"requestID1"}
 		reqBody, _ := json.Marshal(requestIDList)
@@ -2779,7 +2779,7 @@ func TestHTTPServer_DVONamespaceListEndpoint_NoWorkloads(t *testing.T) {
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		expectedResponse := `{"status": "ok", "workloads": []}`
 
@@ -2857,7 +2857,7 @@ func TestHTTPServer_DVONamespaceListEndpoint_OK(t *testing.T) {
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		expectedResponse := types.DVONamespaceListResponse{
 			Status: "ok",
@@ -2907,7 +2907,7 @@ func TestHTTPServer_DVONamespaceListEndpoint_NoAuthToken(t *testing.T) {
 			data.ClusterInfoResult,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -2930,7 +2930,7 @@ func TestHTTPServer_DVONamespaceListEndpoint_NoAMS(t *testing.T) {
 		err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 		assert.Nil(t, err)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -2975,7 +2975,7 @@ func TestHTTPServer_DVONamespaceListEndpoint_AggregatorError(t *testing.T) {
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -3050,7 +3050,7 @@ func TestHTTPServer_DVONamespaceListEndpoint_RecommendationDoesNotExist(t *testi
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		expectedResponse := types.DVONamespaceListResponse{
 			Status: "ok",
@@ -3163,7 +3163,7 @@ func TestHTTPServer_DVONamespaceListEndpoint_FilterOutInactiveClusters(t *testin
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		expectedResponse := types.DVONamespaceListResponse{
 			Status: "ok",
@@ -3226,7 +3226,7 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterNotFound(t *testing.T) {
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -3307,7 +3307,7 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterFoundNoWorkloads(t *testing.T
 			2: 0,
 		}
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -3445,7 +3445,7 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterFoundWithWorkloads(t *testing
 		expectedResponse.Recommendations[1].TemplateData = aggrResp.Workloads.Recommendations[1].TemplateData
 		expectedResponse.Recommendations[1].Objects = aggrResp.Workloads.Recommendations[1].Objects
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -3477,7 +3477,7 @@ func TestHTTPServer_DVONamespaceForCluster1_BadAuthToken(t *testing.T) {
 			data.ClusterInfoResult,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -3507,7 +3507,7 @@ func TestHTTPServer_DVONamespaceForCluster1_BadClusterID(t *testing.T) {
 			data.ClusterInfoResult,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -3553,7 +3553,7 @@ func TestHTTPServer_DVONamespaceForCluster1_NonUUIDNamespaceID(t *testing.T) {
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -3584,7 +3584,7 @@ func TestHTTPServer_DVONamespaceForCluster1_BadNamespaceID(t *testing.T) {
 			data.ClusterInfoResult,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		var longID string
 		for i := 0; i < 8; i++ {
@@ -3614,7 +3614,7 @@ func TestHTTPServer_DVONamespaceForCluster1_NoAMS(t *testing.T) {
 		err := loadMockRuleContentDir(&testdata.RuleContentDirectory3Rules)
 		assert.Nil(t, err)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -3689,7 +3689,7 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterFoundWithWorkloads_RuleConten
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -3764,7 +3764,7 @@ func TestHTTPServer_DVONamespaceForCluster1_ClusterFoundWithWorkloads_NotFoundIn
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -3808,7 +3808,7 @@ func TestHTTPServer_DVONamespaceForCluster1_AggregatorError(t *testing.T) {
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -3853,7 +3853,7 @@ func TestHTTPServer_DVONamespaceForCluster1_AggregatorBadResponse(t *testing.T) 
 			},
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -3886,7 +3886,7 @@ func TestHTTPServer_DVONamespaceForCluster1_AggregatorUnavailable(t *testing.T) 
 
 		// gock expect missing == aggregator request will timeout
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,

--- a/server/server.go
+++ b/server/server.go
@@ -107,6 +107,7 @@ type HTTPServer struct {
 	ErrorChannel      chan error
 	Serv              *http.Server
 	redis             services.RedisInterface
+	rbacClient        auth.RBACClient
 }
 
 // RequestModifier is a type of function which modifies request when proxying
@@ -130,6 +131,7 @@ func New(config Configuration,
 	groupsChannel chan []groups.Group,
 	errorFoundChannel chan bool,
 	errorChannel chan error,
+	rbacClient auth.RBACClient,
 ) *HTTPServer {
 	return &HTTPServer{
 		Config:            config,
@@ -140,6 +142,7 @@ func New(config Configuration,
 		GroupsChannel:     groupsChannel,
 		ErrorFoundChannel: errorFoundChannel,
 		ErrorChannel:      errorChannel,
+		rbacClient:        rbacClient,
 	}
 }
 
@@ -419,7 +422,7 @@ func (server HTTPServer) readClusterInfoForOrgID(orgID ctypes.OrgID) (
 
 	if !server.Config.UseOrgClustersFallback {
 		err := fmt.Errorf("amsclient not initialized")
-		log.Error().Err(err).Msg("")
+		log.Error().Err(err).Send()
 		return nil, err
 	}
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1252,6 +1252,7 @@ func TestServerStartError(t *testing.T) {
 		nil,
 		nil,
 		nil,
+		nil,
 	)
 
 	err := testServer.Start()
@@ -1281,7 +1282,7 @@ func TestAddCORSHeaders(t *testing.T) {
 func TestHTTPServer_SetAMSInfoInReportNoAMSClient(t *testing.T) {
 	report := types.SmartProxyReportV2{}
 	config := helpers.DefaultServerConfig
-	testServer := helpers.CreateHTTPServer(&config, nil, nil, nil, nil, nil, nil)
+	testServer := helpers.CreateHTTPServer(&config, nil, nil, nil, nil, nil, nil, nil)
 	testServer.SetAMSInfoInReport(testdata.ClusterName, &report)
 	assert.Equal(t, string(testdata.ClusterName), report.Meta.DisplayName)
 }
@@ -1294,7 +1295,7 @@ func TestHTTPServer_SetAMSInfoInReportAMSClientClusterIDFound(t *testing.T) {
 		testdata.OrgID,
 		data.ClusterInfoResult,
 	)
-	testServer := helpers.CreateHTTPServer(&config, nil, amsClientMock, nil, nil, nil, nil)
+	testServer := helpers.CreateHTTPServer(&config, nil, amsClientMock, nil, nil, nil, nil, nil)
 	testServer.SetAMSInfoInReport(testdata.ClusterName, &report)
 	assert.Equal(t, data.ClusterDisplayName1, report.Meta.DisplayName)
 }

--- a/server/upgrade_risks_prediction_test.go
+++ b/server/upgrade_risks_prediction_test.go
@@ -217,7 +217,7 @@ func TestHTTPServer_GetUpgradeRisksPrediction(t *testing.T) {
 		)
 
 		expectedResponse := upgradeRecommended
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		helpers.GockExpectAPIRequest(
 			t,
@@ -264,7 +264,7 @@ func TestHTTPServer_GetUpgradeRisksPredictionNotRecommended(t *testing.T) {
 		)
 
 		expectedResponse := upgradeNotRecommended
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		helpers.GockExpectAPIRequest(
 			t,
@@ -300,7 +300,7 @@ func TestHTTPServer_GetUpgradeRisksPredictionNotRecommended(t *testing.T) {
 func TestHTTPServer_GetUpgradeRisksPredictionOfflineAMS(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
 		cluster := testdata.GetRandomClusterInfoListAllUnManaged(1)[0].ID
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -331,7 +331,7 @@ func TestHTTPServer_GetUpgradeRisksPredictionClusterNotBelonging(t *testing.T) {
 			clusterInfoList,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(
 			t,
 			testServer,
@@ -360,7 +360,7 @@ func TestHTTPServer_GetUpgradeRisksPredictionNotFound(t *testing.T) {
 			testdata.OrgID,
 			clusterInfoList,
 		)
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		helpers.GockExpectAPIRequest(
 			t,
@@ -403,7 +403,7 @@ func TestHTTPServer_GetUpgradeRisksPredictionInvalidResponse(t *testing.T) {
 			clusterInfoList,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		helpers.GockExpectAPIRequest(
 			t,
 			helpers.DefaultServicesConfig.UpgradeRisksPredictionEndpoint,
@@ -446,7 +446,7 @@ func TestHTTPServer_GetUpgradeRisksPredictionClusterHasNoData(t *testing.T) {
 			clusterInfoList,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		helpers.GockExpectAPIRequest(
 			t,
 			helpers.DefaultServicesConfig.UpgradeRisksPredictionEndpoint,
@@ -489,7 +489,7 @@ func TestHTTPServer_GetUpgradeRisksPredictionUnavailableDataEngineering(t *testi
 			clusterInfoList,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 		iou_helpers.AssertAPIRequest(
 			t,
 			testServer,
@@ -519,7 +519,7 @@ func TestHTTPServer_GetUpgradeRisksPredictionManagedCluster(t *testing.T) {
 			clusterInfoList,
 		)
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, amsClientMock, nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -562,7 +562,7 @@ func TestHTTPServer_GetUpgradeRisksPrediction__timesout(t *testing.T) {
 		servicesConfig.UpgradeRisksPredictionEndpoint = dataEngServer.URL
 		testServer := helpers.CreateHTTPServer(
 			&helpers.DefaultServerConfig, &servicesConfig, amsClientMock,
-			nil, nil, nil, nil)
+			nil, nil, nil, nil, nil)
 
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -582,7 +582,7 @@ func TestHTTPServer_GetUpgradeRisksPrediction__timesout(t *testing.T) {
 
 func TestHTTPServer_GetMulticlusterURPNoBody(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil, nil)
 		expectedResponse := `{"status":"client didn't provide request body"}`
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -603,7 +603,7 @@ func TestHTTPServer_GetMulticlusterURPNoBody(t *testing.T) {
 
 func TestHTTPServer_GetMulticlusterUpgradeRisksServiceUnvailable(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil, nil)
 		expectedResponse := `{"status":"Upgrade Failure Prediction service is unreachable"}`
 		iou_helpers.AssertAPIRequest(
 			t,
@@ -638,7 +638,7 @@ func TestHTTPServer_GetMulticlusterUpgradeRisksPredictionTwoClusters(t *testing.
 
 		servicesConfig := helpers.DefaultServicesConfig
 		servicesConfig.UpgradeRisksPredictionEndpoint = dataEngServer.URL
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, &servicesConfig, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, &servicesConfig, nil, nil, nil, nil, nil, nil)
 
 		cluster1 := "34c3ecc5-624a-49a5-bab8-4fdc5e51a266"
 		cluster2 := "34c3ecc5-624a-49a5-bab8-4fdc5e51a288"
@@ -677,7 +677,7 @@ func TestHTTPServer_GetMulticlusterUpgradeRisksPredictionNoData(t *testing.T) {
 
 		servicesConfig := helpers.DefaultServicesConfig
 		servicesConfig.UpgradeRisksPredictionEndpoint = dataEngServer.URL
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, &servicesConfig, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, &servicesConfig, nil, nil, nil, nil, nil, nil)
 
 		// Same as response from data-eng, but omiting empty values
 		expectedResponse := `
@@ -728,7 +728,7 @@ func TestHTTPServer_GetMulticlusterUpgradeRisksPredictionOneNoData(t *testing.T)
 		servicesConfig := helpers.DefaultServicesConfig
 		servicesConfig.UpgradeRisksPredictionEndpoint = dataEngServer.URL
 
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, &servicesConfig, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, &servicesConfig, nil, nil, nil, nil, nil, nil)
 
 		// Same as response from data-eng, but omiting empty values
 		expectedResponse := `
@@ -794,7 +794,7 @@ func TestHTTPServer_GetMulticlusterUpgradeRisksPredictionMaxAllowedClusters(t *t
 		defer dataEngServer.Close()
 		servicesConfig := helpers.DefaultServicesConfig
 		servicesConfig.UpgradeRisksPredictionEndpoint = dataEngServer.URL
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, &servicesConfig, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, &servicesConfig, nil, nil, nil, nil, nil, nil)
 
 		clusters := generateUUIDs(server.MaxAllowedClusters)
 		reqBody := fmt.Sprintf(`{"clusters": ["%s"]}`, strings.Join(clusters, `","`))
@@ -818,7 +818,7 @@ func TestHTTPServer_GetMulticlusterUpgradeRisksPredictionMaxAllowedClusters(t *t
 
 func TestHTTPServer_GetMulticlusterURPOverMaxAllowed(t *testing.T) {
 	helpers.RunTestWithTimeout(t, func(t testing.TB) {
-		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil)
+		testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil, nil)
 		clusters := generateUUIDs(server.MaxAllowedClusters + 1)
 		reqBody := fmt.Sprintf(`{"clusters": ["%s"]}`, strings.Join(clusters, `","`))
 

--- a/smart_proxy.go
+++ b/smart_proxy.go
@@ -34,6 +34,7 @@ import (
 	"github.com/rs/zerolog/log"
 
 	"github.com/RedHatInsights/insights-results-smart-proxy/amsclient"
+	"github.com/RedHatInsights/insights-results-smart-proxy/auth"
 	"github.com/RedHatInsights/insights-results-smart-proxy/conf"
 	"github.com/RedHatInsights/insights-results-smart-proxy/server"
 	"github.com/RedHatInsights/insights-results-smart-proxy/services"
@@ -113,6 +114,7 @@ func startServer() ExitCode {
 	servicesCfg := conf.GetServicesConfiguration()
 	amsConfig := conf.GetAMSClientConfiguration()
 	redisConf := conf.GetRedisConfiguration()
+	rbacCfg := conf.GetRBACConfiguration()
 	groupsChannel := make(chan []groups.Group)
 	errorFoundChannel := make(chan bool)
 	errorChannel := make(chan error)
@@ -140,7 +142,12 @@ func startServer() ExitCode {
 	}
 	log.Info().Msg("Redis client created, Redis server is responding")
 
-	serverInstance = server.New(serverCfg, servicesCfg, amsClient, redisClient, groupsChannel, errorFoundChannel, errorChannel)
+	rbac, err := auth.NewRBACClient(&rbacCfg)
+	if err != nil {
+		log.Error().Err(err).Msg("failed to initialize RBAC client")
+		return ExitStatusServerError
+	}
+	serverInstance = server.New(serverCfg, servicesCfg, amsClient, redisClient, groupsChannel, errorFoundChannel, errorChannel, rbac)
 
 	// fill-in additional info used by /info endpoint handler
 	fillInInfoParams(serverInstance.InfoParams)

--- a/tests/config1.toml
+++ b/tests/config1.toml
@@ -62,6 +62,6 @@ environment = "test_env"
 debug = true
 
 [rbac]
-host = "https://api.openshift.com"
+url = "https://api.openshift.com"
 enabled = false
 enforce = false

--- a/tests/helpers/http.go
+++ b/tests/helpers/http.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/RedHatInsights/insights-results-smart-proxy/amsclient"
+	"github.com/RedHatInsights/insights-results-smart-proxy/auth"
 	"github.com/RedHatInsights/insights-results-smart-proxy/content"
 
 	"github.com/RedHatInsights/insights-content-service/groups"
@@ -190,6 +191,7 @@ func assertAPIRequest(
 		groupsChannel,
 		errorFoundChannel,
 		errorChannel,
+		nil, // RBAC client
 	)
 
 	// send the request to newly created REST API server and check its
@@ -207,6 +209,7 @@ func CreateHTTPServer(
 	groupsChannel chan []groups.Group,
 	errorFoundChannel chan bool,
 	errorChannel chan error,
+	rbacClient auth.RBACClient,
 ) *server.HTTPServer {
 	// if custom server configuration is not provided, use default one
 	if serverConfig == nil {
@@ -230,5 +233,6 @@ func CreateHTTPServer(
 		groupsChannel,
 		errorFoundChannel,
 		errorChannel,
+		rbacClient,
 	)
 }


### PR DESCRIPTION
# Description

- RBAC Client
- Add authorization middleware in server
- Update UTs (little bit of coupling when it comes to CreateServer method with so much args, one more refactor commit coming)
- Add `rbac` section to configuration files

Part of CCXDEV-12884


# Why this change

After some investigation around [ADR-036](https://docs.google.com/document/d/1LNun1PuvL3EFyfbSWAa6ixUAm-pJoWzQiNJj7hVjkZY/edit?tab=t.0#heading=h.nq1osedn93p8) and a quick discussion with PM, it's been decided that we should support RBAC, mainly because if a consumer of our API uses it with any kind of user, and has configured resource-based access control, we are not enforcing it as of today.

In this change, we introduce the code necessary to handle authorization, but since we don't know which consumers use what and how it can affect them, RBAC is disabled by default and we're doing some extra logging [here](https://github.com/RedHatInsights/insights-results-smart-proxy/pull/1355/files#diff-08316311bca81628634f7ed55949099773edf5af671129d2e6bcbc7dbd1c6825R119) (there's more to come in the next and last PR).

## Type of change

- New feature (non-breaking change which adds functionality)
- Unit tests

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
