### PR TITLE
Avoid RBAC for requests that do not require authorization

### DIFF
--- a/server/auth_middleware_test.go
+++ b/server/auth_middleware_test.go
@@ -317,7 +317,7 @@ func TestAuthorizationMiddleware(t *testing.T) {
 				w.WriteHeader(http.StatusOK)
 			})
 
-			authHandler := testServer.Authorization(handler)
+			authHandler := testServer.Authorization(handler, nil)
 
 			authHandler.ServeHTTP(recorder, req)
 

--- a/server/export_test.go
+++ b/server/export_test.go
@@ -29,4 +29,5 @@ package server
 var (
 	FillImpacted      = fillImpacted
 	HandleServerError = handleServerError
+	AcmUserAgent      = acmUserAgent
 )

--- a/server/server.go
+++ b/server/server.go
@@ -31,7 +31,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -189,42 +188,6 @@ func (server *HTTPServer) Initialize() http.Handler {
 	server.addEndpointsToRouter(router)
 
 	return router
-}
-
-// setupAuthMiddleware sets up the authentication and authorization middlewares
-// for the given router.
-func (server *HTTPServer) setupAuthMiddleware(router *mux.Router) {
-	apiPrefix := server.Config.APIv1Prefix
-
-	metricsURL := apiPrefix + MetricsEndpoint
-	openAPIv1URL := apiPrefix + filepath.Base(server.Config.APIv1SpecFile)
-	openAPIv2URL := server.Config.APIv2Prefix + filepath.Base(server.Config.APIv2SpecFile)
-	infoV1URL := apiPrefix + InfoEndpoint
-	infoV2URL := server.Config.APIv2Prefix + InfoEndpoint
-
-	// Define noAuthURLs for use in authentication and authorization middleware
-	noAuthURLs := []string{
-		metricsURL,
-		openAPIv1URL,
-		openAPIv2URL,
-		infoV1URL,
-		infoV2URL,
-		metricsURL + "?",   // to be able to test using Frisby
-		openAPIv1URL + "?", // to be able to test using Frisby
-		openAPIv2URL + "?", // to be able to test using Frisby
-	}
-
-	if server.Config.Auth {
-		router.Use(func(next http.Handler) http.Handler {
-			return server.Authentication(next, noAuthURLs)
-		})
-	}
-
-	if server.Config.UseRBAC {
-		router.Use(func(next http.Handler) http.Handler {
-			return server.Authorization(next, noAuthURLs)
-		})
-	}
 }
 
 func (server *HTTPServer) addEndpointsToRouter(router *mux.Router) {


### PR DESCRIPTION
# Description

- Same as we do for authentication, for `HTTP OPTIONS` and metric related URLS, let's skip RBAC.
- Also skip RBAC for requests that come from ACM

Part of CCXDEV-12884

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

CI

## Checklist
* [x] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
