### PR TITLE
[CCXDEV-15149] Switch used Redis instance to AppSRE provided one

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -40,11 +40,12 @@ objects:
     name: ccx-smart-proxy
   spec:
     envName: ${ENV_NAME}
+    inMemoryDb: true
+    sharedInMemoryDbAppName: valkey-writer
     testing:
       iqePlugin: ccx
-    mandatoryDependencies:
-      - ccx-redis
-      - insights-content-service
+    dependencies:
+      - valkey-writer
       - ccx-insights-results
     deployments:
       - name: service


### PR DESCRIPTION
# Description

Switch Redis instance to the one created in `valkey-writer` Clowdapp.

## Type of change

- Configuration update

## Testing steps

The changes were tested in ephemeral, and CRC confirmed that the Clowder feature providing shared in memory DB capability was enabled on stage.

## Checklist
* [ ] `make before_commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
