### PR TITLE
[CCXDEB-15184] Add custom renovate.json config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,22 +1,8 @@
 {
   "gomod": {
-    "schedule": [
-      "after 5am on sunday"
-    ],
-    "postUpdateOptions": [
-      "gomodUpdateImportPaths",
-      "gomodTidy"
-    ],
     "packageRules": [
       {
-        "matchManagers": [
-          "gomod"
-        ],
-        "matchDepTypes": [
-          "indirect"
-        ],
-        "groupName": "all dependencies",
-        "enabled": true
+        "groupName": "all dependencies"
       }
     ]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,23 @@
+{
+  "gomod": {
+    "schedule": [
+      "after 5am on sunday"
+    ],
+    "postUpdateOptions": [
+      "gomodUpdateImportPaths",
+      "gomodTidy"
+    ],
+    "packageRules": [
+      {
+        "matchManagers": [
+          "gomod"
+        ],
+        "matchDepTypes": [
+          "indirect"
+        ],
+        "groupName": "all dependencies",
+        "enabled": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# Description

The PR adds renovate config with only one line: `"groupName": "all dependencies"`. The purpose is to avoid creating multiple different PRs for each dependency, and instead create one PR per week for all updates.

The configuration specifies only one line, as the rest of the configuration is merged with [default one](https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json) before it is applied.

## Type of change

- Configuration update

## Testing steps

NA, need to observe how the configuration works after merging.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
