### PR TITLE
[CCXDEV-15295]Updating logs for better glitchtip handling

### DIFF
--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -92,7 +92,7 @@ func readCompositeRuleID(request *http.Request) (
 			ParamValue: ruleIDParam,
 			ErrString:  msg.Error(),
 		}
-		log.Error().Err(err).Msg("invalid composite rule ID")
+		log.Warn().Err(err).Msg("invalid composite rule ID")
 		return
 	}
 

--- a/server/router_utils.go
+++ b/server/router_utils.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 
 	httputils "github.com/RedHatInsights/insights-operator-utils/http"
+	"github.com/RedHatInsights/insights-operator-utils/responses"
 	ctypes "github.com/RedHatInsights/insights-results-types"
 	"github.com/rs/zerolog/log"
 
@@ -56,11 +57,14 @@ func readRuleIDWithErrorKey(writer http.ResponseWriter, request *http.Request) (
 
 	ruleID, errorKey, err := types.RuleIDWithErrorKeyFromCompositeRuleID(ctypes.RuleID(ruleIDWithErrorKey))
 	if err != nil {
-		handleServerError(writer, &RouterParsingError{
-			ParamName:  RuleIDParamName,
-			ParamValue: ruleIDWithErrorKey,
-			ErrString:  err.Error(),
-		})
+		// Sending response without logging error in handleServerError as the function already sends warning logs
+		respErr := responses.SendBadRequest(writer, fmt.Sprintf(
+			"Error during parsing param '%s' with value '%s'. Error: '%s'",
+			RuleIDParamName, ruleIDWithErrorKey, err.Error(),
+		))
+		if respErr != nil {
+			log.Error().Err(respErr).Msg("Error sending bad request response")
+		}
 		return ctypes.RuleID(""), ctypes.ErrorKey(""), err
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -74,6 +74,15 @@ const (
 	// browserUserAgent is the standard product name set by web browsers (requests made via OCM, OCP Advisor, ..)
 	browserUserAgent = "Mozilla"
 
+	// openAPIGeneratorUserAgent is the product name set by OpenAPI-generated  in iqe tests clients
+	openAPIGeneratorUserAgent = "OpenAPI-Generator"
+
+	// pythonRequestsUserAgent is the product name set by Python requests library in iqe tests
+	pythonRequestsUserAgent = "python-requests"
+
+	// nonRelevantUserAgent is a test user agent used in iqe tests to verify unknown user agent handling
+	nonRelevantUserAgent = "non-relevant-user-agent"
+
 	// JSONContentType represents the application/json content type
 	JSONContentType = "application/json; charset=utf-8"
 
@@ -1023,6 +1032,12 @@ func (server HTTPServer) getKnownUserAgentProduct(request *http.Request) (userAg
 		log.Info().Msg("request made by ACM Operator to be shown in the the Advanced Cluster Management")
 	case browserUserAgent:
 		log.Info().Msg("request made by a regular web browser")
+	case openAPIGeneratorUserAgent:
+		log.Info().Msg("request made by OpenAPI-generated test client from iqe tests")
+	case pythonRequestsUserAgent:
+		log.Warn().Msg("request made by Python requests library probably from iqe tests")
+	case nonRelevantUserAgent:
+		log.Warn().Msg("request made by non-relevant-user-agent test case from iqe tests")
 	default:
 		log.Error().Str(userAgentHeader, request.Header.Get(userAgentHeader)).
 			Str("userAgentProduct", userAgentProduct).

--- a/server/server.go
+++ b/server/server.go
@@ -1027,17 +1027,17 @@ func (server HTTPServer) getKnownUserAgentProduct(request *http.Request) (userAg
 
 	switch userAgentProduct {
 	case insightsOperatorUserAgent:
-		log.Info().Msg("request made by Insights Operator to be shown in the OCP Web console")
+		log.Debug().Msg("request made by Insights Operator to be shown in the OCP Web console")
 	case acmUserAgent:
-		log.Info().Msg("request made by ACM Operator to be shown in the the Advanced Cluster Management")
+		log.Debug().Msg("request made by ACM Operator to be shown in the the Advanced Cluster Management")
 	case browserUserAgent:
-		log.Info().Msg("request made by a regular web browser")
+		log.Debug().Msg("request made by a regular web browser")
 	case openAPIGeneratorUserAgent:
-		log.Info().Msg("request made by OpenAPI-generated test client from iqe tests")
+		log.Debug().Msg("request made by OpenAPI-generated test client from iqe tests")
 	case pythonRequestsUserAgent:
-		log.Warn().Msg("request made by Python requests library probably from iqe tests")
+		log.Debug().Msg("request made by Python requests library probably from iqe tests")
 	case nonRelevantUserAgent:
-		log.Warn().Msg("request made by non-relevant-user-agent test case from iqe tests")
+		log.Debug().Msg("request made by non-relevant-user-agent test case from iqe tests")
 	default:
 		log.Error().Str(userAgentHeader, request.Header.Get(userAgentHeader)).
 			Str("userAgentProduct", userAgentProduct).

--- a/services/redis.go
+++ b/services/redis.go
@@ -242,6 +242,10 @@ func (redisClient *RedisClient) GetRuleHitsForRequest(
 		ruleIDRegex := regexp.MustCompile(`^([a-zA-Z_0-9.]+)[|]([a-zA-Z_0-9.]+)$`)
 
 		isRuleIDValid := ruleIDRegex.MatchString(ruleHit)
+		if ruleHit == "" {
+			log.Debug().Str("RequestID",simplifiedReport.RequestID).Msg("There are no rule hits for given request id")
+			continue
+		}
 		if !isRuleIDValid {
 			log.Error().Str("rule_id", ruleHit).Msg("rule_id retrieved from Redis is in invalid format")
 			continue

--- a/services/redis.go
+++ b/services/redis.go
@@ -243,7 +243,7 @@ func (redisClient *RedisClient) GetRuleHitsForRequest(
 
 		isRuleIDValid := ruleIDRegex.MatchString(ruleHit)
 		if ruleHit == "" {
-			log.Debug().Str("RequestID",simplifiedReport.RequestID).Msg("There are no rule hits for given request id")
+			log.Debug().Str("RequestID", simplifiedReport.RequestID).Msg("There are no rule hits for given request id")
 			continue
 		}
 		if !isRuleIDValid {

--- a/types/operations.go
+++ b/types/operations.go
@@ -52,7 +52,7 @@ func RuleIDWithErrorKeyFromCompositeRuleID(compositeRuleID ctypes.RuleID) (ctype
 
 	if len(splitedRuleID) != 2 {
 		err := fmt.Errorf("invalid rule ID, it must contain only rule ID and error key separated by |")
-		log.Error().Err(err).Send()
+		log.Warn().Msgf("Error during parsing param 'rule_id' with value '%s'. Error: '%s'", string(compositeRuleID), err.Error())
 		return ctypes.RuleID(""), ctypes.ErrorKey(""), err
 	}
 
@@ -63,7 +63,7 @@ func RuleIDWithErrorKeyFromCompositeRuleID(compositeRuleID ctypes.RuleID) (ctype
 
 	if !isRuleIDValid || !isErrorKeyValid {
 		err := fmt.Errorf("invalid rule ID, each part of ID must contain only latin characters, number, underscores or dots")
-		log.Error().Err(err).Send()
+		log.Warn().Msgf("Error during parsing param 'rule_id' with value '%s'. Error: '%s'", string(compositeRuleID), err.Error())
 		return ctypes.RuleID(""), ctypes.ErrorKey(""), err
 	}
 


### PR DESCRIPTION
# Description

This PR is composed of 4 parts.
1. Fixing issue [rule_id retrieved from Redis is in invalid format](https://glitchtip.devshift.net/ccx/issues/835383?project=100) which was triggered even if there was no reports for cluster in redis meaning there was an empty rule_id
2. Fixing duplicit issue in [invalid rule ID, it must contain only rule ID and error key separated by |](https://glitchtip.devshift.net/ccx/issues/835477?project=100) and changing log level to warning as this is not relevant glitchtip error which can be fixed and most of the issues are caused by fuzzy tests.
3. Changing logs for [improper or unknown user agent product](https://glitchtip.devshift.net/ccx/issues/835130?project=100) where `OpenAPI-Generator` is used in iqe api client. And also changing log level for `python-requests` to warning as it is used by iqe tests but could be used as external treat (I can change ti to err if you guys prefer)
Fixes # (issue)
4. changing log level of [invalid composite rule ID](https://glitchtip.devshift.net/ccx/issues/835483/events/f85a1cb053634d19b5b2638eb0c64a17) which is happening only in stage environment and is most likely caused by fuzzy tests. Also this is not error in code so there is no added value of this being logged to glitchttip.

## Type of change

Please delete options that are not relevant.

- Logging update (non-breaking change)

## Testing steps

Tested in ephemeral with iqe tests, then the logs were checked if it contained all needed logs

## Checklist
* [ ] `make before-commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
