### PR TITLE
[CCXDEV-12871] Allow user access even if RBAC is enabled and remove ACM wildcard

### DIFF
--- a/auth/configuration.go
+++ b/auth/configuration.go
@@ -45,7 +45,7 @@ func constructRBACURL(config *RBACConfig) (string, string, error) {
 	}
 
 	// Add the /access/ endpoint and ocp-advisor parameter
-	baseURL.Path = "/access/"
+	baseURL.Path += "/access/"
 
 	params := url.Values{}
 	params.Add("application", "ocp-advisor")

--- a/auth/configuration_test.go
+++ b/auth/configuration_test.go
@@ -42,8 +42,15 @@ func TestConstructRBACURL(t *testing.T) {
 			expectError:  false,
 		},
 		{
+			// ephemeral case:
+			config:       &auth.RBACConfig{URL: "http://rbac-service:8000/api/rbac/v1"},
+			expectedURL:  "http://rbac-service:8000/api/rbac/v1/access/?application=ocp-advisor&limit=100",
+			expectedHost: "rbac-service:8000",
+			expectError:  false,
+		},
+		{
 			config:       &auth.RBACConfig{URL: "wrong-schema:/invalid"},
-			expectedURL:  "https://wrong-schema:/access/?application=ocp-advisor&limit=100",
+			expectedURL:  "https://wrong-schema:/invalid/access/?application=ocp-advisor&limit=100",
 			expectedHost: "wrong-schema:",
 			expectError:  false, //url.Parse and url.ParseURI can't catch bad URLs, careful!
 		},

--- a/auth/rbac.go
+++ b/auth/rbac.go
@@ -65,14 +65,14 @@ func (rc *rbacClientImpl) IsEnforcing() bool {
 // IsAuthorized checks if an account has the correct permissions to access our resources
 func (rc *rbacClientImpl) IsAuthorized(token string) bool {
 	permissions := rc.getPermissions(token)
-	log.Debug().Interface("permissions", permissions).Msg("Account openshift permissions")
+	log.Info().Interface("permissions", permissions).Msg("Account openshift permissions")
 	return permissions != nil
 }
 
 func (rc *rbacClientImpl) getPermissions(identityToken string) map[string][]string {
 	acls := rc.requestAccess(rc.uri, identityToken)
 	if len(acls) > 0 {
-		log.Debug().Interface("acls", acls).Msg("Account all permissions")
+		log.Info().Interface("acls", acls).Msg("Account all permissions")
 		permissions := aggregatePermissions(acls)
 		if len(permissions) > 0 {
 			log.Info().Any("RBAC openshift permissions", permissions).Send()
@@ -80,7 +80,7 @@ func (rc *rbacClientImpl) getPermissions(identityToken string) map[string][]stri
 		}
 		return nil
 	}
-	log.Debug().Msg("Account has no ACLs")
+	log.Info().Msg("Account has no ACLs")
 	return nil
 }
 

--- a/auth/rbac.go
+++ b/auth/rbac.go
@@ -65,19 +65,22 @@ func (rc *rbacClientImpl) IsEnforcing() bool {
 // IsAuthorized checks if an account has the correct permissions to access our resources
 func (rc *rbacClientImpl) IsAuthorized(token string) bool {
 	permissions := rc.getPermissions(token)
+	log.Debug().Interface("permissions", permissions).Msg("Account openshift permissions")
 	return permissions != nil
 }
 
 func (rc *rbacClientImpl) getPermissions(identityToken string) map[string][]string {
 	acls := rc.requestAccess(rc.uri, identityToken)
 	if len(acls) > 0 {
+		log.Debug().Interface("acls", acls).Msg("Account all permissions")
 		permissions := aggregatePermissions(acls)
 		if len(permissions) > 0 {
-			log.Info().Any("RBAC permissions", permissions).Send()
+			log.Info().Any("RBAC openshift permissions", permissions).Send()
 			return permissions
 		}
 		return nil
 	}
+	log.Debug().Msg("Account has no ACLs")
 	return nil
 }
 

--- a/auth/rbac.go
+++ b/auth/rbac.go
@@ -65,14 +65,14 @@ func (rc *rbacClientImpl) IsEnforcing() bool {
 // IsAuthorized checks if an account has the correct permissions to access our resources
 func (rc *rbacClientImpl) IsAuthorized(token string) bool {
 	permissions := rc.getPermissions(token)
-	log.Info().Interface("permissions", permissions).Msg("Account openshift permissions")
+	log.Debug().Interface("permissions", permissions).Msg("Account openshift permissions")
 	return permissions != nil
 }
 
 func (rc *rbacClientImpl) getPermissions(identityToken string) map[string][]string {
 	acls := rc.requestAccess(rc.uri, identityToken)
 	if len(acls) > 0 {
-		log.Info().Interface("acls", acls).Msg("Account all permissions")
+		log.Debug().Interface("acls", acls).Msg("Account all permissions")
 		permissions := aggregatePermissions(acls)
 		if len(permissions) > 0 {
 			log.Info().Any("RBAC openshift permissions", permissions).Send()
@@ -80,7 +80,7 @@ func (rc *rbacClientImpl) getPermissions(identityToken string) map[string][]stri
 		}
 		return nil
 	}
-	log.Info().Msg("Account has no ACLs")
+	log.Debug().Msg("Account has no ACLs")
 	return nil
 }
 

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -320,8 +320,8 @@ parameters:
 - name: ORG_CLUSTERS_FALLBACK
   value: "false"
 - name: USE_RBAC
-  value: "true"
+  value: "false"
 - name: RBAC_SERVER_URL
   value: "http://rbac-service:8000/api/rbac/v1"
 - name: ENFORCE_RBAC
-  value: "true"
+  value: "false"

--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -320,8 +320,8 @@ parameters:
 - name: ORG_CLUSTERS_FALLBACK
   value: "false"
 - name: USE_RBAC
-  value: "false"
+  value: "true"
 - name: RBAC_SERVER_URL
-  value: "https://console.stage.redhat.com/api/rbac/v1"
+  value: "http://rbac-service:8000/api/rbac/v1"
 - name: ENFORCE_RBAC
-  value: "false"
+  value: "true"

--- a/server/auth_middleware.go
+++ b/server/auth_middleware.go
@@ -137,7 +137,7 @@ func (server *HTTPServer) Authorization(next http.Handler, noAuthURLs []string) 
 		// be for all users, but let's first make sure we won't disturb existing users by only
 		// logging unauthorized service accounts
 		if token.Identity.Type == "ServiceAccount" {
-			log.Debug().Str("client ID", token.Identity.ServiceAccount.ClientID).Msg("Received a request from a service account")
+			log.Info().Str("client ID", token.Identity.ServiceAccount.ClientID).Msg("Received a request from a service account")
 			// Check permissions for service accounts
 			if !server.rbacClient.IsAuthorized(auth.GetAuthTokenHeader(r)) {
 				log.Warn().Str(accountType, token.Identity.Type).Msg(accountNotAuthorized)

--- a/server/auth_middleware.go
+++ b/server/auth_middleware.go
@@ -143,6 +143,7 @@ func (server *HTTPServer) Authorization(next http.Handler, noAuthURLs []string) 
 		// be for all users, but let's first make sure we won't disturb existing users by only
 		// logging unauthorized service accounts
 		if token.Identity.Type == "ServiceAccount" {
+			log.Debug().Str("client ID", token.Identity.ServiceAccount.ClientID).Msg("Received a request from a service account")
 			// Check permissions for service accounts
 			if !server.rbacClient.IsAuthorized(auth.GetAuthTokenHeader(r)) {
 				log.Warn().Str(accountType, token.Identity.Type).Msg(accountNotAuthorized)
@@ -154,7 +155,8 @@ func (server *HTTPServer) Authorization(next http.Handler, noAuthURLs []string) 
 		} else {
 			log.Debug().Str(accountType, token.Identity.Type).Msg("RBAC is only used with service accounts for now")
 			// handleServerError(w, &auth.AuthorizationError{ErrString: "unknown identity type"})
-			return
+			// We don't use return because RBAC is not mandatory for users yet
+			// return
 		}
 
 		// Access is authorized, proceed with the request

--- a/server/auth_middleware.go
+++ b/server/auth_middleware.go
@@ -137,7 +137,7 @@ func (server *HTTPServer) Authorization(next http.Handler, noAuthURLs []string) 
 		// be for all users, but let's first make sure we won't disturb existing users by only
 		// logging unauthorized service accounts
 		if token.Identity.Type == "ServiceAccount" {
-			log.Info().Str("client ID", token.Identity.ServiceAccount.ClientID).Msg("Received a request from a service account")
+			log.Debug().Str("client ID", token.Identity.ServiceAccount.ClientID).Msg("Received a request from a service account")
 			// Check permissions for service accounts
 			if !server.rbacClient.IsAuthorized(auth.GetAuthTokenHeader(r)) {
 				log.Warn().Str(accountType, token.Identity.Type).Msg(accountNotAuthorized)

--- a/server/auth_middleware.go
+++ b/server/auth_middleware.go
@@ -127,12 +127,6 @@ func (server *HTTPServer) Authorization(next http.Handler, noAuthURLs []string) 
 			return
 		}
 
-		// We also leave ACM folks out of this for now
-		if server.getKnownUserAgentProduct(r) == acmUserAgent {
-			next.ServeHTTP(w, r)
-			return
-		}
-
 		token, err := auth.DecodeTokenFromHeader(w, r, server.Config.AuthType)
 		if err != nil {
 			handleServerError(w, err)

--- a/server/auth_middleware_test.go
+++ b/server/auth_middleware_test.go
@@ -353,31 +353,3 @@ func TestAuthorization_NoAuthURLs(t *testing.T) {
 	// Verify that the response is OK and RBAC was not used
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
-
-func TestAuthorization_ACMUserAgent(t *testing.T) {
-	// Setup the server and the request
-	rbacClient := &MockRBACClient{authorized: false, enforcing: true}
-	testServer := server.HTTPServer{
-		Config: server.Configuration{
-			Auth:     true,
-			AuthType: "xrh",
-			UseRBAC:  true,
-		},
-	}
-	testServer.SetRBACClient(rbacClient)
-
-	// Create a request with the ACM user agent
-	req := httptest.NewRequest(http.MethodGet, "/some-endpoint", nil)
-	req.Header.Set("User-Agent", server.AcmUserAgent)
-	rr := httptest.NewRecorder()
-
-	// Call the authorization middleware
-	handler := testServer.Authorization(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}), []string{})
-
-	handler.ServeHTTP(rr, req)
-
-	// Verify that the response is OK and RBAC was not used
-	assert.Equal(t, http.StatusOK, rr.Code)
-}


### PR DESCRIPTION
# Description

We decided to support both services accounts (with RBAC) and the current user access, thus we cannot `return` on the `Authorization` function. Also, as we allow users to authenticate, we don't need to define a wildcard for ACM.

This is mainly needed because otherwise we cannot develop iqe tests using `USE_RBAC`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

UTs.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
