### PR TITLE
Add authorization middleware and related config

### DIFF
--- a/auth/configuration.go
+++ b/auth/configuration.go
@@ -27,13 +27,7 @@ import (
 // RBACConfig holds the configuration for RBAC settings.
 type RBACConfig struct {
 	URL         string `mapstructure:"url" toml:"url"`
-	Enabled     bool   `mapstructure:"enabled" toml:"enabled"`
 	EnforceAuth bool   `mapstructure:"enforce" toml:"enforce"`
-}
-
-// IsEnabled returns true if RBAC is enabled in the configuration
-func IsEnabled(config *RBACConfig) bool {
-	return config.Enabled
 }
 
 // constructRBACURL constructs the RBAC URL with the query parameters for checking

--- a/auth/rbac.go
+++ b/auth/rbac.go
@@ -56,6 +56,8 @@ func NewRBACClient(conf *RBACConfig) (RBACClient, error) {
 	}, nil
 }
 
+// IsEnforcing returns wether requests should be denied if the requester does not
+// have the correct permissions.
 func (rc *rbacClientImpl) IsEnforcing() bool {
 	return rc.enforceAuth
 }
@@ -71,6 +73,7 @@ func (rc *rbacClientImpl) getPermissions(identityToken string) map[string][]stri
 	if len(acls) > 0 {
 		permissions := aggregatePermissions(acls)
 		if len(permissions) > 0 {
+			log.Info().Any("RBAC permissions", permissions).Send()
 			return permissions
 		}
 		return nil

--- a/conf/configuration_test.go
+++ b/conf/configuration_test.go
@@ -441,6 +441,5 @@ func TestLoadRBACConfiguration(t *testing.T) {
 	cfg := conf.GetRBACConfiguration()
 
 	assert.Equal(t, "https://api.openshift.com", cfg.URL)
-	assert.Equal(t, false, cfg.Enabled)
 	assert.Equal(t, false, cfg.EnforceAuth)
 }

--- a/config-devel.toml
+++ b/config-devel.toml
@@ -34,6 +34,7 @@ enable_internal_rules_organizations = false
 internal_rules_organizations = []
 log_auth_token = true
 org_clusters_fallback = true
+use_rbac = false
 
 [services]
 aggregator = "http://localhost:8080/api/insights-results-aggregator/v1/"
@@ -55,5 +56,4 @@ timeout_seconds = 30
 
 [rbac]
 url = "https://console.redhat.com/api/rbac/v1"
-enabled = false
 enforce = false

--- a/config.toml
+++ b/config.toml
@@ -28,6 +28,7 @@ enable_internal_rules_organizations = false
 internal_rules_organizations = []
 log_auth_token = true
 org_clusters_fallback = false
+use_rbac = false
 
 [services]
 aggregator = "http://localhost:8080/api/v1/"
@@ -70,5 +71,4 @@ timeout_seconds = 30
 
 [rbac]
 url = "https://console.redhat.com/api/rbac/v1"
-enabled = false
 enforce = false

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -81,6 +81,8 @@ objects:
               value: "${IRSP_ENABLE_INTERNAL_ORGANIZATIONS}"
             - name: INSIGHTS_RESULTS_SMART_PROXY__SERVER__ORG_CLUSTERS_FALLBACK
               value: "${ORG_CLUSTERS_FALLBACK}"
+            - name: INSIGHTS_RESULTS_SMART_PROXY__SERVER__USE_RBAC
+              value: "${USE_RBAC}"
             - name: INSIGHTS_RESULTS_SMART_PROXY__SERVICES__AGGREGATOR
               value: ${INSIGHTS_RESULTS_AGGREGATOR_SERVICE_URL}
             - name: INSIGHTS_RESULTS_SMART_PROXY__SERVICES__CONTENT
@@ -100,6 +102,10 @@ objects:
                   key: password
             - name: INSIGHTS_RESULTS_SMART_PROXY__REDIS__TIMEOUT_SECONDS
               value: ${INSIGHTS_REDIS_TIMEOUT_SECONDS}
+            - name: INSIGHTS_RESULTS_SMART_PROXY__RBAC__URL
+              value: "${RBAC_SERVER_URL}"
+            - name: INSIGHTS_RESULTS_SMART_PROXY__RBAC__ENFORCE
+              value: "${ENFORCE_RBAC}"
             - name: INSIGHTS_RESULTS_SMART_PROXY__SETUP__INTERNAL_RULES_ORGANIZATIONS_CSV_FILE
               value: "${IRSP_INTERNAL_RULES_ORGANIZATIONS_CSV_FILE}"
             - name: INSIGHTS_RESULTS_SMART_PROXY__LOGGING__LOGGING_TO_CLOUD_WATCH_ENABLED
@@ -313,4 +319,9 @@ parameters:
   value: "false"
 - name: ORG_CLUSTERS_FALLBACK
   value: "false"
-
+- name: USE_RBAC
+  value: "false"
+- name: RBAC_SERVER_URL
+  value: "https://console.stage.redhat.com/api/rbac/v1"
+- name: ENFORCE_RBAC
+  value: "false"

--- a/server/configuration.go
+++ b/server/configuration.go
@@ -37,4 +37,5 @@ type Configuration struct {
 	InternalRulesOrganizations       []types.OrgID `mapstructure:"internal_rules_organizations" toml:"internal_rules_organizations"`
 	LogAuthToken                     bool          `mapstructure:"log_auth_token" toml:"log_auth_token"`
 	UseOrgClustersFallback           bool          `mapstructure:"org_clusters_fallback" toml:"org_clusters_fallback"`
+	UseRBAC                          bool          `mapstructure:"use_rbac" toml:"use_rbac"`
 }

--- a/server/server.go
+++ b/server/server.go
@@ -210,6 +210,9 @@ func (server *HTTPServer) Initialize() http.Handler {
 		router.Use(corsMiddleware)
 	}
 
+	if server.Config.UseRBAC {
+		router.Use(func(next http.Handler) http.Handler { return server.Authorization(next) })
+	}
 	server.addEndpointsToRouter(router)
 
 	return router

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -71,6 +71,7 @@ var (
 		EnableCORS:                       false,
 		EnableInternalRulesOrganizations: false,
 		InternalRulesOrganizations:       []ctypes.OrgID{1},
+		UseRBAC:                          false,
 	}
 
 	serverConfigInternalOrganizations1 = server.Configuration{


### PR DESCRIPTION
# Description

The actual authorization middleware. As mentioned in previous PRs, we use a set of environment variables to ensure nothing is done with the data received from RBAC, aside from [some logging](https://github.com/RedHatInsights/insights-results-smart-proxy/compare/master...epapbak:insights-results-smart-proxy:CCXDEV-12884?expand=1#diff-acb167bc7fa8fba4c04f9a19a915331c3dd6e3fb0421dfa50986e9e081180decR96).

Part 4 (probably of 5) of CCXDEV-12884

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- This change requires a documentation update

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
