### PR TITLE
Run CI workflows with Go 1.23

### DIFF
--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -22,10 +22,6 @@ on:
 jobs:
   bdd:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version:
-          - "1.23"
     name: BDD tests
     steps:
       - uses: actions/checkout@v4
@@ -35,7 +31,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: "1.23"
       - name: Build project
         run: make build
       - name: Retrieve Docker compose file

--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -25,7 +25,7 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.22"
+          - "1.23"
     name: BDD for Go ${{ matrix.go-version}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/bdd.yml
+++ b/.github/workflows/bdd.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         go-version:
           - "1.23"
-    name: BDD for Go ${{ matrix.go-version}}
+    name: BDD tests
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -25,8 +25,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.22"
           - "1.23"
+          - "1.24"
     name: Tests for Go ${{ matrix.go-version}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         go-version:
           - "1.23"
-    name: Linters for Go ${{ matrix.go-version}}
+    name: Linters
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -25,7 +25,6 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.22"
           - "1.23"
     name: Linters for Go ${{ matrix.go-version}}
     steps:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -22,17 +22,13 @@ on:
 jobs:
   golint:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version:
-          - "1.23"
     name: Linters
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: "1.23"
       - name: Build project
         run: make
       - name: shellcheck


### PR DESCRIPTION


# Description

Run CI workflows with Go 1.23 and set the tests to also run with 1.24

## Type of change

- Configuration update

## Testing steps

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
