### PR TITLE
fix(CI): use ubuntu-latest

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -21,7 +21,7 @@ on:
 
 jobs:
   bdd:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         go-version:


### PR DESCRIPTION
# Description

Use ubuntu-latest as 20.04 was deprecated.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
