### PR TITLE
[CCXDEV-16245] Switch to shared gotests reusable workflow

### DIFF
--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -1,3 +1,17 @@
+# Copyright 2023 Red Hat, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 name: Go tests
 
 on:

--- a/.github/workflows/gotests.yml
+++ b/.github/workflows/gotests.yml
@@ -1,17 +1,3 @@
-# Copyright 2023 Red Hat, Inc
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#      http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-
 name: Go tests
 
 on:
@@ -19,22 +5,12 @@ on:
     branches: ["master", "main"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   gotests:
-    runs-on: ubuntu-latest
-    name: Go tests
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.25"
-      - name: Show env
-        run: env
-      - name: Unit tests
-        run: make test
-      - name: Retrieve code coverage
-        run: ./check_coverage.sh
-      - uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+    uses: RedHatInsights/processing-tools/.github/workflows/gotests.yaml@master
+    with:
+      coverage_threshold: 50
+    secrets: inherit

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: golangci-lint-full
 
   - repo: https://github.com/RedHatInsights/processing-tools
-    rev: v0.1.0
+    rev: v0.3.0
     hooks:
       - id: abcgo
         args: ['--threshold=64']

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,6 @@ coverage:
       default:
         target: 50%
         threshold: 0%
+
+flags:
+  unit-tests:


### PR DESCRIPTION
# Description

- Replace inline `gotests.yml` with reusable workflow from processing-tools
- Coverage threshold preserved at 50%

Fixes CCXDEV-16245

## Type of change

- Configuration update