### PR TITLE
fix an edge case where an `org_id` from 3scale matches multiple internal organizations in OCM AMS API

### DIFF
--- a/amsclient/amsclient.go
+++ b/amsclient/amsclient.go
@@ -15,8 +15,10 @@
 package amsclient
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -128,14 +130,12 @@ func (c *amsClientImpl) GetClustersForOrganization(orgID types.OrgID, statusFilt
 	clusterInfoList []types.ClusterInfo,
 	err error,
 ) {
-	//TODO check the toggle caching option from conf [CCXDEV-13018]
-	//if c.clusterListCaching {}
 	log.Debug().Uint32(orgIDTag, uint32(orgID)).Msg("Looking up active clusters for the organization")
 	log.Debug().Uint32(orgIDTag, uint32(orgID)).Msgf("GetClustersForOrganization start. AMS client page size %v", c.pageSize)
 
 	tStart := time.Now()
 
-	internalOrgID, err := c.GetInternalOrgIDFromExternal(orgID)
+	internalOrgIDs, err := c.GetInternalOrgIDFromExternal(orgID)
 	if err != nil {
 		return
 	}
@@ -144,8 +144,9 @@ func (c *amsClientImpl) GetClustersForOrganization(orgID types.OrgID, statusFilt
 		statusNegativeFilter = DefaultStatusNegativeFilters
 	}
 
-	searchQuery := generateSearchParameter(internalOrgID, statusFilter, statusNegativeFilter)
 	subscriptionListRequest := c.connection.AccountsMgmt().V1().Subscriptions().List()
+
+	searchQuery := generateSingleClusterSearch(internalOrgIDs, statusFilter, statusNegativeFilter)
 
 	clusterInfoList, err = c.executeSubscriptionListRequest(subscriptionListRequest, searchQuery)
 	if err != nil {
@@ -187,12 +188,16 @@ func (c *amsClientImpl) GetSingleClusterInfoForOrganization(orgID types.OrgID, c
 ) {
 	tStart := time.Now()
 
-	internalOrgID, err := c.GetInternalOrgIDFromExternal(orgID)
+	internalOrgIDs, err := c.GetInternalOrgIDFromExternal(orgID)
 	if err != nil {
 		return
 	}
 
-	searchQuery := fmt.Sprintf("organization_id = '%s' and external_cluster_id = '%s'", internalOrgID, clusterID)
+	searchQuery := fmt.Sprintf(
+		"organization_id in ('%s') and external_cluster_id = '%s'",
+		strings.Join(internalOrgIDs, "','"),
+		clusterID,
+	)
 
 	subscriptionListRequest := c.connection.AccountsMgmt().V1().Subscriptions().List()
 	clusterInfoList, err := c.executeSubscriptionListRequest(subscriptionListRequest, searchQuery)
@@ -210,12 +215,17 @@ func (c *amsClientImpl) GetSingleClusterInfoForOrganization(orgID types.OrgID, c
 	return clusterInfoList[0], nil
 }
 
-// GetInternalOrgIDFromExternal will retrieve the internal organization ID from an external one using AMS API
-func (c *amsClientImpl) GetInternalOrgIDFromExternal(orgID types.OrgID) (string, error) {
+// GetInternalOrgIDFromExternal will retrieve the internal organization IDs (used internally in OCM API)
+// from the external org ID (used in c.r.c. systems) using the AMS API. One external org ID might
+// represent multiple internal org IDs, but they still match the same external org ID which we save in the DB.
+func (c *amsClientImpl) GetInternalOrgIDFromExternal(orgID types.OrgID) (
+	orgIDs []string, err error,
+) {
 	log.Debug().Uint32(orgIDTag, uint32(orgID)).Msg(
-		"Looking for the internal organization ID for an external one",
+		"Looking for the internal organization IDs from an external one",
 	)
 	orgsListRequest := c.connection.AccountsMgmt().V1().Organizations().List()
+
 	response, err := orgsListRequest.
 		Search(fmt.Sprintf("external_id = %d", orgID)).
 		Fields("id,external_id").
@@ -223,21 +233,36 @@ func (c *amsClientImpl) GetInternalOrgIDFromExternal(orgID types.OrgID) (string,
 
 	if err != nil {
 		log.Warn().Err(err).Msg(orgIDRequestFailure)
-		return "", err
+		return
 	}
 
-	if response.Items().Len() != 1 {
-		log.Error().Uint32(orgIDTag, uint32(orgID)).Msg(orgMoreInternalOrgs)
-		return "", fmt.Errorf(orgMoreInternalOrgs)
+	orgIDs = make([]string, response.Items().Len())
+
+	// AMS API doesn't know this org_id. Out of our control, but ultimately fixable by user.
+	// If AMS is enabled, we're relying on it, meaning this has to result in a 403
+	if len(orgIDs) == 0 {
+		err := errors.New(orgNoInternalID)
+		log.Error().Uint32(orgIDTag, uint32(orgID)).Err(err)
+		return nil, &utypes.ForbiddenError{ErrString: "An external API doesn't know about your organization yet."}
 	}
 
-	internalID, ok := response.Items().Get(0).GetID()
-	if !ok {
-		log.Error().Uint32(orgIDTag, uint32(orgID)).Msg(orgNoInternalID)
-		return "", fmt.Errorf(orgNoInternalID)
+	// special case, could possibly cause edge cases down the road, keep the debug log
+	if len(orgIDs) > 1 {
+		log.Debug().Uint32(orgIDTag, uint32(orgID)).Msg(orgMoreInternalOrgs)
 	}
 
-	return internalID, nil
+	for i, item := range response.Items().Slice() {
+		internalID, ok := item.GetID()
+		if !ok {
+			err := errors.New(orgIDRequestFailure)
+			log.Error().Uint32(orgIDTag, uint32(orgID)).Err(err)
+			return nil, err
+		}
+
+		orgIDs[i] = internalID
+	}
+
+	return orgIDs, nil
 }
 
 func (c *amsClientImpl) executeSubscriptionListRequest(

--- a/amsclient/amsclient_test.go
+++ b/amsclient/amsclient_test.go
@@ -32,19 +32,26 @@ import (
 	"github.com/RedHatInsights/insights-results-smart-proxy/types"
 )
 
+// OCM SDK encodes URLs with escaped hex characters
+// %%2C means ,
+// %%3D means =
+// %%21 means !
+// %28%27 %27%29 means (' ')
 const (
 	organizationsSearchEndpoint = "api/accounts_mgmt/v1/organizations?fields=id%%2Cexternal_id&search=external_id+%%3D+{orgID}"
 
 	subscriptionsSearchEndpoint = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id%%2Cdisplay_name%%2Ccluster_id%%2Cmanaged%%2Cstatus&page={pageNum}&" +
-		"search=organization_id+is+%%27{orgID}%%27+and+cluster_id+%%21%%3D+%%27%%27&size={pageSize}")
+		"search=organization_id+in+%%28%%27{orgID}%%27%%29+and+cluster_id+%%21%%3D+%%27%%27&size={pageSize}")
+	subscriptionsSearchEndpointMultipleOrgs = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id%%2Cdisplay_name%%2Ccluster_id%%2Cmanaged%%2Cstatus&page={pageNum}&" +
+		"search=organization_id+in+%%28%%27{orgID1}%%27%%2C%%27{orgID2}%%27%%29+and+cluster_id+%%21%%3D+%%27%%27&size={pageSize}")
 	subscriptionsSearchEndpointWithFilter = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id%%2Cdisplay_name%%2Ccluster_id%%2Cmanaged%%2Cstatus&page={pageNum}&" +
-		"search=organization_id+is+%%27{orgID}%%27+and+cluster_id+%%21%%3D+%%27%%27+and+status+in+%%28%%27{status1}%%27%%2C%%27{status2}%%27%%29&size={pageSize}")
+		"search=organization_id+in+%%28%%27{orgID}%%27%%29+and+cluster_id+%%21%%3D+%%27%%27+and+status+in+%%28%%27{status1}%%27%%2C%%27{status2}%%27%%29&size={pageSize}")
 	subscriptionsSearchEndpointWithDefaultFilter = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id%%2Cdisplay_name%%2Ccluster_id%%2Cmanaged%%2Cstatus&page={pageNum}&" +
-		"search=organization_id+is+%%27{orgID}%%27+and+cluster_id+%%21%%3D+%%27%%27+and+status+not+in+%%28%%27{status1}%%27%%2C%%27{status2}%%27%%2C%%27{status3}%%27%%29&size={pageSize}")
+		"search=organization_id+in+%%28%%27{orgID}%%27%%29+and+cluster_id+%%21%%3D+%%27%%27+and+status+not+in+%%28%%27{status1}%%27%%2C%%27{status2}%%27%%2C%%27{status3}%%27%%29&size={pageSize}")
 	clusterDetailsSearchEndpoint = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id%%2Cdisplay_name%%2Ccluster_id%%2Cmanaged%%2Cstatus&page={pageNum}&" +
 		"search=external_cluster_id+%%3D+%%27{clusterID}%%27&size={pageSize}")
 	singleClusterInfoEndpoint = ("api/accounts_mgmt/v1/subscriptions?fields=external_cluster_id%%2Cdisplay_name%%2Ccluster_id%%2Cmanaged%%2Cstatus&page={pageNum}&" +
-		"search=organization_id+%%3D+%%27{orgID}%%27+and+external_cluster_id+%%3D+%%27{clusterID}%%27&size={pageSize}")
+		"search=organization_id+in+%%28%%27{orgID}%%27%%29+and+external_cluster_id+%%3D+%%27{clusterID}%%27&size={pageSize}")
 )
 
 var (
@@ -125,6 +132,77 @@ func TestClusterForOrganization(t *testing.T) {
 		Method:       http.MethodGet,
 		Endpoint:     subscriptionsSearchEndpoint,
 		EndpointArgs: []interface{}{2, testdata.InternalOrgID, defaultConfig.PageSize},
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusOK,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body: helpers.ToJSONString(testdata.SubscriptionEmptyResponse),
+	})
+
+	clusterList, err := c.GetClustersForOrganization(testdata.ExternalOrgID, nil, []string{})
+	helpers.FailOnError(t, err)
+	assert.Equal(t, 2, len(clusterList))
+	assert.ElementsMatch(t, testdata.OKClustersForOrganization, clusterList)
+}
+
+func TestClusterForOrganizationNoInternalOrgID(t *testing.T) {
+	defer helpers.CleanAfterGock(t)
+	c, err := amsclient.NewAMSClientWithTransport(defaultConfig, gock.DefaultTransport)
+	helpers.FailOnError(t, err)
+
+	// prepare organizations response
+	helpers.GockExpectAPIRequest(t, defaultConfig.URL, &helpers.APIRequest{
+		Method:       http.MethodGet,
+		Endpoint:     organizationsSearchEndpoint,
+		EndpointArgs: []interface{}{testdata.ExternalOrgID},
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusOK,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body: helpers.ToJSONString(testdata.OrganizationResponseNoID),
+	})
+
+	_, err = c.GetClustersForOrganization(testdata.ExternalOrgID, nil, []string{})
+	assert.ErrorContains(t, err, "An external API doesn't know about your organization yet.")
+}
+
+func TestClusterForOrganization2InternalOrgIDs(t *testing.T) {
+	defer helpers.CleanAfterGock(t)
+	c, err := amsclient.NewAMSClientWithTransport(defaultConfig, gock.DefaultTransport)
+	helpers.FailOnError(t, err)
+
+	// prepare organizations response
+	helpers.GockExpectAPIRequest(t, defaultConfig.URL, &helpers.APIRequest{
+		Method:       http.MethodGet,
+		Endpoint:     organizationsSearchEndpoint,
+		EndpointArgs: []interface{}{testdata.ExternalOrgID},
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusOK,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body: helpers.ToJSONString(testdata.OrganizationResponse2IDs),
+	})
+
+	// prepare cluster list request response
+	helpers.GockExpectAPIRequest(t, defaultConfig.URL, &helpers.APIRequest{
+		Method:       http.MethodGet,
+		Endpoint:     subscriptionsSearchEndpointMultipleOrgs,
+		EndpointArgs: []interface{}{1, testdata.InternalOrgID, testdata.InternalOrgID2, defaultConfig.PageSize},
+	}, &helpers.APIResponse{
+		StatusCode: http.StatusOK,
+		Headers: map[string]string{
+			"Content-Type": "application/json",
+		},
+		Body: helpers.ToJSONString(testdata.SubscriptionsResponse),
+	})
+	// second and more requests will be done until the last one returns an empty response (0 sized)
+	helpers.GockExpectAPIRequest(t, defaultConfig.URL, &helpers.APIRequest{
+		Method:       http.MethodGet,
+		Endpoint:     subscriptionsSearchEndpointMultipleOrgs,
+		EndpointArgs: []interface{}{2, testdata.InternalOrgID, testdata.InternalOrgID2, defaultConfig.PageSize},
 	}, &helpers.APIResponse{
 		StatusCode: http.StatusOK,
 		Headers: map[string]string{

--- a/amsclient/utils.go
+++ b/amsclient/utils.go
@@ -19,9 +19,9 @@ import (
 	"strings"
 )
 
-// generateSearchParameter generates a search string for given org_id and desired statuses
-func generateSearchParameter(orgID string, allowedStatuses, disallowedStatuses []string) string {
-	searchQuery := fmt.Sprintf("organization_id is '%s' and cluster_id != ''", orgID)
+// generateSingleClusterSearch generates a search string for given internal org IDs and desired statuses
+func generateSingleClusterSearch(orgIDs []string, allowedStatuses, disallowedStatuses []string) string {
+	searchQuery := fmt.Sprintf("organization_id in ('%s') and cluster_id != ''", strings.Join(orgIDs, "','"))
 
 	if len(allowedStatuses) > 0 {
 		clusterIDQuery := " and status in ('" + strings.Join(allowedStatuses, "','") + "')"

--- a/tests/testdata/amstestdata.go
+++ b/tests/testdata/amstestdata.go
@@ -55,7 +55,8 @@ var (
 		},
 	}
 
-	// OrganizationResponse2IDs contains a correct response, but with 2 orgs, which should not happen
+	// OrganizationResponse2IDs contains a correct response, but with 2 orgs, which might happen temporarily during
+	// ownership or membership transfer.
 	OrganizationResponse2IDs map[string]interface{} = map[string]interface{}{
 		"kind":  "OrganizationList",
 		"page":  1,
@@ -71,6 +72,17 @@ var (
 				"id":          InternalOrgID2,
 			},
 		},
+	}
+
+	// OrganizationResponseNoID contains a correct response, but no internal org matching the external one.
+	// Might happen as a temprary state before OCM gets the information about a newly created account, but our API
+	// shouldn't return 5xx as it's ultimately fixable by the user or external systems.
+	OrganizationResponseNoID map[string]interface{} = map[string]interface{}{
+		"kind":  "OrganizationList",
+		"page":  0,
+		"size":  0,
+		"total": 0,
+		"items": []map[string]interface{}{},
 	}
 
 	// SubscriptionsResponse contains a valid response for subscription from AMS, 2 clusters


### PR DESCRIPTION
# Description
- there is an internal `org_id` used in the OCM AMS API which has to be retrieved from the `/organizations` endpoint.
- the `amsclient` module was implemented in a way that we always expected exactly one internal organization to be returned from the endpoint
- however a single external `org_id` (which we receive in the auth token from 3scale) can represent multiple internal `org_id`s in the OCM/AMS world. This might happen during an ownership/membership transfer, ensuring the user is not left in a state with no ID and can still access their data.
- it's also possible that the external `org_id` doesn't have an internal counterpart yet. This happens when a new account is created, 3scale and SSO are already aware of it, but OCM isn't.

Both of the described edge cases should be temporary, however both of them are ultimately fixable by the user or external systems, so our API shouldn't return 5xx. Any previously problematic `org_id` that I've tried is already working correctly (i.e. only returning one org).

This PR fixes both of these special cases.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)
- Unit tests (no changes in the code)
- Documentation update

## Testing steps
`make before_commit` although golangci-lint is not behaving correctly locally.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
