### PR TITLE
[CCXDEV-14924] Remove Redis password and hostname

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -92,15 +92,8 @@ objects:
               value: ${INSIGHTS_CONTENT_SERVICE_POLL_TIME}
             - name: INSIGHTS_RESULTS_SMART_PROXY__SERVICES__UPGRADE_RISKS_PREDICTION
               value: ${INSIGHTS_DATA_ENGINEERING_URL}
-            - name: INSIGHTS_RESULTS_SMART_PROXY__REDIS__ENDPOINT
-              value: ${INSIGHTS_REDIS_URL}
             - name: INSIGHTS_RESULTS_SMART_PROXY__REDIS__DATABASE
               value: ${INSIGHTS_REDIS_DATABASE}
-            - name: INSIGHTS_RESULTS_SMART_PROXY__REDIS__PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: cache-writer-redis-credentials
-                  key: password
             - name: INSIGHTS_RESULTS_SMART_PROXY__REDIS__TIMEOUT_SECONDS
               value: ${INSIGHTS_REDIS_TIMEOUT_SECONDS}
             - name: INSIGHTS_RESULTS_SMART_PROXY__RBAC__URL
@@ -279,8 +272,6 @@ parameters:
   value: "http://ccx-insights-content-service:10000/api/v1/"
 - name: INSIGHTS_DATA_ENGINEERING_URL
   value: "http://ccx-upgrades-data-eng-svc:8000/"
-- name: INSIGHTS_REDIS_URL
-  value: "ccx-redis:6379"
 - name: INSIGHTS_REDIS_DATABASE
   value: "0"
 - name: INSIGHTS_REDIS_TIMEOUT_SECONDS


### PR DESCRIPTION
# Description

`smart-proxy` Clowdapp was using references to old Redis password and hostname

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Configuration update

## Testing steps

NA

## Checklist
* [ ] `make before-commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
