### PR TITLE
[CCXDEV-15374] Add user-agent metrics for endpoints

### DIFF
--- a/docs/prometheus.md
+++ b/docs/prometheus.md
@@ -16,6 +16,15 @@ of them related with the API usage. These are the API metrics exposed:
 1. `api_endpoints_response_time` API endpoints response time
 1. `api_endpoints_status_codes` a counter of the HTTP status code responses
    returned back by the service
+
+Additionally, the Smart Proxy provides enhanced metrics that include User-Agent information:
+
+1. `api_endpoints_requests_with_user_agent` the total number of requests per endpoint with user agent labels
+
+This enhanced metric include the following label:
+- `endpoint`: The API endpoint pattern
+- `user_agent`: Normalized user agent (e.g., "insights-operator", "browser", "curl", etc.)
+
    
 Additionally it is possible to consume all metrics provided by Go runtime. There
 metrics start with `go_` and `process_` prefixes.

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -17,6 +17,10 @@ var (
 		Name: "rbac_service_accounts_rejected",
 		Help: "The total number of service accounts that were rejected due to ACL",
 	}
+	apiEndpointsRequestsWithUserAgentOps = prometheus.CounterOpts{
+		Name: "api_endpoints_user_agent",
+		Help: "The total number of requests per endpoint with user agent information",
+	}
 )
 
 // RBACIdentityType shows number of requesters by identity type. For example
@@ -26,6 +30,9 @@ var RBACIdentityType = promauto.NewCounterVec(rbacIdentityTypeOps, []string{"typ
 // RBACServiceAccountRejected shows number of SAs that were rejected due to
 // their ACL and our RBAC policies.
 var RBACServiceAccountRejected = promauto.NewCounter(rbacServiceAccountRejectedOps)
+
+// APIEndpointsRequestsWithUserAgent shows the total number of requests per endpoint with user agent
+var APIEndpointsRequestsWithUserAgent = promauto.NewCounterVec(apiEndpointsRequestsWithUserAgentOps, []string{"endpoint", "user_agent"})
 
 // AddAPIMetricsWithNamespace registers API and RBAC metrics under the
 // given Prometheus namespace.
@@ -37,4 +44,7 @@ func AddAPIMetricsWithNamespace(namespace string) {
 
 	rbacServiceAccountRejectedOps.Namespace = namespace
 	RBACServiceAccountRejected = promauto.NewCounter(rbacServiceAccountRejectedOps)
+
+	apiEndpointsRequestsWithUserAgentOps.Namespace = namespace
+	APIEndpointsRequestsWithUserAgent = promauto.NewCounterVec(apiEndpointsRequestsWithUserAgentOps, []string{"endpoint", "user_agent"})
 }

--- a/server/auth_middleware_test.go
+++ b/server/auth_middleware_test.go
@@ -327,7 +327,7 @@ func TestAuthorizationMiddleware(t *testing.T) {
 
 			assert.Equal(t, tc.expectedStatus, recorder.Code)
 
-			assertCounterVecValue(t, 1, metrics.RBACIdentityType, tc.xrhHeader.Identity.Type, initValueRBACIdentityType)
+			assertCounterVecValue(t, 1, metrics.RBACIdentityType, initValueRBACIdentityType, tc.xrhHeader.Identity.Type)
 			if tc.expectedStatus == http.StatusForbidden {
 				assertCounterValue(t, 1, metrics.RBACServiceAccountRejected, initValueRBACServiceAccountRejected)
 			} else {
@@ -365,16 +365,16 @@ func TestAuthorization_NoAuthURLs(t *testing.T) {
 	assert.Equal(t, http.StatusOK, rr.Code)
 }
 
-func assertCounterVecValue(tb testing.TB, expected int64, counterVec *prometheus.CounterVec, label string, initValue int64) {
-	assert.Equal(tb, float64(initValue+expected), getCounterVecValue(tb, counterVec, label))
+func assertCounterVecValue(tb testing.TB, expected int64, counterVec *prometheus.CounterVec, initValue int64, labels ...string) {
+	assert.Equal(tb, float64(initValue+expected), getCounterVecValue(tb, counterVec, labels...))
 }
 
 func assertCounterValue(tb testing.TB, expected int64, counter prometheus.Counter, initValue int64) {
 	assert.Equal(tb, float64(expected+initValue), getCounterValue(tb, counter))
 }
 
-func getCounterVecValue(tb testing.TB, counterVec *prometheus.CounterVec, label string) float64 {
-	counter, err := counterVec.GetMetricWithLabelValues(label)
+func getCounterVecValue(tb testing.TB, counterVec *prometheus.CounterVec, labels ...string) float64 {
+	counter, err := counterVec.GetMetricWithLabelValues(labels...)
 	if err != nil {
 		tb.Errorf("Unable to get counter from counterVec %v", err)
 	}

--- a/server/metrics_middleware.go
+++ b/server/metrics_middleware.go
@@ -1,0 +1,118 @@
+// Copyright 2025 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/RedHatInsights/insights-results-smart-proxy/metrics"
+	"github.com/gorilla/mux"
+	"github.com/rs/zerolog/log"
+)
+
+const unknownUserAgent = "unknown"
+
+// responseWriter wraps http.ResponseWriter to capture status code
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+// WriteHeader captures the status code for metrics
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// normalizeUserAgent normalizes the user agent string to reduce cardinality
+// and prevent potential high cardinality issues in Prometheus
+func normalizeUserAgent(userAgent string) string {
+	if userAgent == "" {
+		return unknownUserAgent
+	}
+
+	// Convert to lowercase for consistency
+	userAgent = strings.ToLower(userAgent)
+
+	// Check for known user agents and normalize them
+	switch {
+	case strings.Contains(userAgent, "insights-operator/mcp-server"):
+		return "insights-operator/mcp-server"
+	case strings.Contains(userAgent, "insights-operator"):
+		return "insights-operator"
+	case strings.Contains(userAgent, "acm-operator"):
+		return "acm-operator"
+	case strings.Contains(userAgent, "mozilla"):
+		return "browser"
+	case strings.Contains(userAgent, "curl"):
+		return "curl"
+	case strings.Contains(userAgent, "wget"):
+		return "wget"
+	case strings.Contains(userAgent, "python"):
+		return "python-client"
+	case strings.Contains(userAgent, "go-http-client"):
+		return "go-client"
+	case strings.Contains(userAgent, "okhttp"):
+		return "okhttp-client"
+	default:
+		return unknownUserAgent
+	}
+}
+
+// getEndpointFromRequest extracts the endpoint pattern from the request
+func getEndpointFromRequest(r *http.Request) string {
+	// Try to get the route from mux
+	route := mux.CurrentRoute(r)
+	if route == nil {
+		log.Error().Msg("router is nil")
+		return ""
+	}
+
+	endpoint, err := route.GetPathTemplate()
+	if err != nil {
+		log.Error().Err(err).Msg("not valid endpoint template found")
+		return ""
+	}
+
+	return endpoint
+}
+
+// MetricsMiddleware creates a middleware that captures user-agent information in metrics
+func MetricsMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Skip metrics endpoint itself to avoid recursion
+		if strings.HasSuffix(r.URL.Path, "/metrics") {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		// Extract and normalize user agent
+		userAgent := r.Header.Get("User-Agent")
+		normalizedUserAgent := normalizeUserAgent(userAgent)
+
+		// Get endpoint pattern
+		endpoint := getEndpointFromRequest(r)
+
+		// Wrap the response writer to capture status code
+		rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
+
+		// Increment request counter
+		metrics.APIEndpointsRequestsWithUserAgent.WithLabelValues(endpoint, normalizedUserAgent).Inc()
+
+		// Call the next handler
+		next.ServeHTTP(rw, r)
+	})
+}

--- a/server/metrics_middleware_test.go
+++ b/server/metrics_middleware_test.go
@@ -1,0 +1,232 @@
+// Copyright 2025 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/RedHatInsights/insights-operator-utils/responses"
+	"github.com/RedHatInsights/insights-results-smart-proxy/metrics"
+	"github.com/RedHatInsights/insights-results-smart-proxy/server"
+	"github.com/RedHatInsights/insights-results-smart-proxy/tests/helpers"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/assert"
+)
+
+type Endpoint struct {
+	Path    string
+	Func    func(http.ResponseWriter, *http.Request)
+	Methods []string
+}
+
+// TestNormalizeUserAgent tests the user agent normalization functionality
+func TestNormalizeUserAgent(t *testing.T) {
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"", "unknown"},
+		{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36", "browser"},
+		{"insights-operator/mcp-server/4.10.0", "insights-operator/mcp-server"},
+		{"insights-operator/4.10.0", "insights-operator"},
+		{"acm-operator/2.5.0", "acm-operator"},
+		{"curl/7.68.0", "curl"},
+		{"wget/1.20.3", "wget"},
+		{"python-requests/2.25.1", "python-client"},
+		{"Go-http-client/1.1", "go-client"},
+		{"okhttp/4.9.0", "okhttp-client"},
+		{"CustomClient/1.0", "unknown"},
+		{"/only_version", "unknown"},
+	}
+
+	endpoints := []Endpoint{
+		{
+			Path: "/test",
+			Func: func(w http.ResponseWriter, r *http.Request) {
+				err := responses.Send(http.StatusOK, w, responses.BuildOkResponse())
+				helpers.FailOnError(t, err)
+			},
+			Methods: []string{http.MethodGet},
+		},
+	}
+
+	// Create test router
+	router := createTestRouter(endpoints)
+
+	// We need to test the internal function, but it's not exported.
+	// For now, we'll test the middleware behavior indirectly through HTTP requests
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			// Create test request with specific user agent
+			req := httptest.NewRequest("GET", "/test", nil)
+			if tc.input != "" {
+				req.Header.Set("User-Agent", tc.input)
+			}
+
+			rr := httptest.NewRecorder()
+			initValueUserAgentMetric := int64(getCounterVecValue(t, metrics.APIEndpointsRequestsWithUserAgent, "/test", tc.expected))
+
+			router.ServeHTTP(rr, req)
+
+			// Verify the request was processed
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assertCounterVecValue(t, 1, metrics.APIEndpointsRequestsWithUserAgent, initValueUserAgentMetric, "/test", tc.expected)
+		})
+	}
+}
+
+// TestMetricsMiddleware tests the metrics middleware functionality
+func TestMetricsMiddleware(t *testing.T) {
+	// Define test endpoints
+	endpoints := []Endpoint{
+		{
+			Path: "/api/v1/clusters",
+			Func: func(w http.ResponseWriter, r *http.Request) {
+				err := responses.Send(http.StatusOK, w, responses.BuildOkResponse())
+				helpers.FailOnError(t, err)
+			},
+			Methods: []string{http.MethodGet},
+		},
+		{
+			Path: "/api/v2/organizations/{orgId}/clusters/{clusterId}/reports",
+			Func: func(w http.ResponseWriter, r *http.Request) {
+				err := responses.Send(http.StatusOK, w, responses.BuildOkResponse())
+				helpers.FailOnError(t, err)
+			},
+			Methods: []string{http.MethodGet},
+		},
+		{
+			Path: "/api/v1/info",
+			Func: func(w http.ResponseWriter, r *http.Request) {
+				err := responses.Send(http.StatusOK, w, responses.BuildOkResponse())
+				helpers.FailOnError(t, err)
+			},
+			Methods: []string{http.MethodGet},
+		},
+		{
+			Path: "/api/v1/org_overview",
+			Func: func(w http.ResponseWriter, r *http.Request) {
+				err := responses.Send(http.StatusOK, w, responses.BuildOkResponse())
+				helpers.FailOnError(t, err)
+			},
+			Methods: []string{http.MethodGet},
+		},
+	}
+
+	// Create test router
+	router := createTestRouter(endpoints)
+
+	// Test different scenarios
+	testCases := []struct {
+		name              string
+		path              string
+		userAgent         string
+		expectedUserAgent string
+		expectedEndpoint  string
+		method            string
+	}{
+		{
+			name:              "Basic request with curl",
+			path:              "/api/v1/clusters",
+			userAgent:         "curl/7.68.0",
+			expectedUserAgent: "curl",
+			expectedEndpoint:  "/api/v1/clusters",
+			method:            "GET",
+		},
+		{
+			name:              "Insights operator request",
+			path:              "/api/v2/organizations/123/clusters/abc/reports",
+			userAgent:         "insights-operator/4.10.0",
+			expectedUserAgent: "insights-operator",
+			expectedEndpoint:  "/api/v2/organizations/{orgId}/clusters/{clusterId}/reports",
+			method:            "GET",
+		},
+		{
+			name:              "Browser request",
+			path:              "/api/v1/info",
+			userAgent:         "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36",
+			expectedUserAgent: "browser",
+			expectedEndpoint:  "/api/v1/info",
+			method:            "GET",
+		},
+		{
+			name:              "Request without user agent",
+			path:              "/api/v1/info",
+			userAgent:         "",
+			expectedUserAgent: "unknown",
+			expectedEndpoint:  "/api/v1/info",
+			method:            "GET",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, tc.path, nil)
+			if tc.userAgent != "" {
+				req.Header.Set("User-Agent", tc.userAgent)
+			}
+			rr := httptest.NewRecorder()
+			initValueUserAgentMetric := int64(getCounterVecValue(t, metrics.APIEndpointsRequestsWithUserAgent, tc.expectedEndpoint, tc.expectedUserAgent))
+
+			// Execute request using the test router
+			router.ServeHTTP(rr, req)
+
+			// Verify the request was processed successfully
+			assert.Equal(t, http.StatusOK, rr.Code)
+			assertCounterVecValue(t, 1, metrics.APIEndpointsRequestsWithUserAgent, initValueUserAgentMetric, tc.expectedEndpoint, tc.expectedUserAgent)
+		})
+	}
+}
+
+// TestMetricsMiddlewareSkipsMetricsEndpoint tests that the middleware skips the /metrics endpoint
+func TestMetricsMiddlewareSkipsMetricsEndpoint(t *testing.T) {
+	// Define test endpoints
+	endpoints := []Endpoint{
+		{
+			Path: "/metrics",
+			Func: func(w http.ResponseWriter, r *http.Request) {
+				err := responses.Send(http.StatusOK, w, responses.BuildOkResponse())
+				helpers.FailOnError(t, err)
+			},
+			Methods: []string{http.MethodGet},
+		},
+	}
+
+	// Create test router
+	router := createTestRouter(endpoints)
+
+	req := httptest.NewRequest("GET", "/metrics", nil)
+	req.Header.Set("User-Agent", "curl/7.68.0")
+	rr := httptest.NewRecorder()
+
+	router.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assertCounterVecValue(t, 0, metrics.APIEndpointsRequestsWithUserAgent, 0, "/metrics", "curl")
+}
+
+// createTestRouter creates a lightweight test router with the specified endpoints
+func createTestRouter(endpoints []Endpoint) *mux.Router {
+	router := mux.NewRouter().StrictSlash(true)
+	router.Use(server.MetricsMiddleware)
+
+	for _, endpoint := range endpoints {
+		router.HandleFunc(endpoint.Path, endpoint.Func).Methods(endpoint.Methods...)
+	}
+
+	return router
+}

--- a/server/server.go
+++ b/server/server.go
@@ -161,6 +161,9 @@ func (server *HTTPServer) Initialize() http.Handler {
 	router := mux.NewRouter().StrictSlash(true)
 	router.Use(httputils.LogRequest)
 
+	// Add custom metrics middleware to capture user-agent information
+	router.Use(MetricsMiddleware)
+
 	// Set up authentication and authorization middleware
 	server.setupAuthMiddleware(router)
 


### PR DESCRIPTION
# Description

Add new metric to track the user-agent used for each request to the endpoints of the server.

The user agent string will be normalised in order to avoid having too much labels

Fixes #CCXDEV-15374

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing steps

Unit tests, CI and some local testing

## Checklist
* [ ] `make before-commit` passes
* [x] updated documentation wherever necessary
* [x] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
