### PR TITLE
update codecov set up to not enforce target

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,12 +2,12 @@ coverage:
   status:
     project:
       default:
-        target: 50%
-        threshold: 0%
+        target: 70%
+        informational: true
     patch:
       default:
-        target: 50%
-        threshold: 0%
+        target: 70%
+        informational: true
 
 flags:
   unit-tests:


### PR DESCRIPTION
# Description

We set a goal for the test coverage to be > 70 percent but smart proxy is lightly below. Therefore updating the target to match the 70 percent but keeping it as "informational" so that the check passes and it just informs us.

## Type of change

Please delete options that are not relevant.

- Configuration update

## Testing steps

## Checklist
* [ ] `make before-commit` passes
* [ ] updated documentation wherever necessary
* [ ] added or modified tests if necessary
* [ ] updated schemas and validators in [insights-data-schemas](https://github.com/RedHatInsights/insights-data-schemas) in case of input/output change
