### PR TITLE
[CCXDEV-9719] Remove obsolete debug endpoints

### DIFF
--- a/server/endpoints_dbg.go
+++ b/server/endpoints_dbg.go
@@ -22,12 +22,6 @@ import (
 )
 
 const (
-	// DbgOrganizationsEndpoint returns all organizations. DEBUG only
-	DbgOrganizationsEndpoint = ira_server.OrganizationsEndpoint
-	// DbgDeleteOrganizationsEndpoint deletes all {organizations}(comma separated array). DEBUG only
-	DbgDeleteOrganizationsEndpoint = ira_server.DeleteOrganizationsEndpoint
-	// DbgDeleteClustersEndpoint deletes all {clusters}(comma separated array). DEBUG only
-	DbgDeleteClustersEndpoint = ira_server.DeleteClustersEndpoint
 	// DbgGetVoteOnRuleEndpoint is an endpoint to get vote on rule. DEBUG only
 	DbgGetVoteOnRuleEndpoint = "clusters/{cluster}/rules/{rule_id}/error_key/{error_key}/get_vote"
 )
@@ -36,10 +30,6 @@ const (
 func (server *HTTPServer) adddbgEndpointsToRouter(router *mux.Router) {
 	apiPrefix := server.Config.APIdbgPrefix
 	aggregatorBaseEndpoint := server.ServicesConfig.AggregatorBaseEndpoint
-
-	router.HandleFunc(apiPrefix+DbgOrganizationsEndpoint, server.proxyTo(aggregatorBaseEndpoint, nil)).Methods(http.MethodGet)
-	router.HandleFunc(apiPrefix+DbgDeleteOrganizationsEndpoint, server.proxyTo(aggregatorBaseEndpoint, nil)).Methods(http.MethodDelete)
-	router.HandleFunc(apiPrefix+DbgDeleteClustersEndpoint, server.proxyTo(aggregatorBaseEndpoint, nil)).Methods(http.MethodDelete)
 
 	router.HandleFunc(apiPrefix+DbgGetVoteOnRuleEndpoint, server.proxyTo(
 		aggregatorBaseEndpoint,

--- a/server/export_test.go
+++ b/server/export_test.go
@@ -30,4 +30,5 @@ var (
 	FillImpacted      = fillImpacted
 	HandleServerError = handleServerError
 	AcmUserAgent      = acmUserAgent
+	ComposeEndpoint   = (*HTTPServer).composeEndpoint
 )

--- a/server/server.go
+++ b/server/server.go
@@ -355,7 +355,15 @@ func sendRequest(
 
 func (server *HTTPServer) composeEndpoint(baseEndpoint, currentEndpoint string) (*url.URL, error) {
 	endpoint := strings.TrimPrefix(currentEndpoint, server.Config.APIv1Prefix)
-	return url.Parse(baseEndpoint + endpoint)
+	endpoint = strings.TrimPrefix(endpoint, server.Config.APIv2Prefix)
+	endpoint = strings.TrimPrefix(endpoint, server.Config.APIdbgPrefix)
+
+	joinedURL, err := url.JoinPath(baseEndpoint, endpoint)
+	if err != nil {
+		log.Error().Err(err).Str("api", baseEndpoint).Str("endpoint", currentEndpoint).Msg("Error while joining endpoint to given API URL")
+		return nil, err
+	}
+	return url.Parse(joinedURL)
 }
 
 func copyHeader(srcHeaders, dstHeaders http.Header) {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1321,6 +1321,44 @@ func TestInfoEndpointNoAuthToken(t *testing.T) {
 	})
 }
 
+// TestComposeEndpoint checks that composeEndpoint method correctly remove the API prefix
+func TestComposeEndpoint(t *testing.T) {
+	type testCase struct {
+		name     string
+		endpoint string
+	}
+	testCases := []testCase{
+		{
+			"test removal of v1 API prefix",
+			"/api/v1/endpoint",
+		},
+		{
+			"test removal of v2 API prefix",
+			"/api/dbg/endpoint",
+		},
+		{
+			"test removal of dbg API prefix",
+			"/api/dbg/endpoint",
+		},
+		{
+			"test that nothing is removed if prefix is missing",
+			"/endpoint",
+		},
+	}
+
+	testServer := helpers.CreateHTTPServer(&helpers.DefaultServerConfig, nil, nil, nil, nil, nil, nil, nil)
+	baseEndpoint := helpers.DefaultServicesConfig.AggregatorBaseEndpoint
+	expectedResponse := "http://localhost:8080/endpoint"
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			endpoint, err := server.ComposeEndpoint(testServer, baseEndpoint, tc.endpoint)
+			assert.NoError(t, err)
+			assert.Equal(t, expectedResponse, endpoint.String())
+		})
+	}
+}
+
 func ruleIDsChecker(t testing.TB, expected, got []byte) {
 	type Response struct {
 		Status string   `json:"status"`


### PR DESCRIPTION
# Description

Remove obsolete debug endpoints + fix composeEndpoint function to remove any API prefix, not only v1.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

New unit test + check endpoint locally.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
